### PR TITLE
Implement ThreadReceiver headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ add_executable(test_infra_extra
     src/infra/thread_message_operation/thread_message_queue.cpp
     src/infra/thread_message_operation/thread_message_sender.cpp
     src/infra/thread_message_operation/thread_message_receiver.cpp
-    src/infra/thread_message_operation/thread_receiver.cpp
+    src/infra/thread_operation/thread_receiver.cpp
     src/infra/thread_message_operation/thread_dispatcher.cpp
     src/infra/process_message_operation/process_message_queue.cpp
     src/infra/process_message_operation/process_message_receiver.cpp

--- a/include/infra/thread_operation/thread_receiver/i_thread_receiver.hpp
+++ b/include/infra/thread_operation/thread_receiver/i_thread_receiver.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace device_reminder {
+
+class IThreadReceiver {
+public:
+    virtual ~IThreadReceiver() = default;
+    virtual void run() = 0;
+    virtual void stop() = 0;
+};
+
+} // namespace device_reminder

--- a/include/infra/thread_operation/thread_receiver/thread_receiver.hpp
+++ b/include/infra/thread_operation/thread_receiver/thread_receiver.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include "infra/thread_operation/thread_receiver/i_thread_receiver.hpp"
+#include "infra/thread_operation/thread_queue/i_thread_queue.hpp"
+#include "infra/thread_operation/thread_message/thread_message.hpp"
+#include "infra/thread_operation/thread_dispatcher/i_thread_dispatcher.hpp"
+#include "infra/logger/i_logger.hpp"
+#include <memory>
+#include <atomic>
+
+namespace device_reminder {
+
+class ThreadReceiver : public IThreadReceiver {
+public:
+    ThreadReceiver(std::shared_ptr<IThreadQueue<ThreadMessage>> queue,
+                   std::shared_ptr<IThreadDispatcher> dispatcher,
+                   std::shared_ptr<ILogger> logger = nullptr);
+    void run() override;
+    void stop() override;
+
+private:
+    std::shared_ptr<IThreadQueue<ThreadMessage>> queue_;
+    std::shared_ptr<IThreadDispatcher> dispatcher_;
+    std::atomic<bool> running_{true};
+    std::shared_ptr<ILogger> logger_;
+};
+
+} // namespace device_reminder

--- a/tests/infra/test_thread_receiver.cpp
+++ b/tests/infra/test_thread_receiver.cpp
@@ -2,9 +2,9 @@
 #include <thread>
 #include <mutex>
 #include <condition_variable>
-#include "thread_message_operation/thread_receiver.hpp"
-#include "thread_message_operation/thread_message_queue.hpp"
-#include "thread_message_operation/i_thread_dispatcher.hpp"
+#include "infra/thread_operation/thread_receiver/thread_receiver.hpp"
+#include "infra/thread_operation/thread_queue/thread_queue.hpp"
+#include "infra/thread_operation/thread_dispatcher/i_thread_dispatcher.hpp"
 
 using namespace device_reminder;
 
@@ -25,7 +25,7 @@ public:
 } // namespace
 
 TEST(ThreadReceiverTest, DispatchesMessages) {
-    auto queue = std::make_shared<ThreadMessageQueue>();
+    auto queue = std::make_shared<ThreadQueue<ThreadMessage>>();
     auto dispatcher = std::make_shared<MockDispatcher>();
     ThreadReceiver receiver(queue, dispatcher);
 


### PR DESCRIPTION
## Summary
- implement `IThreadReceiver` interface and `ThreadReceiver` class headers
- update implementation to use `IThreadQueue`
- move source into `thread_operation`
- adjust build configuration and tests

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: missing headers)*
- `ctest --output-on-failure` *(fails: test executables not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885cc3e1b708328a523eb6c7c390ec3