### PR TITLE
Remove thread_safe_queue dependency

### DIFF
--- a/include/infra/message_operator/message_sender.hpp
+++ b/include/infra/message_operator/message_sender.hpp
@@ -1,38 +1,25 @@
 #pragma once
 
 #include "message_operator/i_message_sender.hpp"
-#include "message_operator/thread_safe_queue.hpp"
+#include "message_operator/message_queue.hpp"
 
-#include <atomic>
 #include <memory>
-#include <mqueue.h>
 #include <string>
-#include <thread>
 
 namespace device_reminder {
 
 class MessageSender : public IMessageSender {
 public:
-    /// @param queue_name   POSIX メッセージキュー名（例: "/device_reminder_mq"）
-    /// @param max_messages キューの最大蓄積メッセージ数（mq_attr::mq_maxmsg）
-    explicit MessageSender(const std::string& queue_name,
-                           long               max_messages = 10,
-                           std::shared_ptr<TSQueue<uint32_t>> q =
-                               std::make_shared<TSQueue<uint32_t>>());
-    ~MessageSender() override;
+    /// @brief POSIX メッセージキューへの送信ラッパー
+    explicit MessageSender(std::shared_ptr<MessageQueue> queue);
+    ~MessageSender() override = default;
 
     /// IMessageSender
     bool enqueue(uint32_t msg) override;
     void stop() override;
 
 private:
-    void run();  // スレッド本体
-
-    std::string                     queue_name_;
-    std::shared_ptr<TSQueue<uint32_t>> queue_;
-    std::thread                     thread_;
-    std::atomic<bool>               running_{true};
-    mqd_t                           mq_{-1};
+    std::shared_ptr<MessageQueue> queue_;
 };
 
 } // namespace device_reminder

--- a/include/infra/process/process_base.hpp
+++ b/include/infra/process/process_base.hpp
@@ -6,7 +6,6 @@
 #include <memory>
 #include <string>
 
-#include "message_operator/thread_safe_queue.hpp"
 #include "message_operator/message_receiver.hpp"
 #include "worker_dispatcher/worker_dispatcher.hpp"
 
@@ -21,7 +20,6 @@ public:
 private:
     static std::atomic<bool> g_stop_flag;           ///< 全スレッド共通の終了フラグ
 
-    std::shared_ptr<TSQueue<std::string>> queue_;   ///< 内部メッセージキュー
     std::unique_ptr<MessageReceiver>       receiver_;
     std::unique_ptr<WorkerDispatcher>      worker_;
 };

--- a/src/infra/message_operator/message_sender.cpp
+++ b/src/infra/message_operator/message_sender.cpp
@@ -1,89 +1,19 @@
 #include "message_operator/message_sender.hpp"
 
-#include <cerrno>
-#include <cstring>
-#include <fcntl.h>
-#include <stdexcept>
-#include <system_error>
-#include <sys/stat.h>
-#include <unistd.h>
-
 namespace device_reminder {
-namespace {
 
-//--------------------------------------------------------------------
-// POSIX メッセージキューを「送信専用」で開く（無ければ作成）
-//--------------------------------------------------------------------
-mqd_t open_or_create_queue(const std::string& name, long max_messages)
-{
-    mq_attr attr{};
-    attr.mq_flags   = 0;
-    attr.mq_maxmsg  = max_messages;
-    attr.mq_msgsize = static_cast<long>(sizeof(uint32_t));
-    attr.mq_curmsgs = 0;
+MessageSender::MessageSender(std::shared_ptr<MessageQueue> queue)
+    : queue_{std::move(queue)} {}
 
-    mqd_t mq = mq_open(name.c_str(), O_WRONLY | O_CREAT, 0644, &attr);
-    if (mq == static_cast<mqd_t>(-1)) {
-        throw std::system_error(errno, std::system_category(),
-                                "mq_open failed for " + name);
-    }
-    return mq;
-}
-
-} // anonymous namespace
-//--------------------------------------------------------------------
-// コンストラクタ
-//--------------------------------------------------------------------
-MessageSender::MessageSender(const std::string& queue_name,
-                             long               max_messages,
-                             std::shared_ptr<TSQueue<uint32_t>> q)
-    : queue_name_{queue_name},
-      queue_{std::move(q)},
-      mq_{open_or_create_queue(queue_name_, max_messages)}
-{
-    thread_ = std::thread(&MessageSender::run, this);
-}
-//--------------------------------------------------------------------
-MessageSender::~MessageSender()
-{
-    stop();
-}
-//--------------------------------------------------------------------
 bool MessageSender::enqueue(uint32_t msg)
 {
-    if (!running_) return false;
+    if (!queue_) return false;
     return queue_->push(msg);
 }
-//--------------------------------------------------------------------
+
 void MessageSender::stop()
 {
-    if (!running_.exchange(false)) return;  // すでに停止処理済み
-    queue_->shutdown();                     // pop_wait を解除
-    if (thread_.joinable()) thread_.join();
-    if (mq_ != static_cast<mqd_t>(-1)) {
-        mq_close(mq_);
-        mq_ = static_cast<mqd_t>(-1);
-    }
-}
-//--------------------------------------------------------------------
-void MessageSender::run()
-{
-    uint32_t msg{};
-    while (running_) {
-        if (!queue_->pop_wait(msg)) {
-            // shutdown() でキューが閉じられた
-            break;
-        }
-        if (mq_send(mq_,
-                    reinterpret_cast<const char*>(&msg),
-                    sizeof(uint32_t),
-                    /*prio=*/0) == -1)
-        {
-            // ポリシーに応じてリトライ／ドロップを選択可
-            throw std::system_error(errno, std::system_category(),
-                                    "mq_send failed");
-        }
-    }
+    // no resources to release
 }
 
 } // namespace device_reminder


### PR DESCRIPTION
## Summary
- MessageSender が内部キューを使わず `MessageQueue` に直接送信するよう変更
- ProcessBase から thread_safe_queue の保持を削除し、実装を簡略化

## Testing
- `cmake ..` (failed: missing googletest)

------
https://chatgpt.com/codex/tasks/task_e_687b610b16608328ae07865470291642