### PR TITLE
Refactor Bluetooth driver interface

### DIFF
--- a/di/app_injector.hpp
+++ b/di/app_injector.hpp
@@ -37,11 +37,6 @@ auto merge_injectors(Tuples&&... tuples) {
 
 inline auto make_app_injector() {
     auto logger = make_logger_injector();
-    // BluetoothScanner の実装が存在しないため、簡易スキャナを定義
-    struct DummyBluetoothScanner : IBluetoothScanner {
-        std::vector<AdvertisementInfo> scan() override { return {}; }
-    };
-
     auto core = std::tuple{
         di::bind<IMainTask>.to<MainTask>(),
         di::bind<IHumanTask>.to<HumanTask>(),
@@ -56,7 +51,6 @@ inline auto make_app_injector() {
         di::bind<IGPIODriver>.to<GPIODriver>(),
         di::bind<IBuzzerDriver>.to<BuzzerDriver>(),
         di::bind<IPIRDriver>.to<PIRDriver>(),
-        di::bind<IBluetoothScanner>.to<DummyBluetoothScanner>(),
         di::bind<IBluetoothDriver>.to<BluetoothDriver>()
     };
 

--- a/include/infra/bluetooth_driver/bluetooth_driver.hpp
+++ b/include/infra/bluetooth_driver/bluetooth_driver.hpp
@@ -3,37 +3,19 @@
 #include "i_bluetooth_driver.hpp"
 #include "infra/logger/i_logger.hpp"
 
-#include <optional>
-#include <memory>
-#include <mutex>
+#include <vector>
+#include <string>
 
 namespace device_reminder {
 
-struct AdvertisementInfo {
-    std::string addr;
-    int8_t      rssi;
-    std::optional<int8_t> tx_power;  ///< 広告から取得したTxPower, なければnullopt
-};
-
-class IBluetoothScanner {
-public:
-    virtual ~IBluetoothScanner() = default;
-    virtual std::vector<AdvertisementInfo> scan() = 0;  ///< 1回だけスキャン
-};
-
 class BluetoothDriver : public IBluetoothDriver {
 public:
-    BluetoothDriver(std::shared_ptr<IBluetoothScanner> scanner,
-                    std::shared_ptr<ILogger> logger = nullptr);
+    explicit BluetoothDriver(ILogger& logger);
 
-    std::vector<DeviceInfo> scan_once(double radius_m) override;
+    std::vector<std::string> scan() override;
 
 private:
-    static double rssi_to_distance(int8_t rssi, int8_t tx_power, double n = 2.0);
-
-    std::shared_ptr<IBluetoothScanner> scanner_;
-    std::shared_ptr<ILogger> logger_;
-    std::mutex mtx_;
+    ILogger* logger_;
 };
 
 } // namespace device_reminder

--- a/include/infra/bluetooth_driver/i_bluetooth_driver.hpp
+++ b/include/infra/bluetooth_driver/i_bluetooth_driver.hpp
@@ -2,16 +2,9 @@
 
 #include <vector>
 #include <string>
-#include <cstdint>
 #include <stdexcept>
 
 namespace device_reminder {
-
-struct DeviceInfo {
-    std::string addr;       ///< MAC アドレス
-    int8_t      rssi;       ///< 受信強度 [dBm]
-    double      est_distance; ///< 推定距離 [m]
-};
 
 class BluetoothDriverError : public std::runtime_error {
 public:
@@ -22,9 +15,9 @@ class IBluetoothDriver {
 public:
     virtual ~IBluetoothDriver() = default;
 
-    /// 半径 radius_m 以内に検知したデバイス一覧を返す
+    /// 周囲のスマートフォン名一覧を取得する
     /// 失敗時は BluetoothDriverError を throw
-    virtual std::vector<DeviceInfo> scan_once(double radius_m) = 0;
+    virtual std::vector<std::string> scan() = 0;
 };
 
 } // namespace device_reminder

--- a/src/core/bluetooth_task.cpp
+++ b/src/core/bluetooth_task.cpp
@@ -26,7 +26,7 @@ void BluetoothTask::run(const IMessage& msg) {
     bool detected = false;
     try {
         if (driver_) {
-            auto devices = driver_->scan_once(2.0);
+            auto devices = driver_->scan();
             detected = !devices.empty();
         }
     } catch (const std::exception& e) {

--- a/tests/infra/test_bluetooth_driver.cpp
+++ b/tests/infra/test_bluetooth_driver.cpp
@@ -1,56 +1,18 @@
 #include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
 #include "infra/bluetooth_driver/bluetooth_driver.hpp"
 
 using namespace device_reminder;
 
 namespace {
-
-class StubScanner : public IBluetoothScanner {
-public:
-    std::vector<AdvertisementInfo> advs{};
-    bool fail = false;
-    int call_count = 0;
-    std::vector<AdvertisementInfo> scan() override {
-        ++call_count;
-        if (fail) throw BluetoothDriverError("scan failed");
-        return advs;
-    }
-};
-
 class DummyLogger : public ILogger {
 public:
     void info(const std::string&) override {}
     void error(const std::string&) override {}
 };
-
 } // namespace
 
-TEST(BluetoothDriverTest, DistanceCalculationAndFilter) {
-    auto scanner = std::make_shared<StubScanner>();
-    scanner->advs.push_back({"AA:BB:CC:DD:EE:FF", -50, -59});
-    scanner->advs.push_back({"11:22:33:44:55:66", -90, -59});
-    BluetoothDriver driver(scanner, std::make_shared<DummyLogger>());
-
-    auto res = driver.scan_once(1.0); // 1m 以内
-    ASSERT_EQ(res.size(), 1u);
-    EXPECT_EQ(res[0].addr, "AA:BB:CC:DD:EE:FF");
-    EXPECT_NEAR(res[0].est_distance, 0.35, 0.05);
+TEST(BluetoothDriverTest, ScanRunsWithoutThrow) {
+    DummyLogger logger;
+    BluetoothDriver driver(logger);
+    EXPECT_NO_THROW({ auto res = driver.scan(); (void)res; });
 }
-
-TEST(BluetoothDriverTest, ScanFailureThrows) {
-    auto scanner = std::make_shared<StubScanner>();
-    scanner->fail = true;
-    BluetoothDriver driver(scanner);
-    EXPECT_THROW(driver.scan_once(1.0), BluetoothDriverError);
-}
-
-TEST(BluetoothDriverTest, MultipleCallsUseSameScanner) {
-    auto scanner = std::make_shared<StubScanner>();
-    BluetoothDriver driver(scanner);
-    driver.scan_once(2.0);
-    driver.scan_once(2.0);
-    EXPECT_EQ(scanner->call_count, 2);
-}
-


### PR DESCRIPTION
## Summary
- redesign IBluetoothDriver to return smartphone names
- simplify BluetoothDriver implementation with popen-based scan
- adjust BluetoothTask to use new interface
- update dependency injector and unit tests accordingly

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687dad00fc0883289666796e3f03ce18