### PR TITLE
Fix ThreadDispatcher handler map

### DIFF
--- a/include/infra/thread_operation/thread_dispatcher/thread_dispatcher.hpp
+++ b/include/infra/thread_operation/thread_dispatcher/thread_dispatcher.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "infra/thread_operation/thread_dispatcher/i_thread_dispatcher.hpp"
 #include "infra/logger/i_logger.hpp"
+#include "infra/thread_operation/thread_message/thread_message_type.hpp"
 #include <unordered_map>
 #include <functional>
 #include <memory>
@@ -9,8 +10,9 @@ namespace device_reminder {
 
 class ThreadDispatcher : public IThreadDispatcher {
 public:
-    using HandlerMap = std::unordered_map<std::shared_ptr<IThreadMessage>,
-                                          std::function<void(std::shared_ptr<IThreadMessage>)>>;
+    using HandlerMap =
+        std::unordered_map<ThreadMessageType,
+                           std::function<void(std::shared_ptr<IThreadMessage>)>>;
 
     ThreadDispatcher(std::shared_ptr<ILogger> logger, HandlerMap handler_map);
 

--- a/src/infra/thread_operation/thread_dispatcher.cpp
+++ b/src/infra/thread_operation/thread_dispatcher.cpp
@@ -1,5 +1,6 @@
 #include "infra/thread_operation/thread_dispatcher/thread_dispatcher.hpp"
 #include "infra/logger/i_logger.hpp"
+#include "infra/thread_operation/thread_message/i_thread_message.hpp"
 #include <utility>
 
 namespace device_reminder {
@@ -12,7 +13,11 @@ ThreadDispatcher::ThreadDispatcher(std::shared_ptr<ILogger> logger,
 }
 
 void ThreadDispatcher::dispatch(std::shared_ptr<IThreadMessage> msg) {
-    auto it = handler_map_.find(msg);
+    if (!msg) {
+        if (logger_) logger_->error("Null thread message");
+        return;
+    }
+    auto it = handler_map_.find(msg->type());
     if (it != handler_map_.end()) {
         it->second(std::move(msg));
     } else {

--- a/tests/infra/test_thread_dispatcher.cpp
+++ b/tests/infra/test_thread_dispatcher.cpp
@@ -1,24 +1,31 @@
 #include <gtest/gtest.h>
-#include "thread_message_operation/thread_dispatcher.hpp"
+#include "infra/thread_operation/thread_dispatcher/thread_dispatcher.hpp"
+#include "infra/thread_operation/thread_message/thread_message.hpp"
 
 using namespace device_reminder;
 
 TEST(ThreadDispatcherTest, CallsRegisteredHandler) {
     bool called = false;
     ThreadDispatcher::HandlerMap map{
-        {ThreadMessageType::StartBuzzer, [&](const ThreadMessage&){ called = true; }}
+        {ThreadMessageType::StartBuzzing,
+         [&](std::shared_ptr<IThreadMessage>) { called = true; }}
     };
     ThreadDispatcher disp(nullptr, map);
-    disp.dispatch(ThreadMessage{ThreadMessageType::StartBuzzer, true});
+    auto msg = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing,
+                                               std::vector<std::string>{});
+    disp.dispatch(msg);
     EXPECT_TRUE(called);
 }
 
 TEST(ThreadDispatcherTest, IgnoresUnknownMessage) {
     bool called = false;
     ThreadDispatcher::HandlerMap map{
-        {ThreadMessageType::StartBuzzer, [&](const ThreadMessage&){ called = true; }}
+        {ThreadMessageType::StartBuzzing,
+         [&](std::shared_ptr<IThreadMessage>) { called = true; }}
     };
     ThreadDispatcher disp(nullptr, map);
-    disp.dispatch(ThreadMessage{ThreadMessageType::StopBuzzer, false});
+    auto msg = std::make_shared<ThreadMessage>(ThreadMessageType::StopBuzzing,
+                                               std::vector<std::string>{});
+    disp.dispatch(msg);
     EXPECT_FALSE(called);
 }


### PR DESCRIPTION
## Summary
- adjust ThreadDispatcher to dispatch by `ThreadMessageType`
- update dispatcher implementation to look up handlers using message type
- modify unit tests for new interface

## Testing
- `g++ -std=c++17 -Iinclude -c src/infra/thread_operation/thread_dispatcher.cpp`
- `g++ -std=c++17 -Iinclude -I/usr/include -c tests/infra/test_thread_dispatcher.cpp`
- `g++ /tmp/thread_dispatcher.o /tmp/test_thread_dispatcher.o -lgtest -lgtest_main -pthread -o /tmp/test_thread_dispatcher && /tmp/test_thread_dispatcher`

------
https://chatgpt.com/codex/tasks/task_e_688986c91ab483289a7480bb722bac89