### PR TITLE
Update ThreadMessage interface

### DIFF
--- a/include/infra/thread_operation/thread_message/i_thread_message.hpp
+++ b/include/infra/thread_operation/thread_message/i_thread_message.hpp
@@ -17,6 +17,7 @@ class IThreadMessage {
 public:
     virtual ~IThreadMessage() = default;
     virtual ThreadMessageType type() const noexcept = 0;
+    virtual std::vector<std::string> payload() const = 0;
     virtual std::shared_ptr<IThreadMessage> clone() const = 0;
     virtual std::string to_string() const = 0;
 };

--- a/include/infra/thread_operation/thread_message/thread_message.hpp
+++ b/include/infra/thread_operation/thread_message/thread_message.hpp
@@ -2,27 +2,34 @@
 #include "infra/thread_operation/thread_message/i_thread_message.hpp"
 #include <memory>
 #include <string>
+#include <vector>
 #include <utility>
 
 namespace device_reminder {
 
 class ThreadMessage final : public IThreadMessage {
 public:
-    ThreadMessage(ThreadMessageType type, std::string payload)
-        : type_{type}, payload_{std::move(payload)} {}
+    ThreadMessage(ThreadMessageType type, const std::vector<std::string>& payload)
+        : type_{type}, payload_{payload} {}
 
     ThreadMessageType type() const noexcept override { return type_; }
-    const std::string& payload() const noexcept { return payload_; }
+    std::vector<std::string> payload() const override { return payload_; }
     std::shared_ptr<IThreadMessage> clone() const override {
         return std::make_shared<ThreadMessage>(*this);
     }
     std::string to_string() const override {
-        return "ThreadMessage{" + std::to_string(static_cast<int>(type_)) + "," + payload_ + "}";
+        std::string result = "ThreadMessage{" + std::to_string(static_cast<int>(type_)) + ",[";
+        for (std::size_t i = 0; i < payload_.size(); ++i) {
+            result += payload_[i];
+            if (i + 1 < payload_.size()) result += ",";
+        }
+        result += "]}";
+        return result;
     }
 
 private:
     ThreadMessageType type_;
-    std::string payload_;
+    std::vector<std::string> payload_;
 };
 
 } // namespace device_reminder


### PR DESCRIPTION
## Summary
- add payload() method to `IThreadMessage`
- update `ThreadMessage` to store a list of strings

## Testing
- `ctest` *(fails: Could not find executable)*

------
https://chatgpt.com/codex/tasks/task_e_68897a3ae158832896e1ed2cc3f3f7ce