### PR TITLE
Move message interfaces into operation folders

### DIFF
--- a/include/core/bluetooth_task/bluetooth_task.hpp
+++ b/include/core/bluetooth_task/bluetooth_task.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/i_message.hpp"
+#include "infra/thread_message_operation/i_thread_message.hpp"
 #include "bluetooth_task/i_bluetooth_task.hpp"
 #include "infra/logger/i_logger.hpp"
 #include "infra/bluetooth_driver/i_bluetooth_driver.hpp"
@@ -18,8 +18,8 @@ public:
                   std::shared_ptr<ILogger> logger = nullptr);
     ~BluetoothTask();
 
-    void run(const IMessage& msg) override;
-    bool send_message(const IMessage& msg) override;
+    void run(const IThreadMessage& msg) override;
+    bool send_message(const IThreadMessage& msg) override;
 
     State state() const noexcept { return state_; }
 

--- a/include/core/bluetooth_task/i_bluetooth_task.hpp
+++ b/include/core/bluetooth_task/i_bluetooth_task.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/i_message.hpp"
+#include "infra/thread_message_operation/i_thread_message.hpp"
 
 namespace device_reminder {
 
@@ -8,8 +8,8 @@ class IBluetoothTask {
 public:
     virtual ~IBluetoothTask() = default;
 
-    virtual void run(const IMessage& msg) = 0;
-    virtual bool send_message(const IMessage& msg) = 0;
+    virtual void run(const IThreadMessage& msg) = 0;
+    virtual bool send_message(const IThreadMessage& msg) = 0;
 };
 
 } // namespace device_reminder

--- a/include/core/buzzer_task/buzzer_task.hpp
+++ b/include/core/buzzer_task/buzzer_task.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/i_message.hpp"
+#include "infra/thread_message_operation/i_thread_message.hpp"
 #include "buzzer_task/i_buzzer_task.hpp"
 #include "infra/buzzer_driver/i_buzzer_driver.hpp"
 #include "infra/timer_service/i_timer_service.hpp"
@@ -20,9 +20,9 @@ public:
                std::shared_ptr<ILogger> logger = nullptr);
 
     void run() override {}
-    bool send_message(const IMessage& msg) override;
+    bool send_message(const IThreadMessage& msg) override;
 
-    void onMessage(const IMessage& msg);
+    void onMessage(const IThreadMessage& msg);
     State state() const noexcept { return state_; }
 
 private:

--- a/include/core/buzzer_task/i_buzzer_task.hpp
+++ b/include/core/buzzer_task/i_buzzer_task.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/i_message.hpp"
+#include "infra/thread_message_operation/i_thread_message.hpp"
 
 namespace device_reminder {
 
@@ -9,7 +9,7 @@ public:
     virtual ~IBuzzerTask() = default;
 
     virtual void run() = 0;
-    virtual bool send_message(const IMessage& msg) = 0;
+    virtual bool send_message(const IThreadMessage& msg) = 0;
 };
 
 } // namespace device_reminder

--- a/include/core/human_task/human_task.hpp
+++ b/include/core/human_task/human_task.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/i_message.hpp"
+#include "infra/thread_message_operation/i_thread_message.hpp"
 #include "human_task/i_human_task.hpp"
 #include "infra/logger/i_logger.hpp"
 #include "infra/pir_driver/i_pir_driver.hpp"
@@ -20,7 +20,7 @@ public:
               std::shared_ptr<ILogger> logger);
     ~HumanTask();
 
-    void run(const IMessage& msg) override;
+    void run(const IThreadMessage& msg) override;
 
     State state() const noexcept { return state_; }
 

--- a/include/core/human_task/i_human_task.hpp
+++ b/include/core/human_task/i_human_task.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/i_message.hpp"
+#include "infra/thread_message_operation/i_thread_message.hpp"
 
 namespace device_reminder {
 
@@ -8,7 +8,7 @@ class IHumanTask {
 public:
     virtual ~IHumanTask() = default;
 
-    virtual void run(const IMessage& msg) = 0;
+    virtual void run(const IThreadMessage& msg) = 0;
 };
 
 } // namespace device_reminder

