### PR TITLE
Add ThreadDispatcher module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(test_infra_extra
     tests/infra/test_thread_message_sender.cpp
     tests/infra/test_thread_message_receiver.cpp
     tests/infra/test_thread_receiver.cpp
+    tests/infra/test_thread_dispatcher.cpp
     tests/infra/test_pir_driver.cpp
     tests/infra/test_timer_service.cpp
     tests/infra/test_worker_dispatcher.cpp
@@ -67,6 +68,7 @@ add_executable(test_infra_extra
     src/infra/thread_message_operation/thread_message_sender.cpp
     src/infra/thread_message_operation/thread_message_receiver.cpp
     src/infra/thread_message_operation/thread_receiver.cpp
+    src/infra/thread_message_operation/thread_dispatcher.cpp
     src/infra/process_message_operation/process_message_queue.cpp
     src/infra/process_message_operation/process_message_receiver.cpp
     src/infra/process_message_operation/process_message_sender.cpp

--- a/include/infra/process_operation/thread_operation/thread_dispatcher/i_thread_dispatcher.hpp
+++ b/include/infra/process_operation/thread_operation/thread_dispatcher/i_thread_dispatcher.hpp
@@ -2,9 +2,11 @@
 #include "infra/thread_message_operation/thread_message.hpp"
 
 namespace device_reminder {
+
 class IThreadDispatcher {
 public:
     virtual ~IThreadDispatcher() = default;
     virtual void dispatch(const ThreadMessage& msg) = 0;
 };
-}
+
+} // namespace device_reminder

--- a/include/infra/process_operation/thread_operation/thread_dispatcher/thread_dispatcher.hpp
+++ b/include/infra/process_operation/thread_operation/thread_dispatcher/thread_dispatcher.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include "infra/process_operation/thread_operation/thread_dispatcher/i_thread_dispatcher.hpp"
+#include "infra/logger/i_logger.hpp"
+#include <unordered_map>
+#include <functional>
+#include <memory>
+
+namespace device_reminder {
+
+class ThreadDispatcher : public IThreadDispatcher {
+public:
+    using HandlerMap = std::unordered_map<MessageType, std::function<void(const ThreadMessage&)>>;
+
+    ThreadDispatcher(std::shared_ptr<ILogger> logger,
+                     HandlerMap handler_map);
+
+    void dispatch(const ThreadMessage& msg) override;
+
+private:
+    std::shared_ptr<ILogger> logger_;
+    HandlerMap handler_map_;
+};
+
+} // namespace device_reminder

--- a/include/infra/process_operation/worker_dispatcher/worker_dispatcher.hpp
+++ b/include/infra/process_operation/worker_dispatcher/worker_dispatcher.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "worker_dispatcher/i_worker_dispatcher.hpp"
+#include "infra/process_operation/worker_dispatcher/i_worker_dispatcher.hpp"
 #include "infra/logger/i_logger.hpp"
 #include <memory>
 

--- a/include/infra/thread_message_operation/i_thread_dispatcher.hpp
+++ b/include/infra/thread_message_operation/i_thread_dispatcher.hpp
@@ -1,2 +1,2 @@
 #pragma once
-#include "infra/process_operation/thread_operation/thread_receiver/i_thread_dispatcher.hpp"
+#include "infra/process_operation/thread_operation/thread_dispatcher/i_thread_dispatcher.hpp"

--- a/include/infra/thread_message_operation/thread_dispatcher.hpp
+++ b/include/infra/thread_message_operation/thread_dispatcher.hpp
@@ -1,0 +1,2 @@
+#pragma once
+#include "infra/process_operation/thread_operation/thread_dispatcher/thread_dispatcher.hpp"

--- a/include/infra/worker_dispatcher/worker_dispatcher.hpp
+++ b/include/infra/worker_dispatcher/worker_dispatcher.hpp
@@ -1,0 +1,2 @@
+#pragma once
+#include "infra/process_operation/worker_dispatcher/worker_dispatcher.hpp"

--- a/include/thread_message_operation/i_thread_dispatcher.hpp
+++ b/include/thread_message_operation/i_thread_dispatcher.hpp
@@ -1,2 +1,2 @@
 #pragma once
-#include "infra/process_operation/thread_operation/thread_receiver/i_thread_dispatcher.hpp"
+#include "infra/process_operation/thread_operation/thread_dispatcher/i_thread_dispatcher.hpp"

--- a/include/thread_message_operation/thread_dispatcher.hpp
+++ b/include/thread_message_operation/thread_dispatcher.hpp
@@ -1,0 +1,2 @@
+#pragma once
+#include "infra/process_operation/thread_operation/thread_dispatcher/thread_dispatcher.hpp"

--- a/src/infra/thread_message_operation/thread_dispatcher.cpp
+++ b/src/infra/thread_message_operation/thread_dispatcher.cpp
@@ -1,0 +1,23 @@
+#include "thread_message_operation/thread_dispatcher.hpp"
+#include "infra/logger/i_logger.hpp"
+#include <utility>
+
+namespace device_reminder {
+
+ThreadDispatcher::ThreadDispatcher(std::shared_ptr<ILogger> logger,
+                                   HandlerMap handler_map)
+    : logger_(std::move(logger)),
+      handler_map_(std::move(handler_map)) {
+    if (logger_) logger_->info("ThreadDispatcher created");
+}
+
+void ThreadDispatcher::dispatch(const ThreadMessage& msg) {
+    auto it = handler_map_.find(msg.type());
+    if (it != handler_map_.end()) {
+        it->second(msg);
+    } else {
+        if (logger_) logger_->info("Unhandled thread message");
+    }
+}
+
+} // namespace device_reminder

--- a/tests/infra/test_thread_dispatcher.cpp
+++ b/tests/infra/test_thread_dispatcher.cpp
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+#include "thread_message_operation/thread_dispatcher.hpp"
+
+using namespace device_reminder;
+
+TEST(ThreadDispatcherTest, CallsRegisteredHandler) {
+    bool called = false;
+    ThreadDispatcher::HandlerMap map{
+        {MessageType::BuzzerOn, [&](const ThreadMessage&){ called = true; }}
+    };
+    ThreadDispatcher disp(nullptr, map);
+    disp.dispatch(ThreadMessage{MessageType::BuzzerOn, true});
+    EXPECT_TRUE(called);
+}
+
+TEST(ThreadDispatcherTest, IgnoresUnknownMessage) {
+    bool called = false;
+    ThreadDispatcher::HandlerMap map{
+        {MessageType::BuzzerOn, [&](const ThreadMessage&){ called = true; }}
+    };
+    ThreadDispatcher disp(nullptr, map);
+    disp.dispatch(ThreadMessage{MessageType::BuzzerOff, false});
+    EXPECT_FALSE(called);
+}


### PR DESCRIPTION
## Summary
- add ThreadDispatcher interface and implementation
- provide adapter headers for thread_dispatcher
- implement basic dispatch behavior and tests
- fix worker_dispatcher include and provide alias header

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6884c3f015408328a56f01a6150ee83b