### PR TITLE
Fix ThreadSender to use non template queue

### DIFF
--- a/include/infra/thread_operation/thread_sender/i_thread_sender.hpp
+++ b/include/infra/thread_operation/thread_sender/i_thread_sender.hpp
@@ -3,8 +3,7 @@
 
 namespace device_reminder {
 
-class IThreadMessage; // forward
-template <typename T>
+class IThreadMessage; // forward declaration
 class IThreadQueue;
 
 class IThreadSender {

--- a/include/infra/thread_operation/thread_sender/thread_sender.hpp
+++ b/include/infra/thread_operation/thread_sender/thread_sender.hpp
@@ -10,13 +10,13 @@ namespace device_reminder {
 class ThreadSender : public IThreadSender {
 public:
     ThreadSender(std::shared_ptr<ILogger> logger,
-                 std::shared_ptr<IThreadQueue<std::shared_ptr<IThreadMessage>>> queue,
+                 std::shared_ptr<IThreadQueue> queue,
                  std::shared_ptr<IThreadMessage> message);
     void send() override;
 
 private:
     std::shared_ptr<ILogger> logger_;
-    std::shared_ptr<IThreadQueue<std::shared_ptr<IThreadMessage>>> queue_;
+    std::shared_ptr<IThreadQueue> queue_;
     std::shared_ptr<IThreadMessage> message_;
 };
 

--- a/src/infra/thread_operation/thread_sender.cpp
+++ b/src/infra/thread_operation/thread_sender.cpp
@@ -5,7 +5,7 @@
 namespace device_reminder {
 
 ThreadSender::ThreadSender(std::shared_ptr<ILogger> logger,
-                           std::shared_ptr<IThreadQueue<std::shared_ptr<IThreadMessage>>> queue,
+                           std::shared_ptr<IThreadQueue> queue,
                            std::shared_ptr<IThreadMessage> message)
     : logger_(std::move(logger)),
       queue_(std::move(queue)),

--- a/tests/infra/test_thread_sender.cpp
+++ b/tests/infra/test_thread_sender.cpp
@@ -18,7 +18,7 @@ public:
 } // namespace
 
 TEST(ThreadSenderTest, SendPushesMessageToQueue) {
-    auto queue = std::make_shared<ThreadQueue<std::shared_ptr<IThreadMessage>>>();
+    auto queue = std::make_shared<ThreadQueue>(nullptr);
     NiceMock<MockLogger> logger;
     auto message = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzer, true);
 
@@ -27,7 +27,7 @@ TEST(ThreadSenderTest, SendPushesMessageToQueue) {
     sender.send();
 
     auto res = queue->pop();
-    ASSERT_TRUE(res.has_value());
-    EXPECT_EQ((*res)->type(), message->type());
-    EXPECT_EQ((*res)->payload(), message->payload());
+    ASSERT_NE(res, nullptr);
+    EXPECT_EQ(res->type(), message->type());
+    EXPECT_EQ(res->payload(), message->payload());
 }


### PR DESCRIPTION
## Summary
- adjust `IThreadSender` interface to forward declare non-template `IThreadQueue`
- update `ThreadSender` constructor to accept `std::shared_ptr<IThreadQueue>`
- update implementation and unit test accordingly

## Testing
- `cmake ..` *(fails: cannot find source file)*

------
https://chatgpt.com/codex/tasks/task_e_68898453e5b883288c0785faab3c71ad