### PR TITLE
Add SpdlogLogger tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,13 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/human_task
     ${CMAKE_SOURCE_DIR}/bluetooth_task
     ${CMAKE_SOURCE_DIR}/buzzer_task
+    ${CMAKE_SOURCE_DIR}/external/spdlog/include
 )
 
 # テストコードと対象ソース
 add_executable(test_app
     tests/core/test_app.cpp
+    tests/infra/test_logger.cpp
     src/core/app.cpp
 )
 

--- a/tests/infra/test_logger.cpp
+++ b/tests/infra/test_logger.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "infra/logger/logger.hpp"
+
+#include <spdlog/logger.h>
+#include <spdlog/sinks/sink.h>
+
+using ::testing::StrictMock;
+
+class MockSink : public spdlog::sinks::sink {
+public:
+    MOCK_METHOD(void, log, (const spdlog::details::log_msg& msg), (override));
+    MOCK_METHOD(void, flush, (), (override));
+    MOCK_METHOD(void, set_pattern, (const std::string& pattern), (override));
+    void set_formatter(std::unique_ptr<spdlog::formatter>) override {}
+};
+
+TEST(SpdlogLoggerTest, InfoOutputsToSink) {
+    auto sink = std::make_shared<StrictMock<MockSink>>();
+    auto spdlogger = std::make_shared<spdlog::logger>("test", sink);
+    device_reminder::SpdlogLogger logger(spdlogger);
+
+    const std::string message = "info message";
+
+    EXPECT_CALL(*sink, log(testing::Truly([&](const spdlog::details::log_msg& msg) {
+        return msg.level == spdlog::level::info && msg.payload == message;
+    })));
+
+    logger.info(message);
+}
+
+TEST(SpdlogLoggerTest, ErrorOutputsToSink) {
+    auto sink = std::make_shared<StrictMock<MockSink>>();
+    auto spdlogger = std::make_shared<spdlog::logger>("test", sink);
+    device_reminder::SpdlogLogger logger(spdlogger);
+
+    const std::string message = "error message";
+
+    EXPECT_CALL(*sink, log(testing::Truly([&](const spdlog::details::log_msg& msg) {
+        return msg.level == spdlog::level::err && msg.payload == message;
+    })));
+
+    logger.error(message);
+}
+


### PR DESCRIPTION
## Summary
- add gtest for SpdlogLogger with gmock sink
- update CMakeLists to include new test and spdlog headers
- ignore build directory

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687c54395ea883288b9e488bfe7b922c