### PR TITLE
Revamp HumanTask interface

### DIFF
--- a/include/core/human_task/human_task.hpp
+++ b/include/core/human_task/human_task.hpp
@@ -1,35 +1,27 @@
 #pragma once
 
-#include "infra/thread_message_operation/i_thread_message.hpp"
 #include "human_task/i_human_task.hpp"
 #include "infra/logger/i_logger.hpp"
 #include "infra/pir_driver/i_pir_driver.hpp"
-#include "infra/timer_service/i_timer_service.hpp"
-#include "process_message_operation/i_process_message_sender.hpp"
+#include "infra/process_operation/process_sender/i_process_sender.hpp"
 #include <memory>
 
 namespace device_reminder {
 
 class HumanTask : public IHumanTask {
 public:
-    enum class State { Detecting, Stopped, Cooldown };
+    HumanTask(std::shared_ptr<ILogger> logger,
+              std::shared_ptr<IPIRDriver> pir,
+              std::shared_ptr<IProcessSender> sender);
 
-    HumanTask(std::shared_ptr<IPIRDriver> pir,
-              std::shared_ptr<ITimerService> timer,
-              std::shared_ptr<IProcessMessageSender> sender,
-              std::shared_ptr<ILogger> logger);
-    ~HumanTask();
-
-    void run(const IThreadMessage& msg) override;
-
-    State state() const noexcept { return state_; }
+    void on_detecting(const std::vector<std::string>& payload) override;
+    void on_stopping(const std::vector<std::string>& payload) override;
+    void on_cooldown(const std::vector<std::string>& payload) override;
 
 private:
-    std::shared_ptr<IPIRDriver>   pir_;
-    std::shared_ptr<ITimerService> timer_;
-    std::shared_ptr<IProcessMessageSender> sender_;
-    std::shared_ptr<ILogger>        logger_;
-    State state_{State::Detecting};
+    std::shared_ptr<ILogger> logger_;
+    std::shared_ptr<IPIRDriver> pir_;
+    std::shared_ptr<IProcessSender> sender_;
 };
 
 } // namespace device_reminder

--- a/include/core/human_task/human_task_handler.hpp
+++ b/include/core/human_task/human_task_handler.hpp
@@ -1,21 +1,24 @@
 #pragma once
 
 #include "interfaces/i_message_handler.hpp"
-#include "infra/thread_message_operation/thread_message.hpp"
-#include "human_task/human_task.hpp"
+#include "infra/thread_operation/thread_message/thread_message.hpp"
+#include "human_task/i_human_task.hpp"
 #include <memory>
 
 namespace device_reminder {
 
 class HumanTaskHandler : public IMessageHandler {
 public:
-    explicit HumanTaskHandler(std::shared_ptr<HumanTask> task)
+    enum class State { Detecting, Stopped, Cooldown };
+
+    explicit HumanTaskHandler(std::shared_ptr<IHumanTask> task)
         : task_(std::move(task)) {}
 
     void handle(const ThreadMessage& msg) override;
 
 private:
-    std::shared_ptr<HumanTask> task_;
+    std::shared_ptr<IHumanTask> task_;
+    State state_{State::Detecting};
 };
 
 } // namespace device_reminder

--- a/include/core/human_task/i_human_task.hpp
+++ b/include/core/human_task/i_human_task.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "infra/thread_message_operation/i_thread_message.hpp"
+#include <string>
+#include <vector>
 
 namespace device_reminder {
 
@@ -8,7 +9,9 @@ class IHumanTask {
 public:
     virtual ~IHumanTask() = default;
 
-    virtual void run(const IThreadMessage& msg) = 0;
+    virtual void on_detecting(const std::vector<std::string>& payload) = 0;
+    virtual void on_stopping(const std::vector<std::string>& payload) = 0;
+    virtual void on_cooldown(const std::vector<std::string>& payload) = 0;
 };
 
 } // namespace device_reminder

--- a/src/core/app/app.cpp
+++ b/src/core/app/app.cpp
@@ -1,5 +1,5 @@
 #include "app/app.hpp"
-#include "thread_message_operation/thread_message.hpp"
+#include "infra/thread_operation/thread_message/thread_message.hpp"
 
 namespace device_reminder {
 
@@ -17,7 +17,7 @@ App::App(std::unique_ptr<IMainTask> main_task,
 int App::run() {
     try {
         main_task_->run(ThreadMessage{});
-        human_task_->run(ThreadMessage{});
+        human_task_->on_detecting({});
         bluetooth_task_->run(ThreadMessage{});
         buzzer_task_->run();
     } catch (const std::exception& e) {

--- a/src/core/human_task/human_task_handler.cpp
+++ b/src/core/human_task/human_task_handler.cpp
@@ -3,7 +3,33 @@
 namespace device_reminder {
 
 void HumanTaskHandler::handle(const ThreadMessage& msg) {
-    if (task_) task_->run(msg);
+    if (!task_) return;
+
+    switch (msg.type()) {
+    case ThreadMessageType::StartHumanDetection:
+        state_ = State::Detecting;
+        break;
+    case ThreadMessageType::StopHumanDetection:
+        state_ = State::Stopped;
+        break;
+    case ThreadMessageType::CooldownTimeout:
+        state_ = State::Cooldown;
+        break;
+    default:
+        break;
+    }
+
+    switch (state_) {
+    case State::Detecting:
+        task_->on_detecting(msg.payload());
+        break;
+    case State::Stopped:
+        task_->on_stopping(msg.payload());
+        break;
+    case State::Cooldown:
+        task_->on_cooldown(msg.payload());
+        break;
+    }
 }
 
 } // namespace device_reminder


### PR DESCRIPTION
## Summary
- redesign `IHumanTask` with explicit detecting/stop/cooldown methods
- implement new `HumanTask` using `IPIRDriver` and `IProcessSender`
- update handler to manage states and delegate to the new API
- adjust `App` startup and update unit tests

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: missing `i_process_message_sender.hpp`)*

------
https://chatgpt.com/codex/tasks/task_e_6889d931bb4c832897501c3241b398d8