### PR TITLE
Add GPIOReader module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,13 @@ add_executable(test_gpio_driver
     tests/stubs/gpiod_stub.cpp
 )
 
+# GPIOReader tests
+add_executable(test_gpio_reader
+    tests/infra/test_gpio_reader.cpp
+    src/infra/gpio_operation/gpio_reader/gpio_reader.cpp
+    tests/stubs/gpiod_stub.cpp
+)
+
 # Additional infra tests
 add_executable(test_infra_extra
     tests/infra/test_local_message_queue.cpp
@@ -102,6 +109,12 @@ target_link_libraries(test_gpio_driver
     gtest_main
 )
 
+target_link_libraries(test_gpio_reader
+    gtest
+    gmock
+    gtest_main
+)
+
 target_link_libraries(test_infra_extra
     gtest
     gmock
@@ -117,12 +130,17 @@ if(UNIX)
 endif()
 
 if(UNIX)
+    target_link_libraries(test_gpio_reader pthread)
+endif()
+
+if(UNIX)
     target_link_libraries(test_infra_extra pthread rt)
 endif()
 
 enable_testing()
 add_test(NAME AllTests COMMAND test_app)
 add_test(NAME GPIODriverTests COMMAND test_gpio_driver)
+add_test(NAME GPIOReaderTests COMMAND test_gpio_reader)
 add_test(NAME InfraExtraTests COMMAND test_infra_extra)
 
 

--- a/include/infra/gpio_operation/gpio_reader/gpio_reader.hpp
+++ b/include/infra/gpio_operation/gpio_reader/gpio_reader.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "i_gpio_reader.hpp"
+#include "infra/logger/i_logger.hpp"
+
+#include <memory>
+#include <string>
+
+struct gpiod_chip;
+struct gpiod_line;
+
+namespace device_reminder {
+
+class GPIOReader : public IGPIOReader {
+public:
+    GPIOReader(std::shared_ptr<ILogger> logger,
+               int pin_no,
+               std::string chip_name = "/dev/gpiochip0");
+    ~GPIOReader() override;
+
+    bool read() override;
+
+private:
+    std::shared_ptr<ILogger> logger_;
+    int pin_no_;
+    std::string chip_name_;
+    gpiod_chip* chip_;
+    gpiod_line* line_;
+};
+
+} // namespace device_reminder

--- a/include/infra/gpio_operation/gpio_reader/i_gpio_reader.hpp
+++ b/include/infra/gpio_operation/gpio_reader/i_gpio_reader.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace device_reminder {
+
+class IGPIOReader {
+public:
+    virtual ~IGPIOReader() = default;
+    virtual bool read() = 0; // true: HIGH, false: LOW
+};
+
+} // namespace device_reminder

--- a/src/infra/gpio_operation/gpio_reader/gpio_reader.cpp
+++ b/src/infra/gpio_operation/gpio_reader/gpio_reader.cpp
@@ -1,0 +1,56 @@
+#include "infra/gpio_operation/gpio_reader/gpio_reader.hpp"
+
+#include <gpiod.h>
+#include <stdexcept>
+
+namespace device_reminder {
+
+GPIOReader::GPIOReader(std::shared_ptr<ILogger> logger,
+                       int pin_no,
+                       std::string chip_name)
+    : logger_(std::move(logger)),
+      pin_no_(pin_no),
+      chip_name_(std::move(chip_name)),
+      chip_(nullptr),
+      line_(nullptr) {
+    chip_ = gpiod_chip_open(chip_name_.c_str());
+    if (!chip_) {
+        if (logger_) logger_->error("Failed to open GPIO chip: " + chip_name_);
+        throw std::runtime_error("Failed to open GPIO chip: " + chip_name_);
+    }
+    line_ = gpiod_chip_get_line(chip_, pin_no_);
+    if (!line_) {
+        if (logger_) logger_->error("Failed to get GPIO line: " + std::to_string(pin_no_));
+        gpiod_chip_close(chip_);
+        throw std::runtime_error("Failed to get GPIO line");
+    }
+    if (gpiod_line_request_input(line_, "device_reminder") < 0) {
+        if (logger_) logger_->error("Failed to request GPIO input line");
+        gpiod_chip_close(chip_);
+        line_ = nullptr;
+        chip_ = nullptr;
+        throw std::runtime_error("Failed to request GPIO input line");
+    }
+}
+
+GPIOReader::~GPIOReader() {
+    if (line_) {
+        gpiod_line_release(line_);
+        line_ = nullptr;
+    }
+    if (chip_) {
+        gpiod_chip_close(chip_);
+        chip_ = nullptr;
+    }
+}
+
+bool GPIOReader::read() {
+    int value = gpiod_line_get_value(line_);
+    if (value < 0) {
+        if (logger_) logger_->error("Failed to read GPIO value");
+        throw std::runtime_error("Failed to read GPIO value");
+    }
+    return value != 0;
+}
+
+} // namespace device_reminder

--- a/tests/infra/test_gpio_reader.cpp
+++ b/tests/infra/test_gpio_reader.cpp
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "infra/gpio_operation/gpio_reader/gpio_reader.hpp"
+#include "stubs/gpiod_stub.h"
+
+using namespace device_reminder;
+
+class GPIOReaderTest : public ::testing::Test {
+protected:
+    void SetUp() override { gpiod_stub_reset(); }
+};
+
+TEST_F(GPIOReaderTest, ConstructorThrowsWhenChipOpenFails) {
+    gpiod_stub_set_fail_chip_open(1);
+    EXPECT_THROW({ GPIOReader reader(nullptr, 1); }, std::runtime_error);
+}
+
+TEST_F(GPIOReaderTest, ReadReturnsTrueForHigh) {
+    gpiod_stub_set_get_value_result(1);
+    GPIOReader reader(nullptr, 1);
+    EXPECT_TRUE(reader.read());
+}
+
+TEST_F(GPIOReaderTest, ReadReturnsFalseForLow) {
+    gpiod_stub_set_get_value_result(0);
+    GPIOReader reader(nullptr, 1);
+    EXPECT_FALSE(reader.read());
+}
+


### PR DESCRIPTION
## Summary
- implement GPIOReader for GPIO input handling
- expose IGPIOReader interface
- add tests for GPIOReader
- hook test target to CMake

## Testing
- `g++ -std=c++17 -Iinclude -Itests -Itests/stubs -I/usr/src/googletest/googletest/include -I/usr/src/googletest/googlemock/include tests/infra/test_gpio_reader.cpp src/infra/gpio_operation/gpio_reader/gpio_reader.cpp tests/stubs/gpiod_stub.cpp /usr/src/googletest/lib/libgtest.a /usr/src/googletest/lib/libgmock.a /usr/src/googletest/lib/libgtest_main.a /usr/src/googletest/lib/libgmock_main.a -pthread -o test_gpio_reader`
- `./test_gpio_reader`

------
https://chatgpt.com/codex/tasks/task_e_68897e6bde7083288ccccff10d190ef9