### PR TITLE
Implement new ThreadMessage spec

### DIFF
--- a/include/infra/process_operation/process_message/i_process_message.hpp
+++ b/include/infra/process_operation/process_message/i_process_message.hpp
@@ -6,7 +6,7 @@ namespace device_reminder {
 class IProcessMessage {
 public:
     virtual ~IProcessMessage() = default;
-    virtual MessageType type() const noexcept = 0;
+    virtual ThreadMessageType type() const noexcept = 0;
     virtual bool payload() const noexcept = 0;
 };
 

--- a/include/infra/process_operation/process_message/process_message.hpp
+++ b/include/infra/process_operation/process_message/process_message.hpp
@@ -5,14 +5,14 @@
 namespace device_reminder {
 
 struct ProcessMessage final : public IProcessMessage {
-    constexpr ProcessMessage(MessageType t = MessageType::None,
+    constexpr ProcessMessage(ThreadMessageType t = ThreadMessageType::None,
                              bool p = false) noexcept
         : type_{t}, payload_{p} {}
 
-    MessageType type() const noexcept override { return type_; }
+    ThreadMessageType type() const noexcept override { return type_; }
     bool payload() const noexcept override { return payload_; }
 
-    MessageType type_;
+    ThreadMessageType type_;
     bool payload_;
 } __attribute__((packed));
 

--- a/include/infra/process_operation/thread_operation/thread_dispatcher/thread_dispatcher.hpp
+++ b/include/infra/process_operation/thread_operation/thread_dispatcher/thread_dispatcher.hpp
@@ -9,7 +9,7 @@ namespace device_reminder {
 
 class ThreadDispatcher : public IThreadDispatcher {
 public:
-    using HandlerMap = std::unordered_map<MessageType, std::function<void(const ThreadMessage&)>>;
+    using HandlerMap = std::unordered_map<ThreadMessageType, std::function<void(const ThreadMessage&)>>;
 
     ThreadDispatcher(std::shared_ptr<ILogger> logger,
                      HandlerMap handler_map);

--- a/include/infra/process_operation/thread_operation/thread_message/i_thread_message.hpp
+++ b/include/infra/process_operation/thread_operation/thread_message/i_thread_message.hpp
@@ -1,28 +1,30 @@
 #pragma once
 #include <cstddef>
+#include <memory>
+#include <string>
 
 namespace device_reminder {
 
-enum class MessageType {
+enum class ThreadMessageType {
     None,
     Timeout,
     HumanDetected,
     HumanDetectStart,
     HumanDetectStop,
-    StartScan,
-    DeviceScanResult,
     BluetoothEvent,
-    BuzzerOn,
-    BuzzerOff,
-    BluetoothScanRequest,
-    DevicePresenceResponse
+    StartBuzzer,
+    StopBuzzer,
+    BluetoothScanRequested,
+    BluetoothScanResponse
 };
 
 class IThreadMessage {
 public:
     virtual ~IThreadMessage() = default;
-    virtual MessageType type() const noexcept = 0;
+    virtual ThreadMessageType type() const noexcept = 0;
     virtual bool payload() const noexcept = 0;
+    virtual std::shared_ptr<IThreadMessage> clone() const = 0;
+    virtual std::string to_string() const = 0;
 };
 
 } // namespace device_reminder

--- a/include/infra/process_operation/thread_operation/thread_message/thread_message.hpp
+++ b/include/infra/process_operation/thread_operation/thread_message/thread_message.hpp
@@ -1,18 +1,27 @@
 #pragma once
 #include "infra/thread_message_operation/i_thread_message.hpp"
 #include <cstddef>
+#include <memory>
+#include <string>
 
 namespace device_reminder {
 
 struct ThreadMessage final : public IThreadMessage {
-    constexpr ThreadMessage(MessageType t = MessageType::None,
+    constexpr ThreadMessage(ThreadMessageType t = ThreadMessageType::None,
                             bool p = false) noexcept
         : type_{t}, payload_{p} {}
 
-    MessageType type() const noexcept override { return type_; }
+    ThreadMessageType type() const noexcept override { return type_; }
     bool payload() const noexcept override { return payload_; }
+    std::shared_ptr<IThreadMessage> clone() const override {
+        return std::make_shared<ThreadMessage>(*this);
+    }
+    std::string to_string() const override {
+        return "ThreadMessage{" + std::to_string(static_cast<int>(type_)) +
+               "," + (payload_ ? "true" : "false") + "}";
+    }
 
-    MessageType type_;
+    ThreadMessageType type_;
     bool payload_;
 } __attribute__((packed));
 

--- a/src/core/bluetooth_task.cpp
+++ b/src/core/bluetooth_task.cpp
@@ -20,7 +20,7 @@ BluetoothTask::~BluetoothTask() {
 }
 
 void BluetoothTask::run(const IThreadMessage& msg) {
-    if (msg.type() != MessageType::BluetoothScanRequest) return;
+    if (msg.type() != ThreadMessageType::BluetoothScanRequested) return;
 
     state_ = State::Scanning;
     bool detected = false;
@@ -34,7 +34,7 @@ void BluetoothTask::run(const IThreadMessage& msg) {
     }
 
     if (sender_) {
-        sender_->enqueue(ProcessMessage{MessageType::DevicePresenceResponse, detected});
+        sender_->enqueue(ProcessMessage{ThreadMessageType::BluetoothScanResponse, detected});
     }
 
     state_ = State::WaitRequest;

--- a/src/core/buzzer_task.cpp
+++ b/src/core/buzzer_task.cpp
@@ -20,13 +20,13 @@ bool BuzzerTask::send_message(const IThreadMessage& msg) {
 
 void BuzzerTask::onMessage(const IThreadMessage& msg) {
     switch (msg.type()) {
-    case MessageType::BuzzerOn:
+    case ThreadMessageType::StartBuzzer:
         if (state_ == State::WaitStart) startBuzzer();
         break;
-    case MessageType::BuzzerOff:
+    case ThreadMessageType::StopBuzzer:
         if (state_ == State::Buzzing) stopBuzzer(true);
         break;
-    case MessageType::Timeout:
+    case ThreadMessageType::Timeout:
         if (state_ == State::Buzzing) stopBuzzer(false);
         break;
     default:
@@ -36,7 +36,7 @@ void BuzzerTask::onMessage(const IThreadMessage& msg) {
 
 void BuzzerTask::startBuzzer() {
     if (driver_) driver_->start();
-    if (timer_) timer_->start(kBuzzDurationMs, ProcessMessage{MessageType::Timeout});
+    if (timer_) timer_->start(kBuzzDurationMs, ProcessMessage{ThreadMessageType::Timeout});
     state_ = State::Buzzing;
 }
 

--- a/src/core/human_task.cpp
+++ b/src/core/human_task.cpp
@@ -24,26 +24,26 @@ HumanTask::~HumanTask() {
 
 void HumanTask::run(const IThreadMessage& msg) {
     switch (msg.type()) {
-    case MessageType::HumanDetected:
+    case ThreadMessageType::HumanDetected:
         if (state_ == State::Detecting) {
-            if (sender_) sender_->enqueue(ProcessMessage{MessageType::HumanDetected, true});
+            if (sender_) sender_->enqueue(ProcessMessage{ThreadMessageType::HumanDetected, true});
             if (logger_) logger_->info("Human detected");
         }
         break;
-    case MessageType::HumanDetectStop:
+    case ThreadMessageType::HumanDetectStop:
         if (state_ == State::Detecting) {
             state_ = State::Stopped;
             if (logger_) logger_->info("Detection stopped");
         }
         break;
-    case MessageType::HumanDetectStart:
+    case ThreadMessageType::HumanDetectStart:
         if (state_ == State::Stopped) {
             state_ = State::Cooldown;
-            if (timer_) timer_->start(5000, ProcessMessage{MessageType::Timeout});
+            if (timer_) timer_->start(5000, ProcessMessage{ThreadMessageType::Timeout});
             if (logger_) logger_->info("Detection cooldown");
         }
         break;
-    case MessageType::Timeout:
+    case ThreadMessageType::Timeout:
         if (state_ == State::Cooldown) {
             state_ = State::Detecting;
             if (logger_) logger_->info("Cooldown end; detecting");

--- a/tests/core/test_bluetooth_task.cpp
+++ b/tests/core/test_bluetooth_task.cpp
@@ -46,7 +46,7 @@ TEST(BluetoothTaskTest, SendsDetectedTrueWhenDeviceFound) {
 
     driver->names = {"phone"};
 
-    task.run(ThreadMessage{MessageType::BluetoothScanRequest});
+    task.run(ThreadMessage{ThreadMessageType::BluetoothScanRequested});
 
     ASSERT_EQ(sender->sent.size(), 1u);
     EXPECT_EQ(sender->sent[0].payload_, true);
@@ -60,7 +60,7 @@ TEST(BluetoothTaskTest, SendsDetectedFalseWhenNoDevice) {
     BluetoothTask task(driver, sender, logger);
 
     driver->names = {};
-    task.run(ThreadMessage{MessageType::BluetoothScanRequest});
+    task.run(ThreadMessage{ThreadMessageType::BluetoothScanRequested});
 
     ASSERT_EQ(sender->sent.size(), 1u);
     EXPECT_EQ(sender->sent[0].payload_, false);
@@ -74,7 +74,7 @@ TEST(BluetoothTaskTest, DriverErrorLogsAndSendsFalse) {
     BluetoothTask task(driver, sender, logger);
 
     driver->fail = true;
-    task.run(ThreadMessage{MessageType::BluetoothScanRequest});
+    task.run(ThreadMessage{ThreadMessageType::BluetoothScanRequested});
 
     ASSERT_EQ(sender->sent.size(), 1u);
     EXPECT_EQ(sender->sent[0].payload_, false);

--- a/tests/core/test_buzzer_task.cpp
+++ b/tests/core/test_buzzer_task.cpp
@@ -36,13 +36,13 @@ TEST(BuzzerTaskTest, StartAndTimeoutStopsBuzzer) {
     BuzzerTask task(driver, timer, logger);
 
     EXPECT_CALL(*driver, start());
-    EXPECT_CALL(*timer, start(4000, testing::Field(&ProcessMessage::type_, MessageType::Timeout)));
-    task.send_message(ThreadMessage{MessageType::BuzzerOn});
+    EXPECT_CALL(*timer, start(4000, testing::Field(&ProcessMessage::type_, ThreadMessageType::Timeout)));
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 
     EXPECT_CALL(*driver, stop());
     EXPECT_CALL(*timer, stop()).Times(0);
-    task.send_message(ThreadMessage{MessageType::Timeout});
+    task.send_message(ThreadMessage{ThreadMessageType::Timeout});
     EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
 }
 
@@ -54,12 +54,12 @@ TEST(BuzzerTaskTest, ManualStopCancelsTimer) {
     BuzzerTask task(driver, timer, logger);
 
     EXPECT_CALL(*driver, start());
-    EXPECT_CALL(*timer, start(4000, testing::Field(&ProcessMessage::type_, MessageType::Timeout)));
-    task.send_message(ThreadMessage{MessageType::BuzzerOn});
+    EXPECT_CALL(*timer, start(4000, testing::Field(&ProcessMessage::type_, ThreadMessageType::Timeout)));
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer});
 
     EXPECT_CALL(*driver, stop());
     EXPECT_CALL(*timer, stop());
-    task.send_message(ThreadMessage{MessageType::BuzzerOff});
+    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzer});
     EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
 }
 
@@ -71,11 +71,11 @@ TEST(BuzzerTaskTest, IgnoreDuplicateStart) {
     BuzzerTask task(driver, timer, logger);
 
     EXPECT_CALL(*driver, start());
-    EXPECT_CALL(*timer, start(4000, testing::Field(&ProcessMessage::type_, MessageType::Timeout)));
-    task.send_message(ThreadMessage{MessageType::BuzzerOn});
+    EXPECT_CALL(*timer, start(4000, testing::Field(&ProcessMessage::type_, ThreadMessageType::Timeout)));
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 
-    task.send_message(ThreadMessage{MessageType::BuzzerOn});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 }
 

--- a/tests/core/test_human_task.cpp
+++ b/tests/core/test_human_task.cpp
@@ -43,7 +43,7 @@ TEST(HumanTaskTest, StopRequestTransitionsToStopped) {
     HumanTask task(pir, timer, sender, logger);
     EXPECT_EQ(task.state(), HumanTask::State::Detecting);
 
-    task.run(ThreadMessage{MessageType::HumanDetectStop});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetectStop});
     EXPECT_EQ(task.state(), HumanTask::State::Stopped);
 }
 
@@ -54,10 +54,10 @@ TEST(HumanTaskTest, StartRequestStartsCooldown) {
     auto logger = std::make_shared<NiceMock<MockLogger>>();
 
     HumanTask task(pir, timer, sender, logger);
-    task.run(ThreadMessage{MessageType::HumanDetectStop});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetectStop});
 
     EXPECT_CALL(*timer, start(testing::_, testing::_));
-    task.run(ThreadMessage{MessageType::HumanDetectStart});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetectStart});
     EXPECT_EQ(task.state(), HumanTask::State::Cooldown);
 }
 
@@ -68,11 +68,11 @@ TEST(HumanTaskTest, TimeoutReturnsToDetecting) {
     auto logger = std::make_shared<NiceMock<MockLogger>>();
 
     HumanTask task(pir, timer, sender, logger);
-    task.run(ThreadMessage{MessageType::HumanDetectStop});
-    task.run(ThreadMessage{MessageType::HumanDetectStart});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetectStop});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetectStart});
     EXPECT_EQ(task.state(), HumanTask::State::Cooldown);
 
-    task.run(ThreadMessage{MessageType::Timeout});
+    task.run(ThreadMessage{ThreadMessageType::Timeout});
     EXPECT_EQ(task.state(), HumanTask::State::Detecting);
 }
 
@@ -84,8 +84,8 @@ TEST(HumanTaskTest, HumanDetectedSendsMessage) {
 
     HumanTask task(pir, timer, sender, logger);
 
-    EXPECT_CALL(*sender, enqueue(testing::Field(&ProcessMessage::type_, MessageType::HumanDetected)));
-    task.run(ThreadMessage{MessageType::HumanDetected});
+    EXPECT_CALL(*sender, enqueue(testing::Field(&ProcessMessage::type_, ThreadMessageType::HumanDetected)));
+    task.run(ThreadMessage{ThreadMessageType::HumanDetected});
 }
 
 } // namespace device_reminder

--- a/tests/core/test_main_task.cpp
+++ b/tests/core/test_main_task.cpp
@@ -40,9 +40,9 @@ TEST(MainTaskTest, HumanDetectedStartsScanAndTimer) {
     MainTask task(det_timer, cd_timer, human_sender, bt_sender, buzzer_sender, logger);
 
     EXPECT_CALL(*det_timer, start(4000, testing::Field(&ProcessMessage::payload_, true)));
-    EXPECT_CALL(*bt_sender, enqueue(testing::Field(&ProcessMessage::type_, MessageType::StartScan)));
+    EXPECT_CALL(*bt_sender, enqueue(testing::Field(&ProcessMessage::type_, ThreadMessageType::BluetoothScanRequested)));
 
-    task.run(ThreadMessage{MessageType::HumanDetected});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetected});
     EXPECT_EQ(task.state(), MainTask::State::WaitDeviceResponse);
 }
 
@@ -56,14 +56,14 @@ TEST(MainTaskTest, DeviceDetectedStopsTimerAndNotifies) {
 
     MainTask task(det_timer, cd_timer, human_sender, bt_sender, buzzer_sender, logger);
 
-    task.run(ThreadMessage{MessageType::HumanDetected});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetected});
 
-    EXPECT_CALL(*human_sender, enqueue(testing::Field(&ProcessMessage::type_, MessageType::HumanDetectStart)));
-    EXPECT_CALL(*buzzer_sender, enqueue(testing::Field(&ProcessMessage::type_, MessageType::BuzzerOff)));
+    EXPECT_CALL(*human_sender, enqueue(testing::Field(&ProcessMessage::type_, ThreadMessageType::HumanDetectStart)));
+    EXPECT_CALL(*buzzer_sender, enqueue(testing::Field(&ProcessMessage::type_, ThreadMessageType::StopBuzzer)));
     EXPECT_CALL(*det_timer, active()).WillOnce(testing::Return(true));
     EXPECT_CALL(*det_timer, stop());
 
-    task.run(ThreadMessage{MessageType::DeviceScanResult, true});
+    task.run(ThreadMessage{ThreadMessageType::BluetoothScanResponse, true});
     EXPECT_EQ(task.state(), MainTask::State::WaitHumanDetect);
 }
 
@@ -76,10 +76,10 @@ TEST(MainTaskTest, DeviceNotDetectedStartsCooldown) {
     auto logger = std::make_shared<NiceMock<MockLogger>>();
 
     MainTask task(det_timer, cd_timer, human_sender, bt_sender, buzzer_sender, logger);
-    task.run(ThreadMessage{MessageType::HumanDetected});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetected});
 
     EXPECT_CALL(*cd_timer, start(1000, testing::Field(&ProcessMessage::payload_, false)));
