### PR TITLE
Refactor ProcessBase and add human task handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,11 @@ include_directories(
 # テストコードと対象ソース
 add_executable(test_app
     tests/core/test_app.cpp
+    tests/core/test_human_task.cpp
     tests/infra/test_logger.cpp
     src/core/app.cpp
+    src/core/human_task.cpp
+    src/core/human_task_handler.cpp
 )
 
 # GPIODriver tests

--- a/include/core/human_task/human_task.hpp
+++ b/include/core/human_task/human_task.hpp
@@ -3,20 +3,33 @@
 #include "message/i_message.hpp"
 #include "human_task/i_human_task.hpp"
 #include "infra/logger/i_logger.hpp"
+#include "infra/pir_driver/i_pir_driver.hpp"
+#include "infra/timer_service/i_timer_service.hpp"
+#include "message_operator/i_message_sender.hpp"
 #include <memory>
 
 namespace device_reminder {
 
 class HumanTask : public IHumanTask {
 public:
-    explicit HumanTask(std::shared_ptr<ILogger> logger);
+    enum class State { Detecting, Stopped, Cooldown };
+
+    HumanTask(std::shared_ptr<IPIRDriver> pir,
+              std::shared_ptr<ITimerService> timer,
+              std::shared_ptr<IMessageSender> sender,
+              std::shared_ptr<ILogger> logger);
     ~HumanTask();
 
-    void run() override;
-    bool send_message(const IMessage& msg) override;
+    void run(const IMessage& msg) override;
+
+    State state() const noexcept { return state_; }
 
 private:
-    std::shared_ptr<ILogger> logger_;
+    std::shared_ptr<IPIRDriver>   pir_;
+    std::shared_ptr<ITimerService> timer_;
+    std::shared_ptr<IMessageSender> sender_;
+    std::shared_ptr<ILogger>        logger_;
+    State state_{State::Detecting};
 };
 
 } // namespace device_reminder

--- a/include/core/human_task/human_task_handler.hpp
+++ b/include/core/human_task/human_task_handler.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "interfaces/i_message_handler.hpp"
+#include "human_task/human_task.hpp"
+#include <memory>
+
+namespace device_reminder {
+
+class HumanTaskHandler : public IMessageHandler {
+public:
+    explicit HumanTaskHandler(std::shared_ptr<HumanTask> task)
+        : task_(std::move(task)) {}
+
+    void handle(const std::string& msg_str) override;
+
+private:
+    std::shared_ptr<HumanTask> task_;
+};
+
+} // namespace device_reminder

--- a/include/core/human_task/human_task_process.hpp
+++ b/include/core/human_task/human_task_process.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "infra/process/process_base.hpp"
+#include "human_task/human_task_handler.hpp"
+#include <memory>
+
+namespace device_reminder {
+
+class HumanTaskProcess : public ProcessBase {
+public:
+    HumanTaskProcess(const std::string& mq_name,
+                     std::shared_ptr<HumanTask> task,
+                     std::shared_ptr<ILogger> logger)
+        : ProcessBase(mq_name,
+                      std::make_shared<HumanTaskHandler>(std::move(task)),
+                      std::move(logger),
+                      4) {}
+};
+
+} // namespace device_reminder

--- a/include/core/human_task/i_human_task.hpp
+++ b/include/core/human_task/i_human_task.hpp
@@ -8,8 +8,7 @@ class IHumanTask {
 public:
     virtual ~IHumanTask() = default;
 
-    virtual void run() = 0;
-    virtual bool send_message(const IMessage& msg) = 0;
+    virtual void run(const IMessage& msg) = 0;
 };
 
 } // namespace device_reminder

--- a/include/infra/message/i_message.hpp
+++ b/include/infra/message/i_message.hpp
@@ -9,6 +9,8 @@ enum class MessageType {
     None,
     Timeout,
     HumanDetected,
+    HumanDetectStart,
+    HumanDetectStop,
     BluetoothEvent,
     BuzzerOn,
     BuzzerOff

--- a/include/infra/process/i_process_base.hpp
+++ b/include/infra/process/i_process_base.hpp
@@ -26,4 +26,7 @@ public:
 
     /// 非同期に終了要求を出す（Ctrl‑C 以外でも停止できるように）
     virtual void stop() = 0;
+
+    /// 優先度を取得（値が小さいほど高優先）
+    virtual int priority() const noexcept = 0;
 };

--- a/include/infra/process/process_base.hpp
+++ b/include/infra/process/process_base.hpp
@@ -14,10 +14,12 @@ class ProcessBase : public IProcessBase {
 public:
     ProcessBase(const std::string& mq_name,
                 std::shared_ptr<IMessageHandler> handler,
-                std::shared_ptr<ILogger> logger);
+                std::shared_ptr<ILogger> logger,
+                int priority = 0);
 
     int  run()  override;  ///< メインループ
     void stop() override;  ///< 外部停止
+    int  priority() const noexcept override { return priority_; }
 
 private:
     static std::atomic<bool> g_stop_flag;           ///< 全スレッド共通の終了フラグ
