### PR TITLE
Add GPIODriver tests with stubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,11 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/include/core
     ${CMAKE_SOURCE_DIR}/include/infra
+    ${CMAKE_SOURCE_DIR}/include/infra/gpio_driver
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_SOURCE_DIR}/src/core
     ${CMAKE_SOURCE_DIR}/tests
+    ${CMAKE_SOURCE_DIR}/tests/stubs
     ${CMAKE_SOURCE_DIR}/main_task
     ${CMAKE_SOURCE_DIR}/human_task
     ${CMAKE_SOURCE_DIR}/bluetooth_task
@@ -26,8 +28,21 @@ add_executable(test_app
     src/core/app.cpp
 )
 
+# GPIODriver tests
+add_executable(test_gpio_driver
+    tests/infra/test_gpio_driver.cpp
+    src/infra/gpio_driver.cpp
+    tests/stubs/gpiod_stub.cpp
+)
+
 # GoogleTestライブラリをリンク
 target_link_libraries(test_app
+    gtest
+    gmock
+    gtest_main
+)
+
+target_link_libraries(test_gpio_driver
     gtest
     gmock
     gtest_main
@@ -37,8 +52,13 @@ if(UNIX)
     target_link_libraries(test_app pthread)
 endif()
 
+if(UNIX)
+    target_link_libraries(test_gpio_driver pthread)
+endif()
+
 enable_testing()
 add_test(NAME AllTests COMMAND test_app)
+add_test(NAME GPIODriverTests COMMAND test_gpio_driver)
 
 
 # 動的ランタイム(MDd)に統一する

--- a/tests/infra/test_gpio_driver.cpp
+++ b/tests/infra/test_gpio_driver.cpp
@@ -1,0 +1,45 @@
+#include <gtest/gtest.h>
+#include "gpio_driver/gpio_driver.hpp"
+#include "stubs/gpiod_stub.h"
+
+using namespace device_reminder;
+
+class GPIODriverTest : public ::testing::Test {
+protected:
+    void SetUp() override { gpiod_stub_reset(); }
+    void TearDown() override {}
+};
+
+TEST_F(GPIODriverTest, OpenChipThrowsOnFailure) {
+    gpiod_stub_set_fail_chip_open(1);
+    GPIODriver driver;
+    EXPECT_THROW(driver.openChip("chip0"), std::runtime_error);
+}
+
+TEST_F(GPIODriverTest, SetupLineRequiresOpenChip) {
+    GPIODriver driver;
+    EXPECT_THROW(driver.setupLine(1), std::runtime_error);
+}
+
+TEST_F(GPIODriverTest, SetupLineThrowsWhenRequestFails) {
+    GPIODriver driver;
+    driver.openChip("chip0");
+    gpiod_stub_set_request_input_result(-1);
+    EXPECT_THROW(driver.setupLine(1), std::runtime_error);
+}
+
+TEST_F(GPIODriverTest, ReadLineReturnsValue) {
+    GPIODriver driver;
+    driver.openChip("chip0");
+    driver.setupLine(1);
+    gpiod_stub_set_get_value_result(1);
+    EXPECT_EQ(driver.readLine(), 1);
+}
+
+TEST_F(GPIODriverTest, ReadLineThrowsOnError) {
+    GPIODriver driver;
+    driver.openChip("chip0");
+    driver.setupLine(1);
+    gpiod_stub_set_get_value_result(-1);
+    EXPECT_THROW(driver.readLine(), std::runtime_error);
+}

--- a/tests/stubs/gpiod.h
+++ b/tests/stubs/gpiod.h
@@ -1,0 +1,22 @@
+#ifndef GPIOD_STUB_H
+#define GPIOD_STUB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct gpiod_chip;
+struct gpiod_line;
+
+struct gpiod_chip* gpiod_chip_open(const char* chipname);
+void gpiod_chip_close(struct gpiod_chip* chip);
+struct gpiod_line* gpiod_chip_get_line(struct gpiod_chip* chip, unsigned int line);
+int gpiod_line_request_input(struct gpiod_line* line, const char* consumer);
+int gpiod_line_get_value(struct gpiod_line* line);
+void gpiod_line_release(struct gpiod_line* line);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // GPIOD_STUB_H

--- a/tests/stubs/gpiod_stub.cpp
+++ b/tests/stubs/gpiod_stub.cpp
@@ -1,0 +1,59 @@
+#include "gpiod_stub.h"
+#include <string>
+
+struct gpiod_chip { std::string name; };
+struct gpiod_line { unsigned int number; };
+
+static int fail_chip_open = 0;
+static int fail_get_line = 0;
+static int request_input_result = 0;
+static int get_value_result = 0;
+
+extern "C" {
+
+void gpiod_stub_reset(void) {
+    fail_chip_open = 0;
+    fail_get_line = 0;
+    request_input_result = 0;
+    get_value_result = 0;
+}
+
+void gpiod_stub_set_fail_chip_open(int val) { fail_chip_open = val; }
+void gpiod_stub_set_fail_get_line(int val) { fail_get_line = val; }
+void gpiod_stub_set_request_input_result(int val) { request_input_result = val; }
+void gpiod_stub_set_get_value_result(int val) { get_value_result = val; }
+
+struct gpiod_chip* gpiod_chip_open(const char* chipname) {
+    if (fail_chip_open) return nullptr;
+    static gpiod_chip chip;
+    chip.name = chipname ? chipname : "";
+    return &chip;
+}
+
+void gpiod_chip_close(struct gpiod_chip* chip) {
+    (void)chip;
+}
+
+struct gpiod_line* gpiod_chip_get_line(struct gpiod_chip* chip, unsigned int line) {
+    (void)chip;
+    if (fail_get_line) return nullptr;
+    static gpiod_line line_obj;
+    line_obj.number = line;
+    return &line_obj;
+}
+
+int gpiod_line_request_input(struct gpiod_line* line, const char* consumer) {
+    (void)line; (void)consumer;
+    return request_input_result;
+}
+
+int gpiod_line_get_value(struct gpiod_line* line) {
+    (void)line;
+    return get_value_result;
+}
+
+void gpiod_line_release(struct gpiod_line* line) {
+    (void)line;
+}
+
+} // extern "C"

--- a/tests/stubs/gpiod_stub.h
+++ b/tests/stubs/gpiod_stub.h
@@ -1,0 +1,20 @@
+#ifndef GPIOD_STUB_CTRL_H
+#define GPIOD_STUB_CTRL_H
+
+#include "gpiod.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void gpiod_stub_reset(void);
+void gpiod_stub_set_fail_chip_open(int val);
+void gpiod_stub_set_fail_get_line(int val);
+void gpiod_stub_set_request_input_result(int val);
+void gpiod_stub_set_get_value_result(int val);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // GPIOD_STUB_CTRL_H


### PR DESCRIPTION
## Summary
- add stub implementation of libgpiod for tests
- add unit tests for `GPIODriver`
- extend `CMakeLists.txt` to build and run new tests

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687c5514fb44832892acc42546248bdf