### PR TITLE
Update FileLoader per new spec

### DIFF
--- a/include/infra/file_loader/file_loader.hpp
+++ b/include/infra/file_loader/file_loader.hpp
@@ -4,23 +4,26 @@
 #include "infra/logger/i_logger.hpp"
 
 #include <string>
-#include <unordered_map>
 #include <memory>
 
 namespace device_reminder {
 
 class FileLoader : public IFileLoader {
 public:
-    FileLoader(const std::string& file_path, std::shared_ptr<ILogger> logger = nullptr);
+    FileLoader(std::shared_ptr<ILogger> logger,
+               const std::string& file_path,
+               const std::string& key);
 
-    int load_int(const std::string& key) const override;
-    std::string load_string(const std::string& key) const override;
+    int load_int() const override;
+    std::string load_string() const override;
+    std::vector<std::string> load_string_list() const override;
 
 private:
-    void parse_file(const std::string& file_path);
+    std::string load_value() const;
 
-    std::unordered_map<std::string, std::string> values_;
     std::shared_ptr<ILogger> logger_;
+    std::string              file_path_;
+    std::string              key_;
 };
 
 } // namespace device_reminder

--- a/include/infra/file_loader/i_file_loader.hpp
+++ b/include/infra/file_loader/i_file_loader.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace device_reminder {
 
@@ -8,8 +9,9 @@ class IFileLoader {
 public:
     virtual ~IFileLoader() = default;
 
-    virtual int load_int(const std::string& key) const = 0;
-    virtual std::string load_string(const std::string& key) const = 0;
+    virtual int load_int() const = 0;
+    virtual std::string load_string() const = 0;
+    virtual std::vector<std::string> load_string_list() const = 0;
 };
 
 } // namespace device_reminder

--- a/src/infra/io/file_loader.cpp
+++ b/src/infra/io/file_loader.cpp
@@ -3,44 +3,55 @@
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
+#include <vector>
 
 namespace device_reminder {
 
-FileLoader::FileLoader(const std::string& file_path, std::shared_ptr<ILogger> logger)
+FileLoader::FileLoader(std::shared_ptr<ILogger> logger,
+                       const std::string& file_path,
+                       const std::string& key)
     : logger_(std::move(logger))
-{
-    parse_file(file_path);
-}
+    , file_path_(file_path)
+    , key_(key)
+{}
 
-int FileLoader::load_int(const std::string& key) const
+int FileLoader::load_int() const
 {
-    auto it = values_.find(key);
-    if (it == values_.end()) {
-        throw std::runtime_error("key not found: " + key);
-    }
+    std::string value = load_value();
     try {
-        return std::stoi(it->second);
+        return std::stoi(value);
     } catch (const std::exception&) {
-        if (logger_) logger_->error(std::string("invalid int value for ") + key);
+        if (logger_) logger_->error(std::string("invalid int value for ") + key_);
         throw;
     }
 }
 
-std::string FileLoader::load_string(const std::string& key) const
+std::string FileLoader::load_string() const
 {
-    auto it = values_.find(key);
-    if (it == values_.end()) {
-        throw std::runtime_error("key not found: " + key);
-    }
-    return it->second;
+    return load_value();
 }
 
-void FileLoader::parse_file(const std::string& file_path)
+std::vector<std::string> FileLoader::load_string_list() const
 {
-    std::ifstream ifs(file_path);
+    std::string value = load_value();
+    std::vector<std::string> result;
+    std::istringstream iss(value);
+    std::string item;
+    while (std::getline(iss, item, ',')) {
+        auto start = item.find_first_not_of(" \t\r\n");
+        if (start == std::string::npos) continue;
+        auto end = item.find_last_not_of(" \t\r\n");
+        result.push_back(item.substr(start, end - start + 1));
+    }
+    return result;
+}
+
+std::string FileLoader::load_value() const
+{
+    std::ifstream ifs(file_path_);
     if (!ifs) {
-        if (logger_) logger_->error("failed to open file: " + file_path);
-        throw std::runtime_error("failed to open file: " + file_path);
+        if (logger_) logger_->error("failed to open file: " + file_path_);
+        throw std::runtime_error("failed to open file: " + file_path_);
     }
 
     std::string line;
@@ -59,16 +70,21 @@ void FileLoader::parse_file(const std::string& file_path)
             if (logger_) logger_->error("invalid line: " + trimmed);
             continue;
         }
-        std::string key = trimmed.substr(0, eq_pos);
+        std::string k = trimmed.substr(0, eq_pos);
         std::string value = trimmed.substr(eq_pos + 1);
 
-        auto key_end = key.find_last_not_of(" \t");
-        if (key_end != std::string::npos) key = key.substr(0, key_end + 1);
+        auto key_end = k.find_last_not_of(" \t");
+        if (key_end != std::string::npos) k = k.substr(0, key_end + 1);
         auto value_start = value.find_first_not_of(" \t");
         if (value_start != std::string::npos) value = value.substr(value_start);
 
-        values_[key] = value;
+        if (k == key_) {
+            return value;
+        }
     }
