### PR TITLE
Refactor WatchDog for new TimerService API

### DIFF
--- a/include/infra/watch_dog/watch_dog.hpp
+++ b/include/infra/watch_dog/watch_dog.hpp
@@ -1,30 +1,22 @@
 #pragma once
 
 #include "infra/watch_dog/i_watch_dog.hpp"
-#include "infra/logger/i_logger.hpp"
 #include "infra/timer_service/i_timer_service.hpp"
-
-#include <functional>
 #include <memory>
 
 namespace device_reminder {
 
 class WatchDog : public IWatchDog {
 public:
-    WatchDog(std::shared_ptr<ILogger> logger,
-             std::shared_ptr<ITimerService> timer,
-             std::function<void()> on_timeout_handler,
-             int timeout_ms);
+    explicit WatchDog(std::shared_ptr<ITimerService> timer_service);
 
     void start() override;
     void stop() override;
     void kick() override;
 
 private:
-    std::shared_ptr<ILogger> logger_;
-    std::shared_ptr<ITimerService> timer_;
-    std::function<void()> on_timeout_;
-    int timeout_ms_{0};
+    std::shared_ptr<ITimerService> timer_service_;
+    bool running_{false};
 };
 
 } // namespace device_reminder


### PR DESCRIPTION
## Summary
- simplify WatchDog interface per updated specification
- refactor implementation to use ITimerService start/stop without parameters
- update unit tests for WatchDog

## Testing
- `g++ -std=c++17 -Iinclude -Iinclude/infra -Iexternal/googletest/googletest/include -Iexternal/googletest/googlemock/include -c src/infra/watch_dog/watch_dog.cpp`
- `g++ -std=c++17 -Iinclude -Iinclude/infra -Iexternal/googletest/googletest/include -Iexternal/googletest/googlemock/include -c tests/infra/test_watch_dog.cpp`
- `g++ /tmp/watch_dog.o /tmp/test_watch_dog.o -Lexternal/googletest/build/lib -lgtest -lgtest_main -lpthread -o /tmp/test_watchdog` *(fails: cannot find -lgtest)*

------
https://chatgpt.com/codex/tasks/task_e_68899256be2c8328a81478ddf91c0e87