### PR TITLE
Fix TimerService header per updated spec

### DIFF
--- a/include/infra/timer_service/timer_service.hpp
+++ b/include/infra/timer_service/timer_service.hpp
@@ -12,9 +12,9 @@ namespace device_reminder {
 
 class TimerService : public ITimerService {
 public:
-    TimerService(std::shared_ptr<ILogger> logger,
-                 int duration_ms,
-                 std::shared_ptr<IThreadSender> sender);
+    explicit TimerService(std::shared_ptr<ILogger> logger,
+                          int duration_ms,
+                          std::shared_ptr<IThreadSender> sender);
     ~TimerService() override;
 
     void start() override;
@@ -27,7 +27,7 @@ private:
     int duration_ms_{0};
     std::shared_ptr<IThreadSender> sender_;
     std::thread thread_;
-    std::atomic_bool running_{false};
+    std::atomic<bool> running_{false};
 };
 
 } // namespace device_reminder


### PR DESCRIPTION
## Summary
- adjust TimerService constructor to be explicit
- use `std::atomic<bool>` for running flag

## Testing
- `cmake ..` *(fails: Cannot find source file src/core/app.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_6889872aec948328919304831a0e8a7a