### PR TITLE
Add BluetoothDriver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(test_infra_extra
     tests/infra/test_worker_dispatcher.cpp
     tests/infra/test_buzzer_driver.cpp
     tests/infra/test_message_codec.cpp
+    tests/infra/test_bluetooth_driver.cpp
     src/infra/local_message_queue.cpp
     src/infra/message_operator/message_queue.cpp
     src/infra/message_operator/message_receiver.cpp
@@ -61,6 +62,7 @@ add_executable(test_infra_extra
     src/infra/pir_driver.cpp
     src/infra/timer_service.cpp
     src/infra/worker_dispatcher.cpp
+    src/infra/bluetooth_driver.cpp
     tests/stubs/posix_mq_stub.cpp
 )
 

--- a/include/infra/bluetooth_driver/bluetooth_driver.hpp
+++ b/include/infra/bluetooth_driver/bluetooth_driver.hpp
@@ -1,14 +1,39 @@
-// buzzer_driver.hpp
 #pragma once
-#include <string>
+
+#include "i_bluetooth_driver.hpp"
+#include "infra/logger/i_logger.hpp"
+
+#include <optional>
+#include <memory>
+#include <mutex>
 
 namespace device_reminder {
 
-class BuzzerDriver {
+struct AdvertisementInfo {
+    std::string addr;
+    int8_t      rssi;
+    std::optional<int8_t> tx_power;  ///< 広告から取得したTxPower, なければnullopt
+};
+
+class IBluetoothScanner {
 public:
-    virtual ~BuzzerDriver() = default;
-    virtual void start_buzzer() = 0;
-    virtual void stop_buzzer() = 0;
-}
+    virtual ~IBluetoothScanner() = default;
+    virtual std::vector<AdvertisementInfo> scan() = 0;  ///< 1回だけスキャン
+};
+
+class BluetoothDriver : public IBluetoothDriver {
+public:
+    BluetoothDriver(std::shared_ptr<IBluetoothScanner> scanner,
+                    std::shared_ptr<ILogger> logger = nullptr);
+
+    std::vector<DeviceInfo> scan_once(double radius_m) override;
+
+private:
+    static double rssi_to_distance(int8_t rssi, int8_t tx_power, double n = 2.0);
+
+    std::shared_ptr<IBluetoothScanner> scanner_;
+    std::shared_ptr<ILogger> logger_;
+    std::mutex mtx_;
+};
 
 } // namespace device_reminder

--- a/include/infra/bluetooth_driver/i_bluetooth_driver.hpp
+++ b/include/infra/bluetooth_driver/i_bluetooth_driver.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <cstdint>
+#include <stdexcept>
+
+namespace device_reminder {
+
+struct DeviceInfo {
+    std::string addr;       ///< MAC アドレス
+    int8_t      rssi;       ///< 受信強度 [dBm]
+    double      est_distance; ///< 推定距離 [m]
+};
+
+class BluetoothDriverError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+class IBluetoothDriver {
+public:
+    virtual ~IBluetoothDriver() = default;
+
+    /// 半径 radius_m 以内に検知したデバイス一覧を返す
+    /// 失敗時は BluetoothDriverError を throw
+    virtual std::vector<DeviceInfo> scan_once(double radius_m) = 0;
+};
+
+} // namespace device_reminder

--- a/src/infra/bluetooth_driver.cpp
+++ b/src/infra/bluetooth_driver.cpp
@@ -1,0 +1,37 @@
+#include "bluetooth_driver/bluetooth_driver.hpp"
+
+#include <cmath>
+
+namespace device_reminder {
+
+BluetoothDriver::BluetoothDriver(std::shared_ptr<IBluetoothScanner> scanner,
+                                 std::shared_ptr<ILogger> logger)
+    : scanner_(std::move(scanner)), logger_(std::move(logger)) {}
+
+std::vector<DeviceInfo> BluetoothDriver::scan_once(double radius_m) {
+    std::lock_guard lk{mtx_};
+    if (!scanner_) throw BluetoothDriverError("scanner not initialized");
+
+    std::vector<AdvertisementInfo> advs;
+    try {
+        advs = scanner_->scan();
+    } catch (const std::exception& ex) {
+        throw BluetoothDriverError(ex.what());
+    }
+
+    std::vector<DeviceInfo> results;
+    for (const auto& adv : advs) {
+        int8_t txp = adv.tx_power.value_or(-59);
+        double dist = rssi_to_distance(adv.rssi, txp);
+        if (dist <= radius_m) {
+            results.push_back(DeviceInfo{adv.addr, adv.rssi, dist});
+        }
+    }
+    return results;
+}
+
+double BluetoothDriver::rssi_to_distance(int8_t rssi, int8_t tx_power, double n) {
+    return std::pow(10.0, (tx_power - rssi) / (10.0 * n));
+}
+
+} // namespace device_reminder

--- a/tests/infra/test_bluetooth_driver.cpp
+++ b/tests/infra/test_bluetooth_driver.cpp
@@ -1,0 +1,56 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "infra/bluetooth_driver/bluetooth_driver.hpp"
+
+using namespace device_reminder;
+
+namespace {
+
+class StubScanner : public IBluetoothScanner {
+public:
+    std::vector<AdvertisementInfo> advs{};
+    bool fail = false;
+    int call_count = 0;
+    std::vector<AdvertisementInfo> scan() override {
+        ++call_count;
+        if (fail) throw BluetoothDriverError("scan failed");
+        return advs;
+    }
+};
+
+class DummyLogger : public ILogger {
+public:
+    void info(const std::string&) override {}
+    void error(const std::string&) override {}
+};
+
+} // namespace
+
+TEST(BluetoothDriverTest, DistanceCalculationAndFilter) {
+    auto scanner = std::make_shared<StubScanner>();
+    scanner->advs.push_back({"AA:BB:CC:DD:EE:FF", -50, -59});
+    scanner->advs.push_back({"11:22:33:44:55:66", -90, -59});
+    BluetoothDriver driver(scanner, std::make_shared<DummyLogger>());
+
+    auto res = driver.scan_once(1.0); // 1m 以内
+    ASSERT_EQ(res.size(), 1u);
+    EXPECT_EQ(res[0].addr, "AA:BB:CC:DD:EE:FF");
+    EXPECT_NEAR(res[0].est_distance, 0.35, 0.05);
+}
+
+TEST(BluetoothDriverTest, ScanFailureThrows) {
+    auto scanner = std::make_shared<StubScanner>();
+    scanner->fail = true;
+    BluetoothDriver driver(scanner);
+    EXPECT_THROW(driver.scan_once(1.0), BluetoothDriverError);
+}
+
+TEST(BluetoothDriverTest, MultipleCallsUseSameScanner) {
+    auto scanner = std::make_shared<StubScanner>();
+    BluetoothDriver driver(scanner);
+    driver.scan_once(2.0);
+    driver.scan_once(2.0);
+    EXPECT_EQ(scanner->call_count, 2);
+}
+


### PR DESCRIPTION
## Summary
- add `BluetoothDriver` interface and implementation
- implement simple scanning algorithm
- add unit tests for BluetoothDriver
- hook new driver/test into CMake

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_687c8a2f0d50832896478526daada0fb