### PR TITLE
Add string loader

### DIFF
--- a/include/infra/file_loader/file_loader.hpp
+++ b/include/infra/file_loader/file_loader.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/io/i_file_loader.hpp"
+#include "infra/file_loader/i_file_loader.hpp"
 #include "infra/logger/i_logger.hpp"
 
 #include <string>
@@ -14,6 +14,7 @@ public:
     FileLoader(const std::string& file_path, std::shared_ptr<ILogger> logger = nullptr);
 
     int load_int(const std::string& key) const override;
+    std::string load_string(const std::string& key) const override;
 
 private:
     void parse_file(const std::string& file_path);

--- a/include/infra/file_loader/i_file_loader.hpp
+++ b/include/infra/file_loader/i_file_loader.hpp
@@ -9,6 +9,7 @@ public:
     virtual ~IFileLoader() = default;
 
     virtual int load_int(const std::string& key) const = 0;
+    virtual std::string load_string(const std::string& key) const = 0;
 };
 
 } // namespace device_reminder

--- a/include/infra/process_operation/process_base/process_base.hpp
+++ b/include/infra/process_operation/process_base/process_base.hpp
@@ -6,7 +6,7 @@
 #include "infra/process_operation/process_receiver/i_process_receiver.hpp"
 #include "infra/process_operation/process_sender/i_process_sender.hpp"
 #include "infra/process_operation/process_dispatcher/i_process_dispatcher.hpp"
-#include "infra/io/i_file_loader.hpp"
+#include "infra/file_loader/i_file_loader.hpp"
 
 #include <atomic>
 #include <memory>

--- a/src/infra/io/file_loader.cpp
+++ b/src/infra/io/file_loader.cpp
@@ -1,4 +1,4 @@
-#include "infra/io/file_loader.hpp"
+#include "infra/file_loader/file_loader.hpp"
 
 #include <fstream>
 #include <sstream>
@@ -24,6 +24,15 @@ int FileLoader::load_int(const std::string& key) const
         if (logger_) logger_->error(std::string("invalid int value for ") + key);
         throw;
     }
+}
+
+std::string FileLoader::load_string(const std::string& key) const
+{
+    auto it = values_.find(key);
+    if (it == values_.end()) {
+        throw std::runtime_error("key not found: " + key);
+    }
+    return it->second;
 }
 
 void FileLoader::parse_file(const std::string& file_path)

--- a/src/infra/process_operation/process_base.cpp
+++ b/src/infra/process_operation/process_base.cpp
@@ -7,7 +7,7 @@
 #include "infra/process_operation/process_receiver/i_process_receiver.hpp"
 #include "infra/process_operation/process_sender/i_process_sender.hpp"
 #include "infra/process_operation/process_dispatcher/i_process_dispatcher.hpp"
-#include "infra/io/i_file_loader.hpp"
+#include "infra/file_loader/i_file_loader.hpp"
 #include "infra/logger/i_logger.hpp"
 
 std::atomic<bool> ProcessBase::g_stop_flag{false};

--- a/tests/infra/test_file_loader.cpp
+++ b/tests/infra/test_file_loader.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include "infra/io/file_loader.hpp"
+#include "infra/file_loader/file_loader.hpp"
 #include "infra/logger/logger.hpp"
 #include <spdlog/logger.h>
 #include <spdlog/sinks/basic_file_sink.h>
@@ -25,4 +25,13 @@ TEST(FileLoaderTest, LoadIntThrowsIfMissing) {
 
     FileLoader loader("/tmp/test_settings.txt");
     EXPECT_THROW(loader.load_int("b"), std::runtime_error);
+}
+
+TEST(FileLoaderTest, LoadStringSuccess) {
+    std::ofstream ofs("/tmp/test_settings.txt");
+    ofs << "device_name=reminder\n";
+    ofs.close();
+
+    FileLoader loader("/tmp/test_settings.txt");
+    EXPECT_EQ(loader.load_string("device_name"), "reminder");
 }


### PR DESCRIPTION
## Summary
- add load_string interface for FileLoader
- implement load_string and update includes
- test FileLoader string retrieval

## Testing
- `g++ -std=c++17 tests/infra/test_file_loader.cpp src/infra/io/file_loader.cpp src/infra/logger/logger.cpp -Iinclude -Iexternal/spdlog/include -lgtest -lgmock -pthread -o /tmp/test_file_loader` *(fails: fatal error: gtest/gtest.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688979d743d483288beb2156e8cdf1fc