### PR TITLE
Implement thread dispatcher interface

### DIFF
--- a/include/infra/thread_operation/thread_dispatcher/i_thread_dispatcher.hpp
+++ b/include/infra/thread_operation/thread_dispatcher/i_thread_dispatcher.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include <memory>
+
+namespace device_reminder {
+
+class IThreadMessage;
+
+class IThreadDispatcher {
+public:
+    virtual ~IThreadDispatcher() = default;
+    virtual void dispatch(std::shared_ptr<IThreadMessage> msg) = 0;
+};
+
+} // namespace device_reminder

--- a/include/infra/thread_operation/thread_dispatcher/thread_dispatcher.hpp
+++ b/include/infra/thread_operation/thread_dispatcher/thread_dispatcher.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include "infra/thread_operation/thread_dispatcher/i_thread_dispatcher.hpp"
+#include "infra/logger/i_logger.hpp"
+#include <unordered_map>
+#include <functional>
+#include <memory>
+
+namespace device_reminder {
+
+class ThreadDispatcher : public IThreadDispatcher {
+public:
+    using HandlerMap = std::unordered_map<std::shared_ptr<IThreadMessage>,
+                                          std::function<void(std::shared_ptr<IThreadMessage>)>>;
+
+    ThreadDispatcher(std::shared_ptr<ILogger> logger, HandlerMap handler_map);
+
+    void dispatch(std::shared_ptr<IThreadMessage> msg) override;
+
+private:
+    std::shared_ptr<ILogger> logger_;
+    HandlerMap handler_map_;
+};
+
+} // namespace device_reminder

--- a/src/infra/thread_message_operation/thread_dispatcher.cpp
+++ b/src/infra/thread_message_operation/thread_dispatcher.cpp
@@ -1,4 +1,4 @@
-#include "thread_message_operation/thread_dispatcher.hpp"
+#include "infra/thread_operation/thread_dispatcher/thread_dispatcher.hpp"
 #include "infra/logger/i_logger.hpp"
 #include <utility>
 
@@ -11,10 +11,10 @@ ThreadDispatcher::ThreadDispatcher(std::shared_ptr<ILogger> logger,
     if (logger_) logger_->info("ThreadDispatcher created");
 }
 
-void ThreadDispatcher::dispatch(const ThreadMessage& msg) {
-    auto it = handler_map_.find(msg.type());
+void ThreadDispatcher::dispatch(std::shared_ptr<IThreadMessage> msg) {
+    auto it = handler_map_.find(msg);
     if (it != handler_map_.end()) {
-        it->second(msg);
+        it->second(std::move(msg));
     } else {
         if (logger_) logger_->info("Unhandled thread message");
     }

--- a/src/infra/thread_message_operation/thread_receiver.cpp
+++ b/src/infra/thread_message_operation/thread_receiver.cpp
@@ -1,6 +1,7 @@
-#include "thread_message_operation/thread_receiver.hpp"
+#include "infra/thread_operation/thread_receiver/thread_receiver.hpp"
 #include "infra/logger/i_logger.hpp"
 #include <utility>
+#include <memory>
 
 namespace device_reminder {
 
@@ -25,7 +26,7 @@ void ThreadReceiver::run() {
         ThreadMessage msg{};
         if (!queue_->pop(msg)) break;
         if (!running_) break;
-        if (dispatcher_) dispatcher_->dispatch(msg);
+        if (dispatcher_) dispatcher_->dispatch(std::make_shared<ThreadMessage>(msg));
     }
     if (logger_) logger_->info("ThreadReceiver loop end");
 }


### PR DESCRIPTION
## Summary
- flesh out `IThreadDispatcher` interface
- implement `ThreadDispatcher` using shared pointer messages
- adjust dispatcher implementation and receiver usage

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: cannot find `infra/thread_message_operation/i_thread_message.hpp`)*

------
https://chatgpt.com/codex/tasks/task_e_6885cc00d6dc8328a439b1d81c999cec