### PR TITLE
Implement ThreadSender module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(test_infra_extra
     tests/infra/test_thread_message_sender.cpp
     tests/infra/test_thread_message_receiver.cpp
     tests/infra/test_thread_receiver.cpp
+    tests/infra/test_thread_sender.cpp
     tests/infra/test_thread_queue.cpp
     tests/infra/test_thread_dispatcher.cpp
     tests/infra/test_pir_driver.cpp
@@ -73,6 +74,7 @@ add_executable(test_infra_extra
     src/infra/process_message_operation/process_message_queue.cpp
     src/infra/process_message_operation/process_message_receiver.cpp
     src/infra/process_message_operation/process_message_sender.cpp
+    src/infra/thread_operation/thread_sender.cpp
     src/infra/pir_driver.cpp
     src/infra/timer_service.cpp
     src/infra/buzzer_driver.cpp

--- a/include/infra/thread_operation/i_thread_sender.hpp
+++ b/include/infra/thread_operation/i_thread_sender.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include <memory>
+
+namespace device_reminder {
+
+class IThreadMessage; // forward
+template <typename T>
+class IThreadQueue;
+
+class IThreadSender {
+public:
+    virtual ~IThreadSender() = default;
+    virtual void send() = 0;
+};
+
+} // namespace device_reminder

--- a/include/infra/thread_operation/thread_sender.hpp
+++ b/include/infra/thread_operation/thread_sender.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include "infra/thread_operation/i_thread_sender.hpp"
+#include "infra/thread_operation/thread_queue/i_thread_queue.hpp"
+#include "infra/process_operation/thread_operation/thread_message/i_thread_message.hpp"
+#include "infra/logger/i_logger.hpp"
+#include <memory>
+
+namespace device_reminder {
+
+class ThreadSender : public IThreadSender {
+public:
+    ThreadSender(std::shared_ptr<ILogger> logger,
+                 std::shared_ptr<IThreadQueue<std::shared_ptr<IThreadMessage>>> queue,
+                 std::shared_ptr<IThreadMessage> message);
+    void send() override;
+
+private:
+    std::shared_ptr<ILogger> logger_;
+    std::shared_ptr<IThreadQueue<std::shared_ptr<IThreadMessage>>> queue_;
+    std::shared_ptr<IThreadMessage> message_;
+};
+
+} // namespace device_reminder

--- a/src/infra/thread_operation/thread_sender.cpp
+++ b/src/infra/thread_operation/thread_sender.cpp
@@ -1,0 +1,24 @@
+#include "thread_operation/thread_sender.hpp"
+#include "infra/logger/i_logger.hpp"
+#include <utility>
+
+namespace device_reminder {
+
+ThreadSender::ThreadSender(std::shared_ptr<ILogger> logger,
+                           std::shared_ptr<IThreadQueue<std::shared_ptr<IThreadMessage>>> queue,
+                           std::shared_ptr<IThreadMessage> message)
+    : logger_(std::move(logger)),
+      queue_(std::move(queue)),
+      message_(std::move(message)) {
+    if (logger_) logger_->info("ThreadSender created");
+}
+
+void ThreadSender::send() {
+    if (!queue_ || !message_) {
+        if (logger_) logger_->error("ThreadSender send failed: null queue or message");
+        return;
+    }
+    queue_->push(message_);
+}
+
+} // namespace device_reminder

--- a/tests/infra/test_thread_sender.cpp
+++ b/tests/infra/test_thread_sender.cpp
@@ -1,0 +1,33 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "thread_operation/thread_sender.hpp"
+#include "thread_operation/thread_queue/thread_queue.hpp"
+#include "process_operation/thread_operation/thread_message/thread_message.hpp"
+#include "infra/logger/i_logger.hpp"
+
+using namespace device_reminder;
+using ::testing::NiceMock;
+
+namespace {
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+};
+} // namespace
+
+TEST(ThreadSenderTest, SendPushesMessageToQueue) {
+    auto queue = std::make_shared<ThreadQueue<std::shared_ptr<IThreadMessage>>>();
+    NiceMock<MockLogger> logger;
+    auto message = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzer, true);
+
+    ThreadSender sender(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), queue, message);
+
+    sender.send();
+
+    auto res = queue->pop();
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ((*res)->type(), message->type());
+    EXPECT_EQ((*res)->payload(), message->payload());
+}


### PR DESCRIPTION
## Summary
- add `IThreadSender` interface
- implement `ThreadSender` class and test
- enable building new test and source in CMake

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6885c13921088328957d037ca564ebbe