--- a/include/core/main_task/i_main_task.hpp
+++ b/include/core/main_task/i_main_task.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/i_message.hpp"
+#include "infra/thread_message_operation/i_thread_message.hpp"
 
 namespace device_reminder {
 
@@ -8,7 +8,7 @@ class IMainTask {
 public:
     virtual ~IMainTask() = default;
 
-    virtual void run(const IMessage& msg) = 0;
+    virtual void run(const IThreadMessage& msg) = 0;
 };
 
 } // namespace device_reminder

--- a/include/core/main_task/main_task.hpp
+++ b/include/core/main_task/main_task.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "infra/i_message.hpp"
+#include "infra/thread_message_operation/i_thread_message.hpp"
 #include "main_task/i_main_task.hpp"
 #include "infra/logger/i_logger.hpp"
 #include "infra/timer_service/i_timer_service.hpp"
@@ -22,7 +22,7 @@ public:
 
     ~MainTask();
 
-    void run(const IMessage& msg) override;
+    void run(const IThreadMessage& msg) override;
     State state() const noexcept { return state_; }
 
 private:

--- a/include/infra/process_message_operation/i_process_message.hpp
+++ b/include/infra/process_message_operation/i_process_message.hpp
@@ -1,11 +1,11 @@
 #pragma once
