### PR TITLE
Add setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# ライブラリを取得するスクリプト
+set -e
+
+# スクリプトの場所を基準に実行
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+libs=(googletest spdlog di)
+for lib in "${libs[@]}"; do
+    if [ ! -e "external/$lib/.git" ]; then
+        echo "$lib を取得します..."
+        git submodule update --init "external/$lib"
+    else
+        echo "$lib は既に取得済みです"
+    fi
+done
+
+echo "セットアップが完了しました"
+


### PR DESCRIPTION
## Summary
- add a script to fetch googleTest, spdlog and di

## Testing
- `bash setup.sh` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_687b7f330b7083288a34d96cbfd1fec4