### PR TITLE
Fix ThreadReceiver queue types

### DIFF
--- a/include/infra/thread_operation/thread_receiver/thread_receiver.hpp
+++ b/include/infra/thread_operation/thread_receiver/thread_receiver.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "infra/thread_operation/thread_receiver/i_thread_receiver.hpp"
 #include "infra/thread_operation/thread_queue/i_thread_queue.hpp"
-#include "infra/thread_operation/thread_message/thread_message.hpp"
+#include "infra/thread_operation/thread_message/i_thread_message.hpp"
 #include "infra/thread_operation/thread_dispatcher/i_thread_dispatcher.hpp"
 #include "infra/logger/i_logger.hpp"
 #include <memory>
@@ -11,7 +11,7 @@ namespace device_reminder {
 
 class ThreadReceiver : public IThreadReceiver {
 public:
-    ThreadReceiver(std::shared_ptr<IThreadQueue<ThreadMessage>> queue,
+    ThreadReceiver(std::shared_ptr<IThreadQueue> queue,
                    std::shared_ptr<IThreadDispatcher> dispatcher,
                    std::shared_ptr<ILogger> logger = nullptr);
 
@@ -19,7 +19,7 @@ public:
     void stop() override;
 
 private:
-    std::shared_ptr<IThreadQueue<ThreadMessage>> queue_;
+    std::shared_ptr<IThreadQueue> queue_;
     std::shared_ptr<IThreadDispatcher> dispatcher_;
     std::atomic<bool> running_{true};
     std::shared_ptr<ILogger> logger_;

--- a/src/infra/thread_operation/thread_receiver.cpp
+++ b/src/infra/thread_operation/thread_receiver.cpp
@@ -5,7 +5,7 @@
 
 namespace device_reminder {
 
-ThreadReceiver::ThreadReceiver(std::shared_ptr<IThreadQueue<ThreadMessage>> queue,
+ThreadReceiver::ThreadReceiver(std::shared_ptr<IThreadQueue> queue,
                                std::shared_ptr<IThreadDispatcher> dispatcher,
                                std::shared_ptr<ILogger> logger)
     : queue_(std::move(queue)),
@@ -22,10 +22,10 @@ void ThreadReceiver::stop() {
 void ThreadReceiver::run() {
     while (running_) {
         if (!queue_) break;
-        auto msg_opt = queue_->pop();
-        if (!msg_opt.has_value()) break;
+        auto msg = queue_->pop();
+        if (!msg) break;
         if (!running_) break;
-        if (dispatcher_) dispatcher_->dispatch(std::make_shared<ThreadMessage>(*msg_opt));
+        if (dispatcher_) dispatcher_->dispatch(msg);
     }
     if (logger_) logger_->info("ThreadReceiver loop end");
 }


### PR DESCRIPTION
## Summary
- update `ThreadReceiver` to accept `IThreadQueue` instead of templated queue
- forward popped messages directly to dispatcher

## Testing
- `cmake ..` *(fails: Cannot find source file)*

------
https://chatgpt.com/codex/tasks/task_e_688991eca0288328891417f6cc0799b8