### PR TITLE
Update TimerService spec

### DIFF
--- a/include/infra/timer_service/i_timer_service.hpp
+++ b/include/infra/timer_service/i_timer_service.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <cstdint>
-#include "infra/process_operation/process_message/process_message.hpp"
+#include <memory>
 
 namespace device_reminder {
 
@@ -9,9 +8,8 @@ class ITimerService {
 public:
     virtual ~ITimerService() = default;
 
-    virtual void start(uint32_t ms, const ProcessMessage& timeout_msg) = 0;
+    virtual void start() = 0;
     virtual void stop() = 0;
-    virtual bool active() const noexcept = 0;
 };
 
 } // namespace device_reminder

--- a/include/infra/timer_service/timer_service.hpp
+++ b/include/infra/timer_service/timer_service.hpp
@@ -1,2 +1,33 @@
 #pragma once
-#include "infra/process_operation/thread_operation/timer_service/timer_service.hpp"
+
+#include "infra/timer_service/i_timer_service.hpp"
+#include "infra/logger/i_logger.hpp"
+#include "infra/thread_operation/i_thread_sender.hpp"
+
+#include <thread>
+#include <atomic>
+#include <memory>
+
+namespace device_reminder {
+
+class TimerService : public ITimerService {
+public:
+    TimerService(std::shared_ptr<ILogger> logger,
+                 int duration_ms,
+                 std::shared_ptr<IThreadSender> sender);
+    ~TimerService() override;
+
+    void start() override;
+    void stop() override;
+
+private:
+    void worker();
+
+    std::shared_ptr<ILogger> logger_;
+    int duration_ms_{0};
+    std::shared_ptr<IThreadSender> sender_;
+    std::thread thread_;
+    std::atomic_bool running_{false};
+};
+
+} // namespace device_reminder

--- a/src/infra/timer_service/timer_service.cpp
+++ b/src/infra/timer_service/timer_service.cpp
@@ -1,36 +1,17 @@
 #include "timer_service/timer_service.hpp"
 #include "infra/logger/i_logger.hpp"
 
-#include <sys/timerfd.h>
-#include <poll.h>
-#include <unistd.h>
-#include <cerrno>
-#include <cstring>
+#include <chrono>
+#include <thread>
 
 namespace device_reminder {
-namespace {
 
-/// ワンショット timerfd を生成
-int create_one_shot_timer_fd(uint32_t ms) {
-    int fd = ::timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
-    if (fd == -1) return -1;
-
-    itimerspec spec{};
-    spec.it_value.tv_sec  = ms / 1000;
-    spec.it_value.tv_nsec = (ms % 1000) * 1'000'000ULL;  // ns へ変換
-
-    if (::timerfd_settime(fd, 0, &spec, nullptr) == -1) {
-        ::close(fd);
-        return -1;
-    }
-    return fd;
-}
-
-} // unnamed namespace
-
-TimerService::TimerService(std::shared_ptr<IProcessMessageSender> sender,
-                           std::shared_ptr<ILogger> logger)
-    : sender_(std::move(sender)), logger_(std::move(logger)) {
+TimerService::TimerService(std::shared_ptr<ILogger> logger,
+                           int duration_ms,
+                           std::shared_ptr<IThreadSender> sender)
+    : logger_(std::move(logger)),
+      duration_ms_(duration_ms),
+      sender_(std::move(sender)) {
     if (logger_) logger_->info("TimerService created");
 }
 
@@ -39,49 +20,26 @@ TimerService::~TimerService() {
     if (logger_) logger_->info("TimerService destroyed");
 }
 
-void TimerService::start(uint32_t ms, const ProcessMessage& timeout_msg) {
-    stop();                         // 既存タイマーを殺してから再起動
+void TimerService::start() {
+    stop();
     running_ = true;
-    active_  = true;
-    thread_  = std::thread(&TimerService::worker, this, ms, timeout_msg);
+    thread_ = std::thread(&TimerService::worker, this);
     if (logger_) logger_->info("TimerService started");
 }
 
 void TimerService::stop() {
     running_ = false;
     if (thread_.joinable()) thread_.join();
-    active_ = false;
     if (logger_) logger_->info("TimerService stopped");
 }
 
-void TimerService::worker(uint32_t ms, ProcessMessage timeout_msg) {
-    int tfd = create_one_shot_timer_fd(ms);
-    if (tfd == -1) {
-        // 生成失敗時は即座にメッセージ送出して終了
-        if (sender_) sender_->enqueue(timeout_msg);
-        if (logger_) logger_->error("failed to create timerfd");
-        active_ = false;
-        return;
+void TimerService::worker() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(duration_ms_));
+    if (running_ && sender_) {
+        sender_->send();
+        if (logger_) logger_->info("TimerService timeout");
     }
-
-    pollfd pfd{ tfd, POLLIN, 0 };
-    while (running_) {
-        int ret = ::poll(&pfd, 1, -1);         // 無限待機
-        if (ret == -1) {
-            if (errno == EINTR) continue;      // シグナル割り込みは再待機
-            break;
-        }
-        if (pfd.revents & POLLIN) {
-            uint64_t expirations;
-            ::read(tfd, &expirations, sizeof(expirations));  // カウンタ読み捨て
-            if (sender_) sender_->enqueue(timeout_msg);      // タイムアウト通知
-            if (logger_) logger_->info("TimerService timeout");
-            break;
-        }
-    }
-    ::close(tfd);
-    active_ = false;
-    if (logger_) logger_->info("TimerService worker exit");
+    running_ = false;
 }
 
 } // namespace device_reminder


### PR DESCRIPTION
## Summary
- adjust `ITimerService` API to `start()/stop()` form
- refactor `TimerService` to accept duration and sender in constructor and send via `IThreadSender`

## Testing
- `cmake -S . -B build` *(fails: Cannot find source file)*

------
https://chatgpt.com/codex/tasks/task_e_6886adf6dd848328be4be9e137fb070b