### PR TITLE
Implement BuzzerProcess and handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,12 +28,15 @@ add_executable(test_app
     tests/core/test_app.cpp
     tests/core/test_main_task.cpp
     tests/core/test_human_task.cpp
+    tests/core/test_buzzer_task.cpp
     tests/infra/test_logger.cpp
     src/core/app.cpp
     src/core/main_task.cpp
     src/core/main_task_handler.cpp
     src/core/human_task.cpp
     src/core/human_task_handler.cpp
+    src/core/buzzer_task.cpp
+    src/core/buzzer_handler.cpp
 )
 
 # GPIODriver tests

--- a/include/core/buzzer_task/buzzer_handler.hpp
+++ b/include/core/buzzer_task/buzzer_handler.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "interfaces/i_message_handler.hpp"
+#include "buzzer_task/buzzer_task.hpp"
+#include <memory>
+
+namespace device_reminder {
+
+class BuzzerHandler : public IMessageHandler {
+public:
+    explicit BuzzerHandler(std::shared_ptr<BuzzerTask> task)
+        : task_(std::move(task)) {}
+
+    void handle(const std::string& msg_str) override;
+
+private:
+    std::shared_ptr<BuzzerTask> task_;
+};
+
+} // namespace device_reminder

--- a/include/core/buzzer_task/buzzer_process.hpp
+++ b/include/core/buzzer_task/buzzer_process.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "infra/process/process_base.hpp"
+#include "buzzer_task/buzzer_handler.hpp"
+#include <memory>
+
+namespace device_reminder {
+
+class BuzzerProcess : public ProcessBase {
+public:
+    BuzzerProcess(const std::string& mq_name,
+                  std::shared_ptr<BuzzerTask> task,
+                  std::shared_ptr<ILogger> logger)
+        : ProcessBase(mq_name,
+                      std::make_shared<BuzzerHandler>(std::move(task)),
+                      std::move(logger),
+                      2) {}
+};
+
+} // namespace device_reminder

--- a/include/core/buzzer_task/buzzer_task.hpp
+++ b/include/core/buzzer_task/buzzer_task.hpp
@@ -2,21 +2,39 @@
 
 #include "message/i_message.hpp"
 #include "buzzer_task/i_buzzer_task.hpp"
+#include "infra/buzzer_driver/i_buzzer_driver.hpp"
+#include "infra/timer_service/i_timer_service.hpp"
 #include "infra/logger/i_logger.hpp"
+
 #include <memory>
+#include <cstdint>
 
 namespace device_reminder {
 
 class BuzzerTask : public IBuzzerTask {
 public:
-    explicit BuzzerTask(std::shared_ptr<ILogger> logger);
-    ~BuzzerTask();
+    enum class State { WaitStart, Buzzing };
 
-    void run() override;
+    BuzzerTask(std::shared_ptr<IBuzzerDriver> driver,
+               std::shared_ptr<ITimerService> timer,
+               std::shared_ptr<ILogger> logger = nullptr);
+
+    void run() override {}
     bool send_message(const IMessage& msg) override;
 
+    void onMessage(const IMessage& msg);
+    State state() const noexcept { return state_; }
+
 private:
-    std::shared_ptr<ILogger> logger_;
+    void startBuzzer();
+    void stopBuzzer(bool cancelTimer);
+
+    static constexpr uint32_t kBuzzDurationMs = 4000;
+
+    std::shared_ptr<IBuzzerDriver>  driver_;
+    std::shared_ptr<ITimerService>  timer_;
+    std::shared_ptr<ILogger>        logger_;
+    State                           state_{State::WaitStart};
 };
 
 } // namespace device_reminder

--- a/src/core/buzzer_handler.cpp
+++ b/src/core/buzzer_handler.cpp
@@ -1,0 +1,20 @@
+#include "buzzer_task/buzzer_handler.hpp"
+#include "message/message.hpp"
+
+namespace device_reminder {
+namespace {
+
+Message parse_message(const std::string& s) {
+    if (s == "on") return Message{MessageType::BuzzerOn};
+    if (s == "off") return Message{MessageType::BuzzerOff};
+    if (s == "timeout") return Message{MessageType::Timeout};
+    return Message{};
+}
+
+} // namespace
+
+void BuzzerHandler::handle(const std::string& msg_str) {
+    if (task_) task_->send_message(parse_message(msg_str));
+}
+
+} // namespace device_reminder

