### PR TITLE
メッセージキューインタフェースの修正

### DIFF
--- a/include/infra/message_operator/i_message_queue.hpp
+++ b/include/infra/message_operator/i_message_queue.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <cstdint>
+#include "message/message.hpp"
 #include <optional>
 
 namespace device_reminder {
@@ -7,17 +7,18 @@ namespace device_reminder {
 class IMessageQueue {
 public:
     virtual ~IMessageQueue() = default;
+    IMessageQueue() = default;
     IMessageQueue(const IMessageQueue&)            = delete;
     IMessageQueue& operator=(const IMessageQueue&) = delete;
 
     /// ブロッキング送信（成功で true）
-    virtual bool push(uint32_t msg) = 0;
+    virtual bool push(const Message& msg) = 0;
 
     /// ブロッキング受信（キューが閉じられていたら std::nullopt）
-    virtual std::optional<uint32_t> pop() = 0;
+    virtual std::optional<Message> pop() = 0;
 
     /// 受信値を out に格納（成功で true）
-    virtual bool pop(uint32_t& out) = 0;
+    virtual bool pop(Message& out) = 0;
 
     /// キューが有効なら true
     virtual bool is_open() const noexcept = 0;

--- a/include/infra/message_operator/i_message_receiver.hpp
+++ b/include/infra/message_operator/i_message_receiver.hpp
@@ -6,7 +6,7 @@ namespace device_reminder {
 
 /**
  * @brief Abstract interface for a message receiver working on its own thread.
- *        Implementations block waiting for incoming uint32_t messages and
+ *        Implementations block waiting for incoming Message objects and
  *        typically forward them to a thread‑safe queue or handler.
  */
 class IMessageReceiver {

--- a/include/infra/message_operator/i_message_sender.hpp
+++ b/include/infra/message_operator/i_message_sender.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <cstdint>
+#include "message/message.hpp"
 
 namespace device_reminder {
 
@@ -8,7 +8,7 @@ public:
     virtual ~IMessageSender() = default;
 
     /// 送信待ちキューにメッセージを追加（成功: true, 停止中: false）
-    virtual bool enqueue(uint32_t msg) = 0;
+    virtual bool enqueue(const Message& msg) = 0;
 
     /// 送信スレッドを停止し，リソースを解放
     virtual void stop() = 0;

--- a/include/infra/message_operator/message_queue.hpp
+++ b/include/infra/message_operator/message_queue.hpp
@@ -20,9 +20,9 @@ public:
 
     ~MessageQueue() override;
 
-    bool push(uint32_t msg) override;
-    std::optional<uint32_t> pop() override;
-    bool pop(uint32_t& out) override;
+    bool push(const Message& msg) override;
+    std::optional<Message> pop() override;
+    bool pop(Message& out) override;
 
     bool is_open() const noexcept override;
     void close() override;

--- a/include/infra/message_operator/message_receiver.hpp
+++ b/include/infra/message_operator/message_receiver.hpp
@@ -2,6 +2,7 @@
 
 #include "message_operator/i_message_receiver.hpp"
 #include "message_operator/i_message_queue.hpp"   // forward declaration of the queue interface
+#include "message/message.hpp"
 
 #include <mqueue.h>
 #include <atomic>
@@ -13,12 +14,12 @@ namespace device_reminder {
 /**
  * @brief Concrete POSIX‑mqueue implementation of IMessageReceiver.
  *        It blocks on a named POSIX message queue and pushes received
- *        uint32_t messages to the provided thread‑safe IMessageQueue.
+ *        Message objects to the provided thread‑safe IMessageQueue.
  */
 class MessageReceiver : public IMessageReceiver {
 public:
     MessageReceiver(const std::string &mq_name,
-                    std::shared_ptr<IMessageQueue<uint32_t>> queue);
+                    std::shared_ptr<IMessageQueue> queue);
     ~MessageReceiver() override;
 
     void operator()() override;
@@ -26,7 +27,7 @@ public:
     bool running() const noexcept override { return running_; }
 
 private:
-    static constexpr long kMsgSize = sizeof(uint32_t);
+    static constexpr long kMsgSize = static_cast<long>(MESSAGE_SIZE);
     static constexpr long kMaxMsgs = 10;
 
     mqd_t open_queue(const std::string &name);
@@ -34,7 +35,7 @@ private:
 
     mqd_t                                      mq_{};
     std::string                                mq_name_;
-    std::shared_ptr<IMessageQueue<uint32_t>>    queue_;
+    std::shared_ptr<IMessageQueue>             queue_;
     std::atomic<bool>                          running_{true};
 };
 

--- a/include/infra/message_operator/message_sender.hpp
+++ b/include/infra/message_operator/message_sender.hpp
@@ -2,6 +2,7 @@
 
 #include "message_operator/i_message_sender.hpp"
 #include "message_operator/thread_safe_queue.hpp"
+#include "message/message.hpp"
 
 #include <atomic>
 #include <memory>
@@ -17,19 +18,19 @@ public:
     /// @param max_messages キューの最大蓄積メッセージ数（mq_attr::mq_maxmsg）
     explicit MessageSender(const std::string& queue_name,
                            long               max_messages = 10,
-                           std::shared_ptr<TSQueue<uint32_t>> q =
-                               std::make_shared<TSQueue<uint32_t>>());
+                           std::shared_ptr<TSQueue<Message>> q =
+                               std::make_shared<TSQueue<Message>>());
     ~MessageSender() override;
 
     /// IMessageSender
-    bool enqueue(uint32_t msg) override;
+    bool enqueue(const Message& msg) override;
     void stop() override;
 
 private:
     void run();  // スレッド本体
 
-    std::string                     queue_name_;
-    std::shared_ptr<TSQueue<uint32_t>> queue_;
+    std::string                    queue_name_;
+    std::shared_ptr<TSQueue<Message>> queue_;
     std::thread                     thread_;
     std::atomic<bool>               running_{true};
     mqd_t                           mq_{-1};

--- a/include/infra/timer_service/i_timer_service.hpp
+++ b/include/infra/timer_service/i_timer_service.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include "message/message.hpp"
 
 namespace device_reminder {
 
@@ -9,9 +10,9 @@ public:
 
     /// ワンショットタイマーを開始
     /// @param milliseconds  タイムアウトまでの時間 [ms]
-    /// @param timeout_msg   タイムアウト時に送信するメッセージ ID
+    /// @param timeout_msg   タイムアウト時に送信するメッセージ
     virtual void start(uint32_t milliseconds,
-                       uint32_t timeout_msg) = 0;
+                       Message timeout_msg) = 0;
 
     /// タイマー停止（起動していない場合は無視）
     virtual void stop() = 0;

--- a/include/infra/timer_service/timer_service.hpp
+++ b/include/infra/timer_service/timer_service.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "timer_service/i_timer_service.hpp"
 #include "message_operator/i_message_sender.hpp"
+#include "message/message.hpp"
 
 #include <atomic>
 #include <cstdint>
@@ -15,13 +16,13 @@ public:
     ~TimerService() override;
 
     void start(uint32_t milliseconds,
-               uint32_t timeout_msg) override;
+               Message timeout_msg) override;
     void stop() override;
     bool active() const noexcept override { return active_; }
 
 private:
     void worker(uint32_t milliseconds,
-                uint32_t timeout_msg);
+                Message timeout_msg);
 
     std::shared_ptr<IMessageSender> sender_;
     std::thread                     thread_;

--- a/src/infra/message_operator/message_queue.cpp
+++ b/src/infra/message_operator/message_queue.cpp
@@ -32,7 +32,7 @@ MessageQueue::MessageQueue(const std::string& name,
         ::mq_attr attr{};
         attr.mq_flags   = 0;                       // ブロッキング
         attr.mq_maxmsg  = static_cast<long>(max_messages);
-        attr.mq_msgsize = static_cast<long>(sizeof(uint32_t));
+        attr.mq_msgsize = static_cast<long>(MESSAGE_SIZE);
         attr.mq_curmsgs = 0;
 
         mq_ = ::mq_open(name_.c_str(),
@@ -65,31 +65,31 @@ void MessageQueue::close() {
     mq_ = static_cast<mqd_t>(-1);
 }
 
-bool MessageQueue::push(uint32_t msg) {
+bool MessageQueue::push(const Message& msg) {
     std::lock_guard lk{mtx_};
     if (!is_open()) return false;
 
     if (::mq_send(mq_, reinterpret_cast<const char*>(&msg),
-                  sizeof(uint32_t), 0) == -1) {
+                  MESSAGE_SIZE, 0) == -1) {
         if (errno == EINTR) return push(msg);   // retry
         throw_errno("mq_send");
     }
     return true;
 }
 
-std::optional<uint32_t> MessageQueue::pop() {
-    uint32_t out{};
+std::optional<Message> MessageQueue::pop() {
+    Message out{};
     if (pop(out)) return out;
     return std::nullopt;
 }
 
-bool MessageQueue::pop(uint32_t& out) {
+bool MessageQueue::pop(Message& out) {
     std::lock_guard lk{mtx_};
     if (!is_open()) return false;
 
     ssize_t n = ::mq_receive(mq_,
                              reinterpret_cast<char*>(&out),
-                             sizeof(uint32_t), nullptr);
+                             MESSAGE_SIZE, nullptr);
 
     if (n == -1) {
         if (errno == EINTR) return pop(out);    // retry

--- a/src/infra/message_operator/message_receiver.cpp
+++ b/src/infra/message_operator/message_receiver.cpp
@@ -34,7 +34,7 @@ void MessageReceiver::close_queue() {
 }
 
 MessageReceiver::MessageReceiver(const std::string &mq_name,
-                                 std::shared_ptr<IMessageQueue<uint32_t>> queue)
+                                 std::shared_ptr<IMessageQueue> queue)
     : mq_name_(mq_name), queue_(std::move(queue)) {
     mq_ = open_queue(mq_name_);
 }
@@ -51,14 +51,14 @@ void MessageReceiver::stop() {
     // Wake the blocking mq_receive() by sending a dummy message.
     mqd_t sender = mq_open(mq_name_.c_str(), O_WRONLY);
     if (sender != static_cast<mqd_t>(-1)) {
-        uint32_t dummy = 0;
+        Message dummy{};
         mq_send(sender, reinterpret_cast<const char *>(&dummy), kMsgSize, 0);
         mq_close(sender);
     }
 }
 
 void MessageReceiver::operator()() {
-    uint32_t msg{};
+    Message msg{};
     while (running_) {
         ssize_t n = mq_receive(mq_, reinterpret_cast<char *>(&msg), kMsgSize, nullptr);
         if (n >= 0) {

--- a/src/infra/timer_service.cpp
+++ b/src/infra/timer_service.cpp
@@ -34,7 +34,7 @@ TimerService::~TimerService() {
     stop();
 }
 
-void TimerService::start(uint32_t ms, uint32_t timeout_msg) {
+void TimerService::start(uint32_t ms, Message timeout_msg) {
     stop();                         // 既存タイマーを殺してから再起動
     running_ = true;
     active_  = true;
@@ -47,7 +47,7 @@ void TimerService::stop() {
     active_ = false;
 }
 
-void TimerService::worker(uint32_t ms, uint32_t timeout_msg) {
+void TimerService::worker(uint32_t ms, Message timeout_msg) {
     int tfd = create_one_shot_timer_fd(ms);
     if (tfd == -1) {
         // 生成失敗時は即座にメッセージ送出して終了


### PR DESCRIPTION
## Summary
- IMessageQueueにデフォルトコンストラクタを追加
- IMessageReceiverのコメントをMessage型に合わせて更新

## Testing
- `g++` で主要ソースを個別ビルドしエラーが無いことを確認
- `cmake ..` は googletest が無いため失敗する


------
https://chatgpt.com/codex/tasks/task_e_687b6290b9b0832898ba9adffeabf8d2