### PR TITLE
Rename SpdlogLogger class

### DIFF
--- a/di/logger_injector.hpp
+++ b/di/logger_injector.hpp
@@ -19,7 +19,7 @@ inline auto make_logger_injector() {
 
     // バインディングの束を返す（injectorは返さない）
     return std::tuple{
-        di::bind<ILogger>.to<SpdlogLogger>(),
+        di::bind<ILogger>.to<Logger>(),
         di::bind<std::shared_ptr<spdlog::logger>>.to(spd_logger).in(di::singleton)
     };
 }

--- a/include/infra/logger/logger.hpp
+++ b/include/infra/logger/logger.hpp
@@ -6,9 +6,9 @@
 
 namespace device_reminder {
 
-class SpdlogLogger : public ILogger {
+class Logger : public ILogger {
 public:
-    explicit SpdlogLogger(std::shared_ptr<spdlog::logger> logger)
+    explicit Logger(std::shared_ptr<spdlog::logger> logger)
         : logger_(std::move(logger)) {}
 
     void info(const std::string& msg) override {

--- a/tests/infra/test_logger.cpp
+++ b/tests/infra/test_logger.cpp
@@ -16,10 +16,10 @@ public:
     void set_formatter(std::unique_ptr<spdlog::formatter>) override {}
 };
 
-TEST(SpdlogLoggerTest, InfoOutputsToSink) {
+TEST(LoggerTest, InfoOutputsToSink) {
     auto sink = std::make_shared<StrictMock<MockSink>>();
     auto spdlogger = std::make_shared<spdlog::logger>("test", sink);
-    device_reminder::SpdlogLogger logger(spdlogger);
+    device_reminder::Logger logger(spdlogger);
 
     const std::string message = "info message";
 
@@ -30,10 +30,10 @@ TEST(SpdlogLoggerTest, InfoOutputsToSink) {
     logger.info(message);
 }
 
-TEST(SpdlogLoggerTest, ErrorOutputsToSink) {
+TEST(LoggerTest, ErrorOutputsToSink) {
     auto sink = std::make_shared<StrictMock<MockSink>>();
     auto spdlogger = std::make_shared<spdlog::logger>("test", sink);
-    device_reminder::SpdlogLogger logger(spdlogger);
+    device_reminder::Logger logger(spdlogger);
 
     const std::string message = "error message";
 


### PR DESCRIPTION
## Summary
- rename `SpdlogLogger` to `Logger`
- update DI bindings and tests

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687dee1bc5c483289d110e8a43f07df3