### PR TITLE
Implement HumanHandler and interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(test_app
     tests/core/test_app.cpp
     tests/core/test_main_task.cpp
     tests/core/test_human_task.cpp
+    tests/core/test_human_handler.cpp
     tests/core/test_buzzer_task.cpp
     tests/core/test_bluetooth_task.cpp
     tests/infra/test_logger.cpp
@@ -36,6 +37,7 @@ add_executable(test_app
     src/core/main_task/main_task.cpp
     src/core/main_task/main_task_handler.cpp
     src/core/human_task/human_task.cpp
+    src/core/human_task/human_handler.cpp
     src/core/human_task/human_task_handler.cpp
     src/core/buzzer_task/buzzer_task.cpp
     src/core/buzzer_task/buzzer_handler.cpp

--- a/include/core/human_task/human_handler.hpp
+++ b/include/core/human_task/human_handler.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "interfaces/i_handler.hpp"
+#include "infra/logger/i_logger.hpp"
+#include "human_task/i_human_task.hpp"
+#include "infra/timer_service/i_timer_service.hpp"
+#include "infra/process_operation/process_message/i_process_message.hpp"
+
+#include <memory>
+
+namespace device_reminder {
+
+class HumanHandler : public IHandler {
+public:
+    HumanHandler(std::shared_ptr<ILogger> logger,
+                 std::shared_ptr<IHumanTask> task,
+                 std::shared_ptr<ITimerService> timer);
+
+    void handle(std::shared_ptr<IProcessMessage> msg) override;
+
+private:
+    enum class State { Detecting, Stopping, Cooldown };
+
+    std::shared_ptr<ILogger>       logger_;
+    std::shared_ptr<IHumanTask>    task_;
+    std::shared_ptr<ITimerService> timer_;
+    State                          state_{State::Detecting};
+};
+
+} // namespace device_reminder

--- a/include/core/interfaces/i_handler.hpp
+++ b/include/core/interfaces/i_handler.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <memory>
+
+namespace device_reminder {
+
+class IProcessMessage;
+
+class IHandler {
+public:
+    virtual ~IHandler() = default;
+    virtual void handle(std::shared_ptr<IProcessMessage> msg) = 0;
+};
+
+} // namespace device_reminder

--- a/src/core/human_task/human_handler.cpp
+++ b/src/core/human_task/human_handler.cpp
@@ -1,0 +1,49 @@
+#include "human_task/human_handler.hpp"
+#include "infra/process_operation/process_message/process_message_type.hpp"
+
+namespace device_reminder {
+
+HumanHandler::HumanHandler(std::shared_ptr<ILogger> logger,
+                           std::shared_ptr<IHumanTask> task,
+                           std::shared_ptr<ITimerService> timer)
+    : logger_(std::move(logger)), task_(std::move(task)), timer_(std::move(timer)) {
+    if (logger_) logger_->info("HumanHandler created");
+}
+
+void HumanHandler::handle(std::shared_ptr<IProcessMessage> msg) {
+    if (!msg || !task_) return;
+
+    switch (msg->type()) {
+    case ProcessMessageType::StartHumanDetection:
+        state_ = State::Detecting;
+        if (timer_) timer_->stop();
+        if (logger_) logger_->info("StartHumanDetection");
+        break;
+    case ProcessMessageType::StopHumanDetection:
+        state_ = State::Stopping;
+        if (timer_) timer_->start();
+        if (logger_) logger_->info("StopHumanDetection");
+        break;
+    case ProcessMessageType::CoolDownTimeout:
+        state_ = State::Cooldown;
+        if (timer_) timer_->stop();
+        if (logger_) logger_->info("CoolDownTimeout");
+        break;
+    default:
+        break;
+    }
+
+    switch (state_) {
+    case State::Detecting:
+        task_->on_detecting(msg->payload());
+        break;
+    case State::Stopping:
+        task_->on_stopping(msg->payload());
+        break;
+    case State::Cooldown:
+        task_->on_cooldown(msg->payload());
+        break;
+    }
+}
+
+} // namespace device_reminder

--- a/tests/core/test_human_handler.cpp
+++ b/tests/core/test_human_handler.cpp
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "human_task/human_handler.hpp"
+#include "infra/process_operation/process_message/process_message.hpp"
+
+using ::testing::StrictMock;
+using ::testing::NiceMock;
+
+namespace device_reminder {
+
+class MockHumanTask : public IHumanTask {
+public:
+    MOCK_METHOD(void, on_detecting, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_stopping, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_cooldown, (const std::vector<std::string>&), (override));
+};
+
+class MockTimer : public ITimerService {
+public:
+    MOCK_METHOD(void, start, (), (override));
+    MOCK_METHOD(void, stop, (), (override));
+};
+
+class DummyLogger : public ILogger {
+public:
+    void info(const std::string&) override {}
+    void error(const std::string&) override {}
+    void warn(const std::string&) override {}
+};
+
+TEST(HumanHandlerTest, StopDetectionStartsTimer) {
+    auto task = std::make_shared<StrictMock<MockHumanTask>>();
+    auto timer = std::make_shared<StrictMock<MockTimer>>();
+    auto logger = std::make_shared<DummyLogger>();
+    HumanHandler handler(logger, task, timer);
+
+    EXPECT_CALL(*task, on_stopping(testing::_)).Times(1);
+    EXPECT_CALL(*timer, start()).Times(1);
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StopHumanDetection, std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+TEST(HumanHandlerTest, StartDetectionStopsTimer) {
+    auto task = std::make_shared<StrictMock<MockHumanTask>>();
+    auto timer = std::make_shared<StrictMock<MockTimer>>();
+    auto logger = std::make_shared<DummyLogger>();
+    HumanHandler handler(logger, task, timer);
+
+    EXPECT_CALL(*task, on_detecting(testing::_)).Times(1);
+    EXPECT_CALL(*timer, stop()).Times(1);
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartHumanDetection, std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+TEST(HumanHandlerTest, CooldownCallsTask) {
+    auto task = std::make_shared<StrictMock<MockHumanTask>>();
+    auto timer = std::make_shared<NiceMock<MockTimer>>();
+    auto logger = std::make_shared<DummyLogger>();
+    HumanHandler handler(logger, task, timer);
+
+    EXPECT_CALL(*task, on_cooldown(testing::_)).Times(1);
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::CoolDownTimeout, std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+} // namespace device_reminder


### PR DESCRIPTION
## Summary
- add new IHandler interface for process message handlers
- implement HumanHandler with state management and timer control
- compile new code in build and add basic tests

## Testing
- `cmake ..` *(fails: external/googletest missing)*

------
https://chatgpt.com/codex/tasks/task_e_688abdf7dfb88328bc5e28491897567a