### PR TITLE
Add generic ThreadQueue implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(test_infra_extra
     tests/infra/test_thread_message_sender.cpp
     tests/infra/test_thread_message_receiver.cpp
     tests/infra/test_thread_receiver.cpp
+    tests/infra/test_thread_queue.cpp
     tests/infra/test_thread_dispatcher.cpp
     tests/infra/test_pir_driver.cpp
     tests/infra/test_timer_service.cpp

--- a/include/infra/thread_message_operation/i_thread_queue.hpp
+++ b/include/infra/thread_message_operation/i_thread_queue.hpp
@@ -1,5 +1,0 @@
-#pragma once
-#include "infra/process_operation/thread_operation/message_queue/i_message_queue.hpp"
-namespace device_reminder {
-using IThreadQueue = IThreadMessageQueue;
-}

--- a/include/infra/thread_operation/thread_queue/i_thread_queue.hpp
+++ b/include/infra/thread_operation/thread_queue/i_thread_queue.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include <optional>
+#include <cstddef>
+
+namespace device_reminder {
+
+template <typename T>
+class IThreadQueue {
+public:
+    virtual ~IThreadQueue() = default;
+
+    virtual void push(const T& item) = 0;
+    virtual std::optional<T> pop(int timeout_ms = -1) = 0;
+    virtual bool empty() const = 0;
+    virtual size_t size() const = 0;
+    virtual void clear() = 0;
+};
+
+} // namespace device_reminder

--- a/include/infra/thread_operation/thread_queue/thread_queue.hpp
+++ b/include/infra/thread_operation/thread_queue/thread_queue.hpp
@@ -1,0 +1,59 @@
+#pragma once
+#include "infra/thread_operation/thread_queue/i_thread_queue.hpp"
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+#include <chrono>
+
+namespace device_reminder {
+
+template <typename T>
+class ThreadQueue : public IThreadQueue<T> {
+public:
+    ThreadQueue() = default;
+
+    void push(const T& item) override {
+        {
+            std::lock_guard<std::mutex> lock(mtx_);
+            q_.push(item);
+        }
+        cv_.notify_one();
+    }
+
+    std::optional<T> pop(int timeout_ms = -1) override {
+        std::unique_lock<std::mutex> lock(mtx_);
+        if (timeout_ms < 0) {
+            cv_.wait(lock, [this]{ return !q_.empty(); });
+        } else {
+            if (!cv_.wait_for(lock, std::chrono::milliseconds(timeout_ms), [this]{ return !q_.empty(); })) {
+                return std::nullopt;
+            }
+        }
+        T val = q_.front();
+        q_.pop();
+        return val;
+    }
+
+    bool empty() const override {
+        std::lock_guard<std::mutex> lock(mtx_);
+        return q_.empty();
+    }
+
+    size_t size() const override {
+        std::lock_guard<std::mutex> lock(mtx_);
+        return q_.size();
+    }
+
+    void clear() override {
+        std::lock_guard<std::mutex> lock(mtx_);
+        std::queue<T> empty_q;
+        std::swap(q_, empty_q);
+    }
+
+private:
+    mutable std::mutex mtx_;
+    std::condition_variable cv_;
+    std::queue<T> q_;
+};
+
+} // namespace device_reminder

--- a/include/thread_message_operation/i_thread_queue.hpp
+++ b/include/thread_message_operation/i_thread_queue.hpp
@@ -1,5 +1,0 @@
-#pragma once
-#include "infra/process_operation/thread_operation/message_queue/i_message_queue.hpp"
-namespace device_reminder {
-using IThreadQueue = IThreadMessageQueue;
-}

--- a/include/thread_operation/thread_queue/i_thread_queue.hpp
+++ b/include/thread_operation/thread_queue/i_thread_queue.hpp
@@ -1,0 +1,2 @@
+#pragma once
+#include "infra/thread_operation/thread_queue/i_thread_queue.hpp"

--- a/include/thread_operation/thread_queue/thread_queue.hpp
+++ b/include/thread_operation/thread_queue/thread_queue.hpp
@@ -1,0 +1,2 @@
+#pragma once
+#include "infra/thread_operation/thread_queue/thread_queue.hpp"

--- a/tests/infra/test_thread_queue.cpp
+++ b/tests/infra/test_thread_queue.cpp
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+#include "thread_operation/thread_queue/thread_queue.hpp"
+
+using namespace device_reminder;
+
+TEST(ThreadQueueTest, PushPopWorks) {
+    ThreadQueue<int> q;
+    q.push(42);
+    auto res = q.pop();
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res.value(), 42);
+}
+
+TEST(ThreadQueueTest, PopTimeoutReturnsNullopt) {
+    ThreadQueue<int> q;
+    auto res = q.pop(10);
+    EXPECT_FALSE(res.has_value());
+}
+
+TEST(ThreadQueueTest, SizeAndClearWork) {
+    ThreadQueue<int> q;
+    EXPECT_TRUE(q.empty());
+    q.push(1);
+    q.push(2);
+    EXPECT_EQ(q.size(), 2u);
+    EXPECT_FALSE(q.empty());
+    q.clear();
+    EXPECT_TRUE(q.empty());
+    EXPECT_EQ(q.size(), 0u);
+}


### PR DESCRIPTION
## Summary
- implement generic `ThreadQueue` and `IThreadQueue` with timeout-based pop, clear, size and empty APIs
- remove unused alias headers that conflicted with new interface
- add unit tests for `ThreadQueue`
- include new tests in CMake build

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6885ad7914cc83288507fab495f1c763