### PR TITLE
Implement WorkerDispatcher queue handling

### DIFF
--- a/include/infra/message_operator/local_message_queue.hpp
+++ b/include/infra/message_operator/local_message_queue.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include "i_message_queue.hpp"
+#include "infra/logger/i_logger.hpp"
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+#include <memory>
+
+namespace device_reminder {
+
+class LocalMessageQueue : public IMessageQueue {
+public:
+    explicit LocalMessageQueue(std::shared_ptr<ILogger> logger = nullptr);
+    ~LocalMessageQueue() override = default;
+
+    bool push(const Message& msg) override;
+    std::optional<Message> pop() override;
+    bool pop(Message& out) override;
+
+    bool is_open() const noexcept override;
+    void close() override;
+
+private:
+    mutable std::mutex mtx_;
+    std::condition_variable cv_;
+    std::queue<Message> q_;
+    bool open_{true};
+    std::shared_ptr<ILogger> logger_;
+};
+
+} // namespace device_reminder

--- a/include/infra/process/process_base.hpp
+++ b/include/infra/process/process_base.hpp
@@ -22,6 +22,7 @@ public:
 private:
     static std::atomic<bool> g_stop_flag;           ///< 全スレッド共通の終了フラグ
 
+    std::shared_ptr<IMessageQueue>         queue_;
     std::unique_ptr<MessageReceiver>       receiver_;
     std::unique_ptr<WorkerDispatcher>      worker_;
     std::shared_ptr<ILogger>               logger_;

--- a/src/infra/local_message_queue.cpp
+++ b/src/infra/local_message_queue.cpp
@@ -1,0 +1,45 @@
+#include "message_operator/local_message_queue.hpp"
+#include "infra/logger/i_logger.hpp"
+
+namespace device_reminder {
+
+LocalMessageQueue::LocalMessageQueue(std::shared_ptr<ILogger> logger)
+    : logger_(std::move(logger)) {}
+
+bool LocalMessageQueue::push(const Message& msg) {
+    std::lock_guard lk{mtx_};
+    if (!open_) return false;
+    q_.push(msg);
+    cv_.notify_one();
+    return true;
+}
+
+std::optional<Message> LocalMessageQueue::pop() {
+    Message out{};
+    if (!pop(out)) return std::nullopt;
+    return out;
+}
+
+bool LocalMessageQueue::pop(Message& out) {
+    std::unique_lock lk{mtx_};
+    cv_.wait(lk, [this]{ return !q_.empty() || !open_; });
+    if (q_.empty() && !open_) return false;
+    out = q_.front();
+    q_.pop();
+    return true;
+}
+
+bool LocalMessageQueue::is_open() const noexcept {
+    std::lock_guard lk{mtx_};
+    return open_;
+}
+
+void LocalMessageQueue::close() {
+    {
+        std::lock_guard lk{mtx_};
+        open_ = false;
+    }
+    cv_.notify_all();
+}
+
+} // namespace device_reminder

--- a/src/infra/process/process_base.cpp
+++ b/src/infra/process/process_base.cpp
@@ -4,6 +4,7 @@
 
 #include "process/process_base.hpp"
 #include "message_operator/i_message_queue.hpp"
+#include "message_operator/local_message_queue.hpp"
 #include "interfaces/i_message_handler.hpp"
 #include "infra/logger/i_logger.hpp"
 
@@ -12,8 +13,9 @@ std::atomic<bool> ProcessBase::g_stop_flag{false};
 ProcessBase::ProcessBase(const std::string& mq_name,
                          std::shared_ptr<IMessageHandler> handler,
                          std::shared_ptr<ILogger> logger)
-    : receiver_{std::make_unique<MessageReceiver>(mq_name, nullptr)},
-      worker_  {std::make_unique<WorkerDispatcher>(0, handler, logger)},
+    : queue_{std::make_shared<LocalMessageQueue>(logger)},
+      receiver_{std::make_unique<MessageReceiver>(mq_name, queue_, logger)},
+      worker_  {std::make_unique<WorkerDispatcher>(queue_, handler, logger)},
       logger_(std::move(logger))
 {
     // Ctrl‑C (SIGINT) を捕捉して終了フラグを立てる


### PR DESCRIPTION
## Summary
- WorkerDispatcher now watches an external queue and removes enqueue API
- introduce `LocalMessageQueue` implementing `IMessageQueue`
- ProcessBase constructs a LocalMessageQueue for MessageReceiver and WorkerDispatcher

## Testing
- `cmake ..`
- `make -j4`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687c6c95521c83289649dd4a5ae14d33