-    task.run(ThreadMessage{MessageType::DeviceScanResult, false});
+    task.run(ThreadMessage{ThreadMessageType::BluetoothScanResponse, false});
     EXPECT_EQ(task.state(), MainTask::State::ScanCooldown);
 }
 
@@ -92,11 +92,11 @@ TEST(MainTaskTest, CooldownTimeoutRestartsScan) {
     auto logger = std::make_shared<NiceMock<MockLogger>>();
 
     MainTask task(det_timer, cd_timer, human_sender, bt_sender, buzzer_sender, logger);
-    task.run(ThreadMessage{MessageType::HumanDetected});
-    task.run(ThreadMessage{MessageType::DeviceScanResult, false});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetected});
+    task.run(ThreadMessage{ThreadMessageType::BluetoothScanResponse, false});
 
-    EXPECT_CALL(*bt_sender, enqueue(testing::Field(&ProcessMessage::type_, MessageType::StartScan)));
-    task.run(ThreadMessage{MessageType::Timeout, false});
+    EXPECT_CALL(*bt_sender, enqueue(testing::Field(&ProcessMessage::type_, ThreadMessageType::BluetoothScanRequested)));
+    task.run(ThreadMessage{ThreadMessageType::Timeout, false});
     EXPECT_EQ(task.state(), MainTask::State::WaitDeviceResponse);
 }
 
