### PR TITLE
Add warn log level and move implementation to cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(test_app
     tests/core/test_buzzer_task.cpp
     tests/core/test_bluetooth_task.cpp
     tests/infra/test_logger.cpp
+    src/infra/logger.cpp
     src/core/app.cpp
     src/core/main_task.cpp
     src/core/main_task_handler.cpp
@@ -66,6 +67,7 @@ add_executable(test_infra_extra
     tests/infra/test_buzzer_driver.cpp
     tests/infra/test_bluetooth_driver.cpp
     tests/infra/test_file_loader.cpp
+    src/infra/logger.cpp
     src/infra/thread_message_operation/thread_message_queue.cpp
     src/infra/thread_message_operation/thread_message_sender.cpp
     src/infra/thread_message_operation/thread_message_receiver.cpp

--- a/include/infra/logger/i_logger.hpp
+++ b/include/infra/logger/i_logger.hpp
@@ -10,6 +10,7 @@ public:
 
     virtual void info(const std::string& msg) = 0;
     virtual void error(const std::string& msg) = 0;
+    virtual void warn(const std::string& msg) = 0;
 };
 
 } // namespace device_reminder

--- a/include/infra/logger/logger.hpp
+++ b/include/infra/logger/logger.hpp
@@ -8,16 +8,11 @@ namespace device_reminder {
 
 class Logger : public ILogger {
 public:
-    explicit Logger(std::shared_ptr<spdlog::logger> logger)
-        : logger_(std::move(logger)) {}
+    explicit Logger(std::shared_ptr<spdlog::logger> logger);
 
-    void info(const std::string& msg) override {
-        logger_->info(msg);
-    }
-
-    void error(const std::string& msg) override {
-        logger_->error(msg);
-    }
+    void info(const std::string& msg) override;
+    void error(const std::string& msg) override;
+    void warn(const std::string& msg) override;
 
 private:
     std::shared_ptr<spdlog::logger> logger_;

--- a/src/infra/logger.cpp
+++ b/src/infra/logger.cpp
@@ -1,0 +1,20 @@
+#include "infra/logger/logger.hpp"
+
+namespace device_reminder {
+
+Logger::Logger(std::shared_ptr<spdlog::logger> logger)
+    : logger_(std::move(logger)) {}
+
+void Logger::info(const std::string& msg) {
+    logger_->info(msg);
+}
+
+void Logger::error(const std::string& msg) {
+    logger_->error(msg);
+}
+
+void Logger::warn(const std::string& msg) {
+    logger_->warn(msg);
+}
+
+} // namespace device_reminder


### PR DESCRIPTION
## Summary
- add `warn` API to `ILogger`
- declare `Logger` methods in header
- implement `Logger` methods in new `logger.cpp`
- compile new `logger.cpp` in CMake

## Testing
- `cmake -S . -B build` *(fails: infra/thread_message_operation/i_thread_message.hpp not found)*
- `cmake --build build` *(fails: fatal error: infra/thread_message_operation/i_thread_message.hpp: No such file or directory)*
- `ctest --test-dir build` *(fails to find executables)*

------
https://chatgpt.com/codex/tasks/task_e_6885d58502108328808976a673fcb425