### PR TITLE
Implement clone and to_string for ProcessMessage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ add_executable(test_infra_extra
     src/infra/thread_message_operation/thread_message_receiver.cpp
     src/infra/thread_message_operation/thread_receiver.cpp
     src/infra/thread_message_operation/thread_dispatcher.cpp
+    src/infra/process_operation/process_message.cpp
     src/infra/process_message_operation/process_message_queue.cpp
     src/infra/process_message_operation/process_message_receiver.cpp
     src/infra/process_message_operation/process_message_sender.cpp

--- a/include/infra/process_operation/process_message/i_process_message.hpp
+++ b/include/infra/process_operation/process_message/i_process_message.hpp
@@ -8,6 +8,8 @@ public:
     virtual ~IProcessMessage() = default;
     virtual ThreadMessageType type() const noexcept = 0;
     virtual bool payload() const noexcept = 0;
+    virtual std::shared_ptr<IProcessMessage> clone() const = 0;
+    virtual std::string to_string() const = 0;
 };
 
 } // namespace device_reminder

--- a/include/infra/process_operation/process_message/process_message.hpp
+++ b/include/infra/process_operation/process_message/process_message.hpp
@@ -1,16 +1,21 @@
 #pragma once
 #include "infra/process_message_operation/i_process_message.hpp"
 #include <cstddef>
+#include <memory>
+#include <string>
 
 namespace device_reminder {
 
-struct ProcessMessage final : public IProcessMessage {
+class ProcessMessage final : public IProcessMessage {
+public:
     constexpr ProcessMessage(ThreadMessageType t = ThreadMessageType::None,
                              bool p = false) noexcept
         : type_{t}, payload_{p} {}
 
     ThreadMessageType type() const noexcept override { return type_; }
     bool payload() const noexcept override { return payload_; }
+    std::shared_ptr<IProcessMessage> clone() const override;
+    std::string to_string() const override;
 
     ThreadMessageType type_;
     bool payload_;

--- a/src/infra/process_operation/process_message.cpp
+++ b/src/infra/process_operation/process_message.cpp
@@ -1,0 +1,17 @@
+#include "process_message_operation/process_message.hpp"
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace device_reminder {
+
+std::shared_ptr<IProcessMessage> ProcessMessage::clone() const {
+    return std::make_shared<ProcessMessage>(*this);
+}
+
+std::string ProcessMessage::to_string() const {
+    return "ProcessMessage{" + std::to_string(static_cast<int>(type_)) + "," +
+           (payload_ ? "true" : "false") + "}";
+}
+
+} // namespace device_reminder


### PR DESCRIPTION
## Summary
- add `clone` と `to_string` を `IProcessMessage` インタフェースへ追加
- `ProcessMessage` に新しいメソッドの宣言を追加
- `ProcessMessage` 実装ファイルを新規作成
- テスト用ビルド対象へ `process_message.cpp` を追加

## Testing
- `cmake` 実行はソースパスの不整合により失敗

------
https://chatgpt.com/codex/tasks/task_e_6886af4f5e748328b0f96e9390e04628