@@ -109,9 +109,9 @@ TEST(MainTaskTest, DetectionTimeoutReturnsToWaitHuman) {
     auto logger = std::make_shared<NiceMock<MockLogger>>();
 
     MainTask task(det_timer, cd_timer, human_sender, bt_sender, buzzer_sender, logger);
-    task.run(ThreadMessage{MessageType::HumanDetected});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetected});
 
-    task.run(ThreadMessage{MessageType::Timeout, true});
+    task.run(ThreadMessage{ThreadMessageType::Timeout, true});
     EXPECT_EQ(task.state(), MainTask::State::WaitHumanDetect);
 }
 

--- a/tests/infra/test_local_message_queue.cpp
+++ b/tests/infra/test_local_message_queue.cpp
@@ -16,7 +16,7 @@ public:
 
 TEST(ThreadMessageQueueTest, PushPopWorks) {
     ThreadMessageQueue q;
-    ThreadMessage m{MessageType::BuzzerOn, true};
+    ThreadMessage m{ThreadMessageType::StartBuzzer, true};
     EXPECT_TRUE(q.push(m));
     auto res = q.pop();
     ASSERT_TRUE(res.has_value());

--- a/tests/infra/test_message_queue.cpp
+++ b/tests/infra/test_message_queue.cpp
@@ -12,7 +12,7 @@ static std::string unique_queue_name(const std::string& base) {
 TEST(MessageQueueTest, PushAndPop) {
     std::string name = unique_queue_name("mq_test_");
     ProcessMessageQueue mq(name, true);
-    ProcessMessage msg{MessageType::BuzzerOn, true};
+    ProcessMessage msg{ThreadMessageType::StartBuzzer, true};
     EXPECT_TRUE(mq.push(msg));
     auto res = mq.pop();
     ASSERT_TRUE(res.has_value());

--- a/tests/infra/test_message_receiver.cpp
+++ b/tests/infra/test_message_receiver.cpp
@@ -30,7 +30,7 @@ TEST(MessageReceiverTest, ReceivesAndPushes) {
 
     mqd_t mq = mq_open(name.c_str(), O_WRONLY);
     ASSERT_NE(mq, static_cast<mqd_t>(-1));
-    ProcessMessage msg{MessageType::BuzzerOn, true};
+    ProcessMessage msg{ThreadMessageType::StartBuzzer, true};
     mq_send(mq, reinterpret_cast<const char*>(&msg), PROCESS_MESSAGE_SIZE, 0);
     mq_close(mq);
 

--- a/tests/infra/test_message_sender.cpp
+++ b/tests/infra/test_message_sender.cpp
@@ -14,7 +14,7 @@ TEST(MessageSenderTest, EnqueueSendsMessage) {
     std::string name = unique_name("sender_test_");
     ProcessMessageSender sender(name, 5);
 
-    ProcessMessage msg{MessageType::BuzzerOn, true};
+    ProcessMessage msg{ThreadMessageType::StartBuzzer, true};
     ASSERT_TRUE(sender.enqueue(msg));
 
     mqd_t mq = mq_open(name.c_str(), O_RDONLY);

--- a/tests/infra/test_thread_dispatcher.cpp
+++ b/tests/infra/test_thread_dispatcher.cpp
@@ -6,19 +6,19 @@ using namespace device_reminder;
 TEST(ThreadDispatcherTest, CallsRegisteredHandler) {
     bool called = false;
     ThreadDispatcher::HandlerMap map{
-        {MessageType::BuzzerOn, [&](const ThreadMessage&){ called = true; }}
+        {ThreadMessageType::StartBuzzer, [&](const ThreadMessage&){ called = true; }}
     };
     ThreadDispatcher disp(nullptr, map);
-    disp.dispatch(ThreadMessage{MessageType::BuzzerOn, true});
+    disp.dispatch(ThreadMessage{ThreadMessageType::StartBuzzer, true});
     EXPECT_TRUE(called);
 }
 
 TEST(ThreadDispatcherTest, IgnoresUnknownMessage) {
     bool called = false;
     ThreadDispatcher::HandlerMap map{
-        {MessageType::BuzzerOn, [&](const ThreadMessage&){ called = true; }}
+        {ThreadMessageType::StartBuzzer, [&](const ThreadMessage&){ called = true; }}
     };
     ThreadDispatcher disp(nullptr, map);
-    disp.dispatch(ThreadMessage{MessageType::BuzzerOff, false});
+    disp.dispatch(ThreadMessage{ThreadMessageType::StopBuzzer, false});
     EXPECT_FALSE(called);
 }

--- a/tests/infra/test_thread_message_receiver.cpp
+++ b/tests/infra/test_thread_message_receiver.cpp
@@ -22,7 +22,7 @@ TEST(ThreadMessageReceiverTest, ReceivesMessages) {
 
     std::thread th{std::ref(receiver)};
 
-    ThreadMessage msg{MessageType::BuzzerOn, true};
+    ThreadMessage msg{ThreadMessageType::StartBuzzer, true};
     queue->push(msg);
 
     {

--- a/tests/infra/test_thread_message_sender.cpp
+++ b/tests/infra/test_thread_message_sender.cpp
@@ -8,7 +8,7 @@ TEST(ThreadMessageSenderTest, EnqueueAddsToQueue) {
     auto queue = std::make_shared<ThreadMessageQueue>();
     ThreadMessageSender sender(queue);
 
-    ThreadMessage msg{MessageType::BuzzerOn, true};
+    ThreadMessage msg{ThreadMessageType::StartBuzzer, true};
     ASSERT_TRUE(sender.enqueue(msg));
 
     auto res = queue->pop();

--- a/tests/infra/test_thread_receiver.cpp
+++ b/tests/infra/test_thread_receiver.cpp
@@ -31,7 +31,7 @@ TEST(ThreadReceiverTest, DispatchesMessages) {
 
     std::thread th{[&]{ receiver.run(); }};
 
-    ThreadMessage msg{MessageType::BuzzerOn, true};
+    ThreadMessage msg{ThreadMessageType::StartBuzzer, true};
     queue->push(msg);
 
     {

--- a/tests/infra/test_timer_service.cpp
+++ b/tests/infra/test_timer_service.cpp
@@ -28,8 +28,8 @@ TEST(TimerServiceTest, SendsTimeoutMessage) {
     auto sender = std::make_shared<StrictMock<MockSender>>();
     NiceMock<MockLogger> logger;
     TimerService timer(sender, std::shared_ptr<ILogger>(&logger, [](ILogger*){}));
-    ProcessMessage m{MessageType::Timeout, false};
-    EXPECT_CALL(*sender, enqueue(testing::Field(&ProcessMessage::type_, MessageType::Timeout))).Times(1);
+    ProcessMessage m{ThreadMessageType::Timeout, false};
+    EXPECT_CALL(*sender, enqueue(testing::Field(&ProcessMessage::type_, ThreadMessageType::Timeout))).Times(1);
     timer.start(10, m);
     std::this_thread::sleep_for(std::chrono::milliseconds(30));
     while (timer.active()) {

--- a/tests/infra/test_worker_dispatcher.cpp
+++ b/tests/infra/test_worker_dispatcher.cpp
@@ -22,7 +22,7 @@ TEST(WorkerDispatcherTest, DispatchesMessage) {
     WorkerDispatcher disp(queue, handler);
     disp.start();
 
-    ThreadMessage msg{MessageType::BuzzerOn, true};
+    ThreadMessage msg{ThreadMessageType::StartBuzzer, true};
     queue->push(msg);
 
     {


### PR DESCRIPTION
## Summary
- refactor thread message types to `ThreadMessageType`
- implement `clone` and `to_string` helpers
- rename buzzer and bluetooth message enum names
- update core modules and tests to use new types

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6885afbb6d748328a4dd552538840dd6