### PR TITLE
Improve CMake to fetch deps automatically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,52 @@
 cmake_minimum_required(VERSION 3.10)
 project(device_reminder_test)
 
+include(FetchContent)
+
 set(CMAKE_CXX_STANDARD 17)
 
-# GoogleTest のサブディレクトリを追加
-add_subdirectory(external/googletest)
+# GoogleTest を取得
+if(EXISTS ${CMAKE_SOURCE_DIR}/external/googletest/CMakeLists.txt)
+    add_subdirectory(external/googletest)
+else()
+    message(STATUS "Fetching googletest via FetchContent")
+    FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG release-1.14.0
+    )
+    FetchContent_MakeAvailable(googletest)
+endif()
+
+# spdlog を取得（ヘッダオンリー）
+if(EXISTS ${CMAKE_SOURCE_DIR}/external/spdlog/CMakeLists.txt)
+    add_subdirectory(external/spdlog)
+    set(SPDLOG_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/external/spdlog/include)
+else()
+    message(STATUS "Fetching spdlog via FetchContent")
+    FetchContent_Declare(
+        spdlog
+        GIT_REPOSITORY https://github.com/gabime/spdlog.git
+        GIT_TAG v1.13.0
+    )
+    FetchContent_MakeAvailable(spdlog)
+    set(SPDLOG_INCLUDE_DIR ${spdlog_SOURCE_DIR}/include)
+endif()
+
+# boost.di を取得
+if(EXISTS ${CMAKE_SOURCE_DIR}/external/di/CMakeLists.txt)
+    add_subdirectory(external/di)
+    set(BOOST_DI_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/external/di/include)
+else()
+    message(STATUS "Fetching boost.di via FetchContent")
+    FetchContent_Declare(
+        boost_di
+        GIT_REPOSITORY https://github.com/boost-ext/di.git
+        GIT_TAG v1.3.0
+    )
+    FetchContent_MakeAvailable(boost_di)
+    set(BOOST_DI_INCLUDE_DIR ${boost_di_SOURCE_DIR}/include)
+endif()
 
 # ヘッダーファイルのパス
 include_directories(
@@ -20,7 +62,8 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/human_task
     ${CMAKE_SOURCE_DIR}/bluetooth_task
     ${CMAKE_SOURCE_DIR}/buzzer_task
-    ${CMAKE_SOURCE_DIR}/external/spdlog/include
+    ${SPDLOG_INCLUDE_DIR}
+    ${BOOST_DI_INCLUDE_DIR}
 )
 
 # テストコードと対象ソース


### PR DESCRIPTION
## Summary
- fetch GoogleTest/spdlog/boost.di at configure time when submodules are missing
- reference the fetched include dirs

## Testing
- `cmake ..` *(fails: unable to clone googletest)*

------
https://chatgpt.com/codex/tasks/task_e_688ad518dce48328b8d94c236975004c