### PR TITLE
Add comprehensive infra module tests with stubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,27 @@ add_executable(test_gpio_driver
     tests/stubs/gpiod_stub.cpp
 )
 
+# Additional infra tests
+add_executable(test_infra_extra
+    tests/infra/test_local_message_queue.cpp
+    tests/infra/test_message_queue.cpp
+    tests/infra/test_message_sender.cpp
+    tests/infra/test_message_receiver.cpp
+    tests/infra/test_pir_driver.cpp
+    tests/infra/test_timer_service.cpp
+    tests/infra/test_worker_dispatcher.cpp
+    tests/infra/test_buzzer_driver.cpp
+    tests/infra/test_message_codec.cpp
+    src/infra/local_message_queue.cpp
+    src/infra/message_operator/message_queue.cpp
+    src/infra/message_operator/message_receiver.cpp
+    src/infra/message_operator/message_sender.cpp
+    src/infra/pir_driver.cpp
+    src/infra/timer_service.cpp
+    src/infra/worker_dispatcher.cpp
+    tests/stubs/posix_mq_stub.cpp
+)
+
 # GoogleTestライブラリをリンク
 target_link_libraries(test_app
     gtest
@@ -48,6 +69,12 @@ target_link_libraries(test_app
 )
 
 target_link_libraries(test_gpio_driver
+    gtest
+    gmock
+    gtest_main
+)
+
+target_link_libraries(test_infra_extra
     gtest
     gmock
     gtest_main
@@ -61,9 +88,14 @@ if(UNIX)
     target_link_libraries(test_gpio_driver pthread)
 endif()
 
+if(UNIX)
+    target_link_libraries(test_infra_extra pthread rt)
+endif()
+
 enable_testing()
 add_test(NAME AllTests COMMAND test_app)
 add_test(NAME GPIODriverTests COMMAND test_gpio_driver)
+add_test(NAME InfraExtraTests COMMAND test_infra_extra)
 
 
 # 動的ランタイム(MDd)に統一する

--- a/include/infra/message_codec/codec.hpp
+++ b/include/infra/message_codec/codec.hpp
@@ -6,7 +6,7 @@
 
 namespace device_reminder {
 
-using RawMsg = std::array<char, BASIC_MSG_SIZE>;
+using RawMsg = std::array<char, MESSAGE_SIZE>;
 
 inline RawMsg encode(const IMessage& m) {
     RawMsg raw{};
@@ -17,7 +17,7 @@ inline RawMsg encode(const IMessage& m) {
 }
 
 inline std::unique_ptr<IMessage> decode(const char* buf, size_t sz) {
-    if (sz != BASIC_MSG_SIZE) return {};
+    if (sz != MESSAGE_SIZE) return {};
     const auto* in = reinterpret_cast<const Message*>(buf);
     return std::make_unique<Message>(in->type_, in->payload_);
 }

--- a/include/infra/message_operator/i_message_queue.hpp
+++ b/include/infra/message_operator/i_message_queue.hpp
@@ -6,6 +6,7 @@ namespace device_reminder {
 
 class IMessageQueue {
 public:
+    IMessageQueue() = default;
     virtual ~IMessageQueue() = default;
     IMessageQueue(const IMessageQueue&)            = delete;
     IMessageQueue& operator=(const IMessageQueue&) = delete;

--- a/tests/infra/test_buzzer_driver.cpp
+++ b/tests/infra/test_buzzer_driver.cpp
@@ -1,0 +1,28 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "infra/buzzer_driver/buzzer_driver.hpp"
+
+using namespace device_reminder;
+using ::testing::StrictMock;
+
+namespace {
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+};
+} // namespace
+
+TEST(BuzzerDriverTest, StartStopLogAndOutput) {
+    testing::internal::CaptureStdout();
+    auto logger = std::make_shared<StrictMock<MockLogger>>();
+    BuzzerDriver driver(logger);
+    EXPECT_CALL(*logger, info(testing::HasSubstr("Start Buzzer"))).Times(1);
+    driver.start_buzzer();
+    EXPECT_CALL(*logger, info(testing::HasSubstr("Stop Buzzer"))).Times(1);
+    driver.stop_buzzer();
+    std::string output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("Start Buzzer"));
+    EXPECT_THAT(output, testing::HasSubstr("Stop Buzzer"));
+}

--- a/tests/infra/test_local_message_queue.cpp
+++ b/tests/infra/test_local_message_queue.cpp
@@ -1,0 +1,33 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "infra/message_operator/local_message_queue.hpp"
+#include "infra/logger/i_logger.hpp"
+
+using namespace device_reminder;
+
+namespace {
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+};
+} // namespace
+
+TEST(LocalMessageQueueTest, PushPopWorks) {
+    LocalMessageQueue q;
+    Message m{MessageType::BuzzerOn, true};
+    EXPECT_TRUE(q.push(m));
+    auto res = q.pop();
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->type_, m.type_);
+    EXPECT_EQ(res->payload_, m.payload_);
+}
+
+TEST(LocalMessageQueueTest, CloseMakesPopReturnFalse) {
+    LocalMessageQueue q;
+    q.close();
+    EXPECT_FALSE(q.is_open());
+    Message out{};
+    EXPECT_FALSE(q.pop(out));
+}

--- a/tests/infra/test_message_codec.cpp
+++ b/tests/infra/test_message_codec.cpp
@@ -1,0 +1,14 @@
+#include <gtest/gtest.h>
+
+#include "infra/message_codec/codec.hpp"
+
+using namespace device_reminder;
+
+TEST(MessageCodecTest, EncodeDecodeRoundtrip) {
+    Message msg{MessageType::BuzzerOn, true};
+    auto raw = encode(msg);
+    auto decoded = decode(raw.data(), raw.size());
+    ASSERT_TRUE(decoded);
+    EXPECT_EQ(decoded->type(), msg.type());
+    EXPECT_EQ(decoded->payload(), msg.payload());
+}

--- a/tests/infra/test_message_queue.cpp
+++ b/tests/infra/test_message_queue.cpp
@@ -1,0 +1,23 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "infra/message_operator/message_queue.hpp"
+
+using namespace device_reminder;
+
+static std::string unique_queue_name(const std::string& base) {
+    return "/" + base + std::to_string(::getpid()) + std::to_string(::time(nullptr));
+}
+
+TEST(MessageQueueTest, PushAndPop) {
+    std::string name = unique_queue_name("mq_test_");
+    MessageQueue mq(name, true);
+    Message msg{MessageType::BuzzerOn, true};
+    EXPECT_TRUE(mq.push(msg));
+    auto res = mq.pop();
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->type_, msg.type_);
+    EXPECT_EQ(res->payload_, msg.payload_);
+    mq.close();
+    EXPECT_FALSE(mq.is_open());
+}

--- a/tests/infra/test_message_receiver.cpp
+++ b/tests/infra/test_message_receiver.cpp
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "infra/message_operator/message_receiver.hpp"
+#include "infra/message_operator/local_message_queue.hpp"
+#include "infra/logger/i_logger.hpp"
+#include <mqueue.h>
+#include <thread>
+
+using namespace device_reminder;
+
+namespace {
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+};
+} // namespace
+
+static std::string unique_name(const std::string& base) {
+    return "/" + base + std::to_string(::getpid()) + std::to_string(::time(nullptr));
+}
+
+TEST(MessageReceiverTest, ReceivesAndPushes) {
+    std::string name = unique_name("receiver_test_");
+    auto queue = std::make_shared<LocalMessageQueue>();
+    MockLogger logger;
+    MessageReceiver receiver(name, queue, std::shared_ptr<ILogger>(&logger, [](ILogger*){}));
+    std::thread th{std::ref(receiver)};
+
+    mqd_t mq = mq_open(name.c_str(), O_WRONLY);
+    ASSERT_NE(mq, static_cast<mqd_t>(-1));
+    Message msg{MessageType::BuzzerOn, true};
+    mq_send(mq, reinterpret_cast<const char*>(&msg), MESSAGE_SIZE, 0);
+    mq_close(mq);
+
+    auto res = queue->pop();
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->type_, msg.type_);
+
+    receiver.stop();
+    th.join();
+}