@@ -25,4 +27,5 @@ private:
     std::unique_ptr<MessageReceiver>       receiver_;
     std::unique_ptr<WorkerDispatcher>      worker_;
     std::shared_ptr<ILogger>               logger_;
+    int                                    priority_{0};
 };

--- a/src/core/app.cpp
+++ b/src/core/app.cpp
@@ -1,4 +1,5 @@
 #include "app/app.hpp"
+#include "message/message.hpp"
 
 namespace device_reminder {
 
@@ -16,7 +17,7 @@ App::App(std::unique_ptr<IMainTask> main_task,
 int App::run() {
     try {
         main_task_->run();
-        human_task_->run();
+        human_task_->run(Message{});
         bluetooth_task_->run();
         buzzer_task_->run();
     } catch (const std::exception& e) {

--- a/src/core/human_task.cpp
+++ b/src/core/human_task.cpp
@@ -1,24 +1,57 @@
-#include "human_task.hpp"
+#include "human_task/human_task.hpp"
 #include "infra/logger/i_logger.hpp"
+#include "message/message.hpp"
 
 namespace device_reminder {
 
-HumanTask::HumanTask(std::shared_ptr<ILogger> logger)
-    : logger_(std::move(logger)) {
+HumanTask::HumanTask(std::shared_ptr<IPIRDriver> pir,
+                     std::shared_ptr<ITimerService> timer,
+                     std::shared_ptr<IMessageSender> sender,
+                     std::shared_ptr<ILogger> logger)
+    : pir_(std::move(pir))
+    , timer_(std::move(timer))
+    , sender_(std::move(sender))
+    , logger_(std::move(logger))
+    , state_(State::Detecting)
+{
     if (logger_) logger_->info("HumanTask created");
 }
 
 HumanTask::~HumanTask() {
+    if (timer_ && timer_->active()) timer_->stop();
     if (logger_) logger_->info("HumanTask destroyed");
 }
 
-void HumanTask::run() {
-    if (logger_) logger_->info("HumanTask running");
-}
-
-bool HumanTask::send_message(const IMessage& msg) {
-    if (logger_) logger_->info("HumanTask send_message");
-    return true;
+void HumanTask::run(const IMessage& msg) {
+    switch (msg.type()) {
+    case MessageType::HumanDetected:
+        if (state_ == State::Detecting) {
+            if (sender_) sender_->enqueue(Message{MessageType::HumanDetected, true});
+            if (logger_) logger_->info("Human detected");
+        }
+        break;
+    case MessageType::HumanDetectStop:
+        if (state_ == State::Detecting) {
+            state_ = State::Stopped;
+            if (logger_) logger_->info("Detection stopped");
+        }
+        break;
+    case MessageType::HumanDetectStart:
+        if (state_ == State::Stopped) {
+            state_ = State::Cooldown;
+            if (timer_) timer_->start(5000, Message{MessageType::Timeout});
+            if (logger_) logger_->info("Detection cooldown");
+        }
+        break;
+    case MessageType::Timeout:
+        if (state_ == State::Cooldown) {
+            state_ = State::Detecting;
+            if (logger_) logger_->info("Cooldown end; detecting");
+        }
+        break;
+    default:
+        break;
+    }
 }
 
 } // namespace device_reminder

--- a/src/core/human_task_handler.cpp
+++ b/src/core/human_task_handler.cpp
@@ -1,0 +1,21 @@
+#include "human_task/human_task_handler.hpp"
+#include "message/message.hpp"
+
+namespace device_reminder {
+
+namespace {
+Message parse_message(const std::string& s) {
+    if (s == "start") return Message{MessageType::HumanDetectStart};
+    if (s == "stop")  return Message{MessageType::HumanDetectStop};
+    if (s == "detect") return Message{MessageType::HumanDetected};
+    if (s == "timeout") return Message{MessageType::Timeout};
+    return Message{};
+}
+} // namespace
+
+void HumanTaskHandler::handle(const std::string& msg_str) {
+    if (task_) task_->run(parse_message(msg_str));
+}
+
+} // namespace device_reminder
+

--- a/src/infra/process/process_base.cpp
+++ b/src/infra/process/process_base.cpp
@@ -11,10 +11,12 @@ std::atomic<bool> ProcessBase::g_stop_flag{false};
 
 ProcessBase::ProcessBase(const std::string& mq_name,
                          std::shared_ptr<IMessageHandler> handler,
-                         std::shared_ptr<ILogger> logger)
+                         std::shared_ptr<ILogger> logger,
+                         int priority)
     : receiver_{std::make_unique<MessageReceiver>(mq_name, nullptr)},
       worker_  {std::make_unique<WorkerDispatcher>(0, handler, logger)},
-      logger_(std::move(logger))
+      logger_(std::move(logger)),
+      priority_(priority)
 {
     // Ctrl‑C (SIGINT) を捕捉して終了フラグを立てる
     struct sigaction sa {};

--- a/tests/core/test_app.cpp
+++ b/tests/core/test_app.cpp
@@ -17,8 +17,7 @@ public:
 
 class MockHumanTask : public device_reminder::IHumanTask {
 public:
-    MOCK_METHOD(void, run, (), (override));
-    MOCK_METHOD(bool, send_message, (const device_reminder::IMessage& msg), (override));
+    MOCK_METHOD(void, run, (const device_reminder::IMessage& msg), (override));
 };
 
 class MockBluetoothTask : public device_reminder::IBluetoothTask {
@@ -63,7 +62,7 @@ TEST(AppTest, Run_CallsAllTaskRunMethods) {
 
     // 各 run メソッドが1回ずつ呼び出されることを期待
     EXPECT_CALL(*main_ptr, run()).Times(1);
-    EXPECT_CALL(*human_ptr, run()).Times(1);
+    EXPECT_CALL(*human_ptr, run(testing::_)).Times(1);
     EXPECT_CALL(*bluetooth_ptr, run()).Times(1);
     EXPECT_CALL(*buzzer_ptr, run()).Times(1);
     EXPECT_CALL(*logger_ptr, info(testing::_)).Times(testing::AtLeast(1));

--- a/tests/core/test_human_task.cpp
+++ b/tests/core/test_human_task.cpp
@@ -1,0 +1,90 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "human_task/human_task.hpp"
+#include "message/message.hpp"
+
+using ::testing::StrictMock;
+using ::testing::NiceMock;
+
+namespace device_reminder {
+
+class MockPIR : public IPIRDriver {
+public:
+    MOCK_METHOD(int, read, (), (override));
+};
+
+class MockTimer : public ITimerService {
+public:
+    MOCK_METHOD(void, start, (uint32_t, const Message&), (override));
+    MOCK_METHOD(void, stop, (), (override));
+    MOCK_METHOD(bool, active, (), (const, noexcept, override));
+};
+
+class MockSender : public IMessageSender {
+public:
+    MOCK_METHOD(bool, enqueue, (const Message&), (override));
+    MOCK_METHOD(void, stop, (), (override));
+};
+
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+};
+
+TEST(HumanTaskTest, StopRequestTransitionsToStopped) {
+    auto pir = std::make_shared<NiceMock<MockPIR>>();
+    auto timer = std::make_shared<NiceMock<MockTimer>>();
+    auto sender = std::make_shared<NiceMock<MockSender>>();
+    auto logger = std::make_shared<NiceMock<MockLogger>>();
+
+    HumanTask task(pir, timer, sender, logger);
+    EXPECT_EQ(task.state(), HumanTask::State::Detecting);
+
+    task.run(Message{MessageType::HumanDetectStop});
+    EXPECT_EQ(task.state(), HumanTask::State::Stopped);
+}
+
+TEST(HumanTaskTest, StartRequestStartsCooldown) {
+    auto pir = std::make_shared<NiceMock<MockPIR>>();
+    auto timer = std::make_shared<NiceMock<MockTimer>>();
+    auto sender = std::make_shared<NiceMock<MockSender>>();
+    auto logger = std::make_shared<NiceMock<MockLogger>>();
+
+    HumanTask task(pir, timer, sender, logger);
+    task.run(Message{MessageType::HumanDetectStop});
+
+    EXPECT_CALL(*timer, start(testing::_, testing::_));
+    task.run(Message{MessageType::HumanDetectStart});
+    EXPECT_EQ(task.state(), HumanTask::State::Cooldown);
+}
+
+TEST(HumanTaskTest, TimeoutReturnsToDetecting) {
+    auto pir = std::make_shared<NiceMock<MockPIR>>();
+    auto timer = std::make_shared<NiceMock<MockTimer>>();
+    auto sender = std::make_shared<NiceMock<MockSender>>();
+    auto logger = std::make_shared<NiceMock<MockLogger>>();
+
+    HumanTask task(pir, timer, sender, logger);
+    task.run(Message{MessageType::HumanDetectStop});
+    task.run(Message{MessageType::HumanDetectStart});
+    EXPECT_EQ(task.state(), HumanTask::State::Cooldown);
+
+    task.run(Message{MessageType::Timeout});
+    EXPECT_EQ(task.state(), HumanTask::State::Detecting);
+}
+
+TEST(HumanTaskTest, HumanDetectedSendsMessage) {
+    auto pir = std::make_shared<NiceMock<MockPIR>>();
+    auto timer = std::make_shared<NiceMock<MockTimer>>();
+    auto sender = std::make_shared<StrictMock<MockSender>>();
+    auto logger = std::make_shared<NiceMock<MockLogger>>();
+
+    HumanTask task(pir, timer, sender, logger);
+
+    EXPECT_CALL(*sender, enqueue(testing::Field(&Message::type_, MessageType::HumanDetected)));
+    task.run(Message{MessageType::HumanDetected});
+}
+
+} // namespace device_reminder


### PR DESCRIPTION
## Summary
- introduce priority support to `ProcessBase`
- create `HumanTaskHandler` to adapt messages for WorkerDispatcher
- provide `HumanTaskProcess` using `ProcessBase` with priority 4
- update build and tests

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687c6021b9b8832885544b108d12e0d7