-#include "infra/message_type.hpp"
+#include "infra/thread_message_operation/i_thread_message.hpp"
 
 namespace device_reminder {
 
-class IMessage {
+class IProcessMessage {
 public:
-    virtual ~IMessage() = default;
+    virtual ~IProcessMessage() = default;
     virtual MessageType type() const noexcept = 0;
     virtual bool payload() const noexcept = 0;
 };

--- a/include/infra/process_message_operation/i_process_message_queue.hpp
+++ b/include/infra/process_message_operation/i_process_message_queue.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include <optional>
+#include "infra/process_message_operation/process_message.hpp"
+
+namespace device_reminder {
+
+class IProcessMessageQueue {
+public:
+    virtual ~IProcessMessageQueue() = default;
+    virtual bool push(const ProcessMessage& msg) = 0;
+    virtual std::optional<ProcessMessage> pop() = 0;
+    virtual bool pop(ProcessMessage& out) = 0;
+    virtual bool is_open() const noexcept = 0;
+    virtual void close() = 0;
+};
+
+} // namespace device_reminder

--- a/include/infra/process_message_operation/i_process_message_receiver.hpp
+++ b/include/infra/process_message_operation/i_process_message_receiver.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include "infra/thread_message_operation/i_message_queue.hpp"
+#include <memory>
+
+namespace device_reminder {
+
+class IProcessMessageReceiver {
+public:
+    virtual ~IProcessMessageReceiver() = default;
+    virtual void operator()() = 0;
+    virtual void stop() = 0;
+    virtual bool running() const noexcept = 0;
+};
+
+} // namespace device_reminder

--- a/include/infra/process_message_operation/process_message.hpp
+++ b/include/infra/process_message_operation/process_message.hpp
@@ -1,10 +1,10 @@
 #pragma once
-#include "infra/i_message.hpp"
+#include "infra/process_message_operation/i_process_message.hpp"
 #include <cstddef>
 
 namespace device_reminder {
 
-struct ProcessMessage final : public IMessage {
+struct ProcessMessage final : public IProcessMessage {
     constexpr ProcessMessage(MessageType t = MessageType::None,
                              bool p = false) noexcept
         : type_{t}, payload_{p} {}

--- a/include/infra/process_message_operation/process_message_queue.hpp
+++ b/include/infra/process_message_operation/process_message_queue.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "infra/process_message_operation/process_message.hpp"
 #include "infra/logger/i_logger.hpp"
+#include "infra/process_message_operation/i_process_message_queue.hpp"
 #include <memory>
 #include <optional>
 
@@ -10,7 +11,7 @@
 
 namespace device_reminder {
 
-class ProcessMessageQueue {
+class ProcessMessageQueue : public IProcessMessageQueue {
 public:
     explicit ProcessMessageQueue(const std::string& name,
                                  bool create = false,

--- a/include/infra/process_message_operation/process_message_receiver.hpp
+++ b/include/infra/process_message_operation/process_message_receiver.hpp
@@ -2,6 +2,7 @@
 #include "infra/process_message_operation/process_message.hpp"
 #include "infra/process_message_operation/process_message_queue.hpp" // forward decl
 #include "infra/thread_message_operation/i_message_queue.hpp"
+#include "infra/process_message_operation/i_process_message_receiver.hpp"
 #include "infra/logger/i_logger.hpp"
 #include <mqueue.h>
 #include <atomic>
@@ -10,7 +11,7 @@
 
 namespace device_reminder {
 
-class ProcessMessageReceiver {
+class ProcessMessageReceiver : public IProcessMessageReceiver {
 public:
     ProcessMessageReceiver(const std::string& mq_name,
                            std::shared_ptr<IThreadMessageQueue> queue,

--- a/include/infra/thread_message_operation/i_thread_message.hpp
+++ b/include/infra/thread_message_operation/i_thread_message.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 namespace device_reminder {
 
@@ -15,6 +16,13 @@ enum class MessageType {
     BuzzerOff,
     BluetoothScanRequest,
     DevicePresenceResponse
+};
+
+class IThreadMessage {
+public:
+    virtual ~IThreadMessage() = default;
+    virtual MessageType type() const noexcept = 0;
+    virtual bool payload() const noexcept = 0;
 };
 
 } // namespace device_reminder

--- a/include/infra/thread_message_operation/i_thread_message_receiver.hpp
+++ b/include/infra/thread_message_operation/i_thread_message_receiver.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include <functional>
+#include "infra/thread_message_operation/thread_message.hpp"
+
+namespace device_reminder {
+
+class IThreadMessageReceiver {
+public:
+    using MessageHandler = std::function<void(const ThreadMessage&)>;
+    virtual ~IThreadMessageReceiver() = default;
+    virtual void operator()() = 0;
+    virtual void stop() = 0;
+    virtual bool running() const noexcept = 0;
+};
+
+} // namespace device_reminder

--- a/include/infra/thread_message_operation/i_thread_message_sender.hpp
+++ b/include/infra/thread_message_operation/i_thread_message_sender.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include "infra/thread_message_operation/thread_message.hpp"
+
+namespace device_reminder {
+
+class IThreadMessageSender {
+public:
+    virtual ~IThreadMessageSender() = default;
+    virtual bool enqueue(const ThreadMessage& msg) = 0;
+    virtual void stop() = 0;
+};
+
+} // namespace device_reminder

--- a/include/infra/thread_message_operation/thread_message.hpp
+++ b/include/infra/thread_message_operation/thread_message.hpp
@@ -1,10 +1,10 @@
 #pragma once
-#include "infra/i_message.hpp"
+#include "infra/thread_message_operation/i_thread_message.hpp"
 #include <cstddef>
 
 namespace device_reminder {
 
-struct ThreadMessage final : public IMessage {
+struct ThreadMessage final : public IThreadMessage {
     constexpr ThreadMessage(MessageType t = MessageType::None,
                             bool p = false) noexcept
         : type_{t}, payload_{p} {}

--- a/include/infra/thread_message_operation/thread_message_receiver.hpp
+++ b/include/infra/thread_message_operation/thread_message_receiver.hpp
@@ -2,13 +2,14 @@
 #include "infra/thread_message_operation/i_message_queue.hpp"
 #include "infra/thread_message_operation/thread_message.hpp"
 #include "infra/logger/i_logger.hpp"
+#include "infra/thread_message_operation/i_thread_message_receiver.hpp"
 #include <functional>
 #include <memory>
 #include <atomic>
 
 namespace device_reminder {
 
-class ThreadMessageReceiver {
+class ThreadMessageReceiver : public IThreadMessageReceiver {
 public:
     using MessageHandler = std::function<void(const ThreadMessage&)>;
 

--- a/include/infra/thread_message_operation/thread_message_sender.hpp
+++ b/include/infra/thread_message_operation/thread_message_sender.hpp
@@ -2,11 +2,12 @@
 #include "infra/thread_message_operation/i_message_queue.hpp"
 #include "infra/thread_message_operation/thread_message.hpp"
 #include "infra/logger/i_logger.hpp"
+#include "infra/thread_message_operation/i_thread_message_sender.hpp"
 #include <memory>
 
 namespace device_reminder {
 
-class ThreadMessageSender {
+class ThreadMessageSender : public IThreadMessageSender {
 public:
     explicit ThreadMessageSender(std::shared_ptr<IThreadMessageQueue> queue,
                                  std::shared_ptr<ILogger> logger = nullptr);

--- a/src/core/bluetooth_task.cpp
+++ b/src/core/bluetooth_task.cpp
@@ -1,5 +1,5 @@
 #include "bluetooth_task/bluetooth_task.hpp"
-#include "infra/i_message.hpp"
+#include "infra/thread_message_operation/i_thread_message.hpp"
 #include "infra/logger/i_logger.hpp"
 #include "infra/bluetooth_driver/i_bluetooth_driver.hpp"
 #include "process_message_operation/i_process_message_sender.hpp"
@@ -19,7 +19,7 @@ BluetoothTask::~BluetoothTask() {
     if (logger_) logger_->info("BluetoothTask destroyed");
 }
 
-void BluetoothTask::run(const IMessage& msg) {
+void BluetoothTask::run(const IThreadMessage& msg) {
     if (msg.type() != MessageType::BluetoothScanRequest) return;
 
     state_ = State::Scanning;
@@ -40,7 +40,7 @@ void BluetoothTask::run(const IMessage& msg) {
     state_ = State::WaitRequest;
 }
 
-bool BluetoothTask::send_message(const IMessage& msg) {
+bool BluetoothTask::send_message(const IThreadMessage& msg) {
     run(msg);
     return true;
 }

--- a/src/core/buzzer_task.cpp
+++ b/src/core/buzzer_task.cpp
@@ -13,12 +13,12 @@ BuzzerTask::BuzzerTask(std::shared_ptr<IBuzzerDriver> driver,
     if (logger_) logger_->info("BuzzerTask created");
 }
 
-bool BuzzerTask::send_message(const IMessage& msg) {
+bool BuzzerTask::send_message(const IThreadMessage& msg) {
     onMessage(msg);
     return true;
 }
 
-void BuzzerTask::onMessage(const IMessage& msg) {
+void BuzzerTask::onMessage(const IThreadMessage& msg) {
     switch (msg.type()) {
     case MessageType::BuzzerOn:
         if (state_ == State::WaitStart) startBuzzer();

--- a/src/core/human_task.cpp
+++ b/src/core/human_task.cpp
@@ -22,7 +22,7 @@ HumanTask::~HumanTask() {
     if (logger_) logger_->info("HumanTask destroyed");
 }
 
-void HumanTask::run(const IMessage& msg) {
+void HumanTask::run(const IThreadMessage& msg) {
     switch (msg.type()) {
     case MessageType::HumanDetected:
         if (state_ == State::Detecting) {

--- a/src/core/main_task.cpp
+++ b/src/core/main_task.cpp
@@ -23,7 +23,7 @@ MainTask::~MainTask() {
     if (logger_) logger_->info("MainTask destroyed");
 }
 
-void MainTask::run(const IMessage& msg) {
+void MainTask::run(const IThreadMessage& msg) {
     auto type = msg.type();
     switch (state_) {
     case State::WaitHumanDetect:

--- a/tests/core/test_app.cpp
+++ b/tests/core/test_app.cpp
@@ -11,25 +11,25 @@ namespace device_reminder {
 // 各プロセスのモッククラス
 class MockMainTask : public device_reminder::IMainTask {
 public:
-    MOCK_METHOD(void, run, (const device_reminder::IMessage& msg), (override));
+    MOCK_METHOD(void, run, (const device_reminder::IThreadMessage& msg), (override));
 };
 
 class MockHumanTask : public device_reminder::IHumanTask {
 public:
-    MOCK_METHOD(void, run, (const device_reminder::IMessage& msg), (override));
+    MOCK_METHOD(void, run, (const device_reminder::IThreadMessage& msg), (override));
 };
 
 class MockBluetoothTask : public device_reminder::IBluetoothTask {
 public:
-    MOCK_METHOD(void, run, (const device_reminder::IMessage& msg), (override));
-    MOCK_METHOD(bool, send_message, (const device_reminder::IMessage& msg), (override));
+    MOCK_METHOD(void, run, (const device_reminder::IThreadMessage& msg), (override));
+    MOCK_METHOD(bool, send_message, (const device_reminder::IThreadMessage& msg), (override));
 };
 
 
 class MockBuzzerTask : public device_reminder::IBuzzerTask {
 public:
     MOCK_METHOD(void, run, (), (override));
-    MOCK_METHOD(bool, send_message, (const device_reminder::IMessage& msg), (override));
+    MOCK_METHOD(bool, send_message, (const device_reminder::IThreadMessage& msg), (override));
 };
 
 // ロガーのモック

--- a/tests/core/test_bluetooth_task.cpp
+++ b/tests/core/test_bluetooth_task.cpp
@@ -4,7 +4,7 @@
 #include "bluetooth_task/bluetooth_task.hpp"
 #include "infra/bluetooth_driver/i_bluetooth_driver.hpp"
 #include "process_message_operation/i_process_message_sender.hpp"
-#include "process_message_operation/process_message.hpp"
+#include "thread_message_operation/thread_message.hpp"
 
 using namespace std;
 
@@ -46,7 +46,7 @@ TEST(BluetoothTaskTest, SendsDetectedTrueWhenDeviceFound) {
 
     driver->names = {"phone"};
 
-    task.run(ProcessMessage{MessageType::BluetoothScanRequest});
+    task.run(ThreadMessage{MessageType::BluetoothScanRequest});
 
     ASSERT_EQ(sender->sent.size(), 1u);
     EXPECT_EQ(sender->sent[0].payload_, true);
@@ -60,7 +60,7 @@ TEST(BluetoothTaskTest, SendsDetectedFalseWhenNoDevice) {
     BluetoothTask task(driver, sender, logger);
 
     driver->names = {};
-    task.run(ProcessMessage{MessageType::BluetoothScanRequest});
+    task.run(ThreadMessage{MessageType::BluetoothScanRequest});
 
     ASSERT_EQ(sender->sent.size(), 1u);
     EXPECT_EQ(sender->sent[0].payload_, false);
@@ -74,7 +74,7 @@ TEST(BluetoothTaskTest, DriverErrorLogsAndSendsFalse) {
     BluetoothTask task(driver, sender, logger);
 
     driver->fail = true;
-    task.run(ProcessMessage{MessageType::BluetoothScanRequest});
+    task.run(ThreadMessage{MessageType::BluetoothScanRequest});
 
     ASSERT_EQ(sender->sent.size(), 1u);
     EXPECT_EQ(sender->sent[0].payload_, false);

--- a/tests/core/test_buzzer_task.cpp
+++ b/tests/core/test_buzzer_task.cpp
@@ -2,7 +2,7 @@
 #include <gmock/gmock.h>
 
 #include "buzzer_task/buzzer_task.hpp"
-#include "process_message_operation/process_message.hpp"
+#include "thread_message_operation/thread_message.hpp"
 
 using ::testing::StrictMock;
 using ::testing::NiceMock;
@@ -37,12 +37,12 @@ TEST(BuzzerTaskTest, StartAndTimeoutStopsBuzzer) {
 
     EXPECT_CALL(*driver, start());
     EXPECT_CALL(*timer, start(4000, testing::Field(&ProcessMessage::type_, MessageType::Timeout)));
-    task.send_message(ProcessMessage{MessageType::BuzzerOn});
+    task.send_message(ThreadMessage{MessageType::BuzzerOn});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 
     EXPECT_CALL(*driver, stop());
     EXPECT_CALL(*timer, stop()).Times(0);
-    task.send_message(ProcessMessage{MessageType::Timeout});
+    task.send_message(ThreadMessage{MessageType::Timeout});
     EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
 }
 
@@ -55,11 +55,11 @@ TEST(BuzzerTaskTest, ManualStopCancelsTimer) {
 
     EXPECT_CALL(*driver, start());
     EXPECT_CALL(*timer, start(4000, testing::Field(&ProcessMessage::type_, MessageType::Timeout)));
-    task.send_message(ProcessMessage{MessageType::BuzzerOn});
+    task.send_message(ThreadMessage{MessageType::BuzzerOn});
 
     EXPECT_CALL(*driver, stop());
     EXPECT_CALL(*timer, stop());
-    task.send_message(ProcessMessage{MessageType::BuzzerOff});
+    task.send_message(ThreadMessage{MessageType::BuzzerOff});
     EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
 }
 
@@ -72,10 +72,10 @@ TEST(BuzzerTaskTest, IgnoreDuplicateStart) {
 
     EXPECT_CALL(*driver, start());
     EXPECT_CALL(*timer, start(4000, testing::Field(&ProcessMessage::type_, MessageType::Timeout)));
-    task.send_message(ProcessMessage{MessageType::BuzzerOn});
+    task.send_message(ThreadMessage{MessageType::BuzzerOn});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 
-    task.send_message(ProcessMessage{MessageType::BuzzerOn});
+    task.send_message(ThreadMessage{MessageType::BuzzerOn});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 }
 

--- a/tests/core/test_human_task.cpp
+++ b/tests/core/test_human_task.cpp
@@ -2,7 +2,7 @@
 #include <gmock/gmock.h>
 
 #include "human_task/human_task.hpp"
-#include "process_message_operation/process_message.hpp"
+#include "thread_message_operation/thread_message.hpp"
 #include "process_message_operation/i_process_message_sender.hpp"
 
 using ::testing::StrictMock;
@@ -43,7 +43,7 @@ TEST(HumanTaskTest, StopRequestTransitionsToStopped) {
     HumanTask task(pir, timer, sender, logger);
     EXPECT_EQ(task.state(), HumanTask::State::Detecting);
 
-    task.run(ProcessMessage{MessageType::HumanDetectStop});
+    task.run(ThreadMessage{MessageType::HumanDetectStop});
     EXPECT_EQ(task.state(), HumanTask::State::Stopped);
 }
 
@@ -54,10 +54,10 @@ TEST(HumanTaskTest, StartRequestStartsCooldown) {
     auto logger = std::make_shared<NiceMock<MockLogger>>();
 
     HumanTask task(pir, timer, sender, logger);
-    task.run(ProcessMessage{MessageType::HumanDetectStop});
+    task.run(ThreadMessage{MessageType::HumanDetectStop});
 
     EXPECT_CALL(*timer, start(testing::_, testing::_));
-    task.run(ProcessMessage{MessageType::HumanDetectStart});
+    task.run(ThreadMessage{MessageType::HumanDetectStart});
     EXPECT_EQ(task.state(), HumanTask::State::Cooldown);
 }
 
@@ -68,11 +68,11 @@ TEST(HumanTaskTest, TimeoutReturnsToDetecting) {
     auto logger = std::make_shared<NiceMock<MockLogger>>();
 
     HumanTask task(pir, timer, sender, logger);
-    task.run(ProcessMessage{MessageType::HumanDetectStop});
-    task.run(ProcessMessage{MessageType::HumanDetectStart});
+    task.run(ThreadMessage{MessageType::HumanDetectStop});
+    task.run(ThreadMessage{MessageType::HumanDetectStart});
     EXPECT_EQ(task.state(), HumanTask::State::Cooldown);
 
-    task.run(ProcessMessage{MessageType::Timeout});
+    task.run(ThreadMessage{MessageType::Timeout});
     EXPECT_EQ(task.state(), HumanTask::State::Detecting);
 }
 
@@ -85,7 +85,7 @@ TEST(HumanTaskTest, HumanDetectedSendsMessage) {
     HumanTask task(pir, timer, sender, logger);
 
     EXPECT_CALL(*sender, enqueue(testing::Field(&ProcessMessage::type_, MessageType::HumanDetected)));
-    task.run(ProcessMessage{MessageType::HumanDetected});
+    task.run(ThreadMessage{MessageType::HumanDetected});
 }
 
 } // namespace device_reminder


### PR DESCRIPTION
## Summary
- delete obsolete infra/i_message.hpp and message_type.hpp
- introduce i_process_message*, i_thread_message* headers with MessageType
- adapt core tasks and tests to new interfaces

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687f0593fddc8328bd5a59f311f42e9c