--- a/tests/infra/test_message_sender.cpp
+++ b/tests/infra/test_message_sender.cpp
@@ -1,0 +1,29 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "infra/message_operator/message_sender.hpp"
+#include <mqueue.h>
+
+using namespace device_reminder;
+
+static std::string unique_name(const std::string& base) {
+    return "/" + base + std::to_string(::getpid()) + std::to_string(::time(nullptr));
+}
+
+TEST(MessageSenderTest, EnqueueSendsMessage) {
+    std::string name = unique_name("sender_test_");
+    MessageSender sender(name, 5);
+
+    Message msg{MessageType::BuzzerOn, true};
+    ASSERT_TRUE(sender.enqueue(msg));
+
+    mqd_t mq = mq_open(name.c_str(), O_RDONLY);
+    ASSERT_NE(mq, static_cast<mqd_t>(-1));
+    Message out{};
+    ssize_t n = mq_receive(mq, reinterpret_cast<char*>(&out), MESSAGE_SIZE, nullptr);
+    EXPECT_EQ(n, (ssize_t)MESSAGE_SIZE);
+    EXPECT_EQ(out.type_, msg.type_);
+    mq_close(mq);
+
+    sender.stop();
+}

--- a/tests/infra/test_pir_driver.cpp
+++ b/tests/infra/test_pir_driver.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "infra/pir_driver/pir_driver.hpp"
+#include "infra/gpio_driver/i_gpio_driver.hpp"
+#include "infra/logger/i_logger.hpp"
+
+using namespace device_reminder;
+using ::testing::StrictMock;
+
+namespace {
+class MockGPIO : public IGPIODriver {
+public:
+    MOCK_METHOD(void, openChip, (const std::string&), (override));
+    MOCK_METHOD(void, setupLine, (unsigned int), (override));
+    MOCK_METHOD(int, readLine, (), (override));
+    MOCK_METHOD(void, close, (), (override));
+};
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+};
+} // namespace
+
+TEST(PIRDriverTest, InitCallsGPIO) {
+    StrictMock<MockGPIO> gpio;
+    StrictMock<MockLogger> logger;
+    EXPECT_CALL(gpio, openChip("/dev/gpiochip0"));
+    EXPECT_CALL(gpio, setupLine(17));
+    EXPECT_CALL(logger, info(testing::_)).Times(testing::AtLeast(1));
+    EXPECT_CALL(gpio, close());
+    {
+        PIRDriver driver(&gpio, &logger, 17, "/dev/gpiochip0");
+        EXPECT_CALL(gpio, readLine()).WillOnce(testing::Return(1));
+        EXPECT_EQ(driver.read(), 1);
+    }
+}