+    if (logger_) logger_->error("key not found: " + key_);
+    throw std::runtime_error("key not found: " + key_);
 }
 
 } // namespace device_reminder
+

--- a/tests/infra/test_file_loader.cpp
+++ b/tests/infra/test_file_loader.cpp
@@ -13,9 +13,9 @@ TEST(FileLoaderTest, LoadIntSuccess) {
     ofs.close();
 
     auto spd = std::make_shared<spdlog::logger>("test", std::make_shared<spdlog::sinks::basic_file_sink_mt>("/tmp/test_log.txt"));
-    FileLoader loader("/tmp/test_settings.txt", std::make_shared<Logger>(spd));
+    FileLoader loader(std::make_shared<Logger>(spd), "/tmp/test_settings.txt", "buzz_duration_ms");
 
-    EXPECT_EQ(loader.load_int("buzz_duration_ms"), 5000);
+    EXPECT_EQ(loader.load_int(), 5000);
 }
 
 TEST(FileLoaderTest, LoadIntThrowsIfMissing) {
@@ -23,8 +23,8 @@ TEST(FileLoaderTest, LoadIntThrowsIfMissing) {
     ofs << "a=1\n";
     ofs.close();
 
-    FileLoader loader("/tmp/test_settings.txt");
-    EXPECT_THROW(loader.load_int("b"), std::runtime_error);
+    FileLoader loader(nullptr, "/tmp/test_settings.txt", "b");
+    EXPECT_THROW(loader.load_int(), std::runtime_error);
 }
 
 TEST(FileLoaderTest, LoadStringSuccess) {
@@ -32,6 +32,19 @@ TEST(FileLoaderTest, LoadStringSuccess) {
     ofs << "device_name=reminder\n";
     ofs.close();
 
-    FileLoader loader("/tmp/test_settings.txt");
-    EXPECT_EQ(loader.load_string("device_name"), "reminder");
+    FileLoader loader(nullptr, "/tmp/test_settings.txt", "device_name");
+    EXPECT_EQ(loader.load_string(), "reminder");
+}
+
+TEST(FileLoaderTest, LoadStringListSuccess) {
+    std::ofstream ofs("/tmp/test_settings.txt");
+    ofs << "device_list=phone,watch,tablet\n";
+    ofs.close();
+
+    FileLoader loader(nullptr, "/tmp/test_settings.txt", "device_list");
+    auto list = loader.load_string_list();
+    ASSERT_EQ(list.size(), 3);
+    EXPECT_EQ(list[0], "phone");
+    EXPECT_EQ(list[1], "watch");
+    EXPECT_EQ(list[2], "tablet");
 }


### PR DESCRIPTION
## Summary
- change `IFileLoader` interface to no longer require key parameter and to support string list
- rewrite `FileLoader` implementation to read the file each call and use constructor parameters `(logger, file_path, key)`
- adjust unit tests for new interface

## Testing
- `g++ -std=c++17 -Iinclude -Itests -c src/infra/io/file_loader.cpp`
- `g++ -std=c++17 -Iinclude -Itests -c tests/infra/test_file_loader.cpp` *(fails: `gtest/gtest.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889c99c51b88328ba29f9dc0a912c5c