--- a/src/core/buzzer_task.cpp
+++ b/src/core/buzzer_task.cpp
@@ -1,25 +1,49 @@
-#include "buzzer_task.hpp"
-#include <iostream>
-#include "infra/logger/i_logger.hpp"
+#include "buzzer_task/buzzer_task.hpp"
+#include "message/message.hpp"
 
 namespace device_reminder {
 
-BuzzerTask::BuzzerTask(std::shared_ptr<ILogger> logger)
-    : logger_(std::move(logger)) {
+BuzzerTask::BuzzerTask(std::shared_ptr<IBuzzerDriver> driver,
+                       std::shared_ptr<ITimerService> timer,
+                       std::shared_ptr<ILogger> logger)
+    : driver_(std::move(driver))
+    , timer_(std::move(timer))
+    , logger_(std::move(logger))
+{
     if (logger_) logger_->info("BuzzerTask created");
 }
 
-BuzzerTask::~BuzzerTask() {
-    if (logger_) logger_->info("BuzzerTask destroyed");
-}
-
-void BuzzerTask::run() {
-    if (logger_) logger_->info("BuzzerTask running");
-}
-
 bool BuzzerTask::send_message(const IMessage& msg) {
-    if (logger_) logger_->info("BuzzerTask send_message");
+    onMessage(msg);
     return true;
+}
+
+void BuzzerTask::onMessage(const IMessage& msg) {
+    switch (msg.type()) {
+    case MessageType::BuzzerOn:
+        if (state_ == State::WaitStart) startBuzzer();
+        break;
+    case MessageType::BuzzerOff:
+        if (state_ == State::Buzzing) stopBuzzer(true);
+        break;
+    case MessageType::Timeout:
+        if (state_ == State::Buzzing) stopBuzzer(false);
+        break;
+    default:
+        break;
+    }
+}
+
+void BuzzerTask::startBuzzer() {
+    if (driver_) driver_->start_buzzer();
+    if (timer_) timer_->start(kBuzzDurationMs, Message{MessageType::Timeout});
+    state_ = State::Buzzing;
+}
+
+void BuzzerTask::stopBuzzer(bool cancelTimer) {
+    if (driver_) driver_->stop_buzzer();
+    if (cancelTimer && timer_) timer_->stop();
+    state_ = State::WaitStart;
 }
 
 } // namespace device_reminder

--- a/tests/core/test_buzzer_task.cpp
+++ b/tests/core/test_buzzer_task.cpp
@@ -1,0 +1,82 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "buzzer_task/buzzer_task.hpp"
+#include "message/message.hpp"
+
+using ::testing::StrictMock;
+using ::testing::NiceMock;
+
+namespace device_reminder {
+
+class MockDriver : public IBuzzerDriver {
+public:
+    MOCK_METHOD(void, start_buzzer, (), (override));
+    MOCK_METHOD(void, stop_buzzer, (), (override));
+};
+
+class MockTimer : public ITimerService {
+public:
+    MOCK_METHOD(void, start, (uint32_t, const Message&), (override));
+    MOCK_METHOD(void, stop, (), (override));
+    MOCK_METHOD(bool, active, (), (const, noexcept, override));
+};
+
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+};
+
+TEST(BuzzerTaskTest, StartAndTimeoutStopsBuzzer) {
+    auto driver = std::make_shared<StrictMock<MockDriver>>();
+    auto timer = std::make_shared<StrictMock<MockTimer>>();
+    auto logger = std::make_shared<NiceMock<MockLogger>>();
+
+    BuzzerTask task(driver, timer, logger);
+
+    EXPECT_CALL(*driver, start_buzzer());
+    EXPECT_CALL(*timer, start(4000, testing::Field(&Message::type_, MessageType::Timeout)));
+    task.send_message(Message{MessageType::BuzzerOn});
+    EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
+
+    EXPECT_CALL(*driver, stop_buzzer());
+    EXPECT_CALL(*timer, stop()).Times(0);
+    task.send_message(Message{MessageType::Timeout});
+    EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
+}
+
+TEST(BuzzerTaskTest, ManualStopCancelsTimer) {
+    auto driver = std::make_shared<StrictMock<MockDriver>>();
+    auto timer = std::make_shared<StrictMock<MockTimer>>();
+    auto logger = std::make_shared<NiceMock<MockLogger>>();
+
+    BuzzerTask task(driver, timer, logger);
+
+    EXPECT_CALL(*driver, start_buzzer());
+    EXPECT_CALL(*timer, start(4000, testing::Field(&Message::type_, MessageType::Timeout)));
+    task.send_message(Message{MessageType::BuzzerOn});
+
+    EXPECT_CALL(*driver, stop_buzzer());
+    EXPECT_CALL(*timer, stop());
+    task.send_message(Message{MessageType::BuzzerOff});
+    EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
+}
+
+TEST(BuzzerTaskTest, IgnoreDuplicateStart) {
+    auto driver = std::make_shared<StrictMock<MockDriver>>();
+    auto timer = std::make_shared<StrictMock<MockTimer>>();
+    auto logger = std::make_shared<NiceMock<MockLogger>>();
+
+    BuzzerTask task(driver, timer, logger);
+
+    EXPECT_CALL(*driver, start_buzzer());
+    EXPECT_CALL(*timer, start(4000, testing::Field(&Message::type_, MessageType::Timeout)));
+    task.send_message(Message{MessageType::BuzzerOn});
+    EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
+
+    task.send_message(Message{MessageType::BuzzerOn});
+    EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
+}
+
+} // namespace device_reminder


### PR DESCRIPTION
## Summary
- add BuzzerHandler to translate raw strings into BuzzerTask messages
- provide BuzzerProcess derived from ProcessBase
- compile buzzer handler in test build

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687c902c7a488328b89a49eca2be9c48