--- a/tests/infra/test_timer_service.cpp
+++ b/tests/infra/test_timer_service.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "infra/timer_service/timer_service.hpp"
+#include "infra/message_operator/i_message_sender.hpp"
+#include <thread>
+#include <chrono>
+
+using namespace device_reminder;
+using ::testing::StrictMock;
+using ::testing::NiceMock;
+
+namespace {
+class MockSender : public IMessageSender {
+public:
+    MOCK_METHOD(bool, enqueue, (const Message&), (override));
+    MOCK_METHOD(void, stop, (), (override));
+};
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+};
+} // namespace
+
+TEST(TimerServiceTest, SendsTimeoutMessage) {
+    auto sender = std::make_shared<StrictMock<MockSender>>();
+    NiceMock<MockLogger> logger;
+    TimerService timer(sender, std::shared_ptr<ILogger>(&logger, [](ILogger*){}));
+    Message m{MessageType::Timeout, false};
+    EXPECT_CALL(*sender, enqueue(testing::Field(&Message::type_, MessageType::Timeout))).Times(1);
+    timer.start(10, m);
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    while (timer.active()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    timer.stop();
+}

--- a/tests/infra/test_worker_dispatcher.cpp
+++ b/tests/infra/test_worker_dispatcher.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "infra/worker_dispatcher/worker_dispatcher.hpp"
+#include "infra/message_operator/local_message_queue.hpp"
+
+using namespace device_reminder;
+
+TEST(WorkerDispatcherTest, DispatchesMessage) {
+    auto queue = std::make_shared<LocalMessageQueue>();
+    Message received{};
+    std::mutex m;
+    std::condition_variable cv;
+    bool got = false;
+    auto handler = [&](const Message& msg){
+        std::lock_guard lk(m);
+        received = msg;
+        got = true;
+        cv.notify_one();
+    };
+
+    WorkerDispatcher disp(queue, handler);
+    disp.start();
+
+    Message msg{MessageType::BuzzerOn, true};
+    queue->push(msg);
+
+    {
+        std::unique_lock lk(m);
+        cv.wait_for(lk, std::chrono::milliseconds(100), [&]{ return got; });
+    }
+
+    disp.stop();
+    disp.join();
+    ASSERT_TRUE(got);
+    EXPECT_EQ(received.type_, msg.type_);
+}

--- a/tests/stubs/posix_mq_stub.cpp
+++ b/tests/stubs/posix_mq_stub.cpp
@@ -1,0 +1,45 @@
+#include "posix_mq_stub.h"
+#include <queue>
+#include <string>
+#include <cstring>
+#include <errno.h>
+
+struct StubMQ {
+    std::queue<std::string> q;
+};
+static StubMQ g_mq;
+static int fail_open = 0;
+static int fail_send = 0;
+static int fail_receive = 0;
+
+extern "C" {
+
+void mq_stub_reset(void) {
+    while(!g_mq.q.empty()) g_mq.q.pop();
+    fail_open = fail_send = fail_receive = 0;
+}
+void mq_stub_set_fail_open(int v) { fail_open = v; }
+void mq_stub_set_fail_send(int v) { fail_send = v; }
+void mq_stub_set_fail_receive(int v) { fail_receive = v; }
+
+mqd_t mq_open(const char*, int, ...) {
+    if(fail_open) { errno = EINVAL; return (mqd_t)-1; }
+    return 1; // dummy descriptor
+}
+int mq_close(mqd_t) { return 0; }
+int mq_unlink(const char*) { return 0; }
+int mq_send(mqd_t, const char* msg_ptr, size_t msg_len, unsigned int) {
+    if(fail_send) { errno = EINVAL; return -1; }
+    g_mq.q.emplace(msg_ptr, msg_len);
+    return 0;
+}
+ssize_t mq_receive(mqd_t, char* msg_ptr, size_t msg_len, unsigned int*) {
+    if(fail_receive || g_mq.q.empty()) { errno = EAGAIN; return -1; }
+    auto& s = g_mq.q.front();
+    size_t n = std::min(msg_len, s.size());
+    std::memcpy(msg_ptr, s.data(), n);
+    g_mq.q.pop();
+    return static_cast<ssize_t>(n);
+}
+
+} // extern "C"

--- a/tests/stubs/posix_mq_stub.h
+++ b/tests/stubs/posix_mq_stub.h
@@ -1,0 +1,14 @@
+#ifndef POSIX_MQ_STUB_H
+#define POSIX_MQ_STUB_H
+#include <mqueue.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+void mq_stub_reset(void);
+void mq_stub_set_fail_open(int v);
+void mq_stub_set_fail_send(int v);
+void mq_stub_set_fail_receive(int v);
+#ifdef __cplusplus
+}
+#endif
+#endif


### PR DESCRIPTION
## Summary
- add unit tests for various infra components
- include a POSIX message queue stub for testing
- fix codec constant and message queue interface
- integrate new tests with CMake build

## Testing
- `cmake --build . --config Release`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687c79e92cb08328aee44d3ae0dd1f34