### PR TITLE
Add MainHandler implementation and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,12 +72,14 @@ add_executable(test_app
     tests/core/test_main_task.cpp
     tests/core/test_human_task.cpp
     tests/core/test_human_handler.cpp
+    tests/core/test_main_handler.cpp
     tests/core/test_buzzer_task.cpp
     tests/core/test_bluetooth_task.cpp
     tests/infra/test_logger.cpp
     src/infra/logger/logger.cpp
     src/core/app/app.cpp
     src/core/main_task/main_task.cpp
+    src/core/main_task/main_handler.cpp
     src/core/human_task/human_task.cpp
     src/core/human_task/human_handler.cpp
     src/core/human_task/human_process.cpp

--- a/include/core/main_task/main_handler.hpp
+++ b/include/core/main_task/main_handler.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "core/interfaces/i_handler.hpp"
+#include "infra/logger/i_logger.hpp"
+#include "core/main_task/i_main_task.hpp"
+#include "infra/timer_service/i_timer_service.hpp"
+#include "infra/file_loader/i_file_loader.hpp"
+
+#include <memory>
+
+namespace device_reminder {
+
+class MainHandler : public IHandler {
+public:
+    MainHandler(std::shared_ptr<ILogger> logger,
+                std::shared_ptr<IMainTask> task,
+                std::shared_ptr<ITimerService> timer_service,
+                std::shared_ptr<IFileLoader> file_loader);
+
+    void handle(std::shared_ptr<IProcessMessage> msg) override;
+
+private:
+    std::shared_ptr<ILogger>       logger_;
+    std::shared_ptr<IMainTask>     task_;
+    std::shared_ptr<ITimerService> timer_service_;
+    std::shared_ptr<IFileLoader>   file_loader_;
+};
+
+} // namespace device_reminder

--- a/src/core/main_task/main_handler.cpp
+++ b/src/core/main_task/main_handler.cpp
@@ -1,0 +1,42 @@
+#include "main_task/main_handler.hpp"
+#include "infra/process_operation/process_message/process_message_type.hpp"
+
+namespace device_reminder {
+
+MainHandler::MainHandler(std::shared_ptr<ILogger> logger,
+                         std::shared_ptr<IMainTask> task,
+                         std::shared_ptr<ITimerService> timer_service,
+                         std::shared_ptr<IFileLoader> file_loader)
+    : logger_(std::move(logger))
+    , task_(std::move(task))
+    , timer_service_(std::move(timer_service))
+    , file_loader_(std::move(file_loader)) {
+    if (logger_) logger_->info("MainHandler created");
+}
+
+void MainHandler::handle(std::shared_ptr<IProcessMessage> msg) {
+    if (!msg || !task_) return;
+
+    switch (msg->type()) {
+    case ProcessMessageType::HumanDetected:
+        task_->on_waiting_for_human(msg->payload());
+        break;
+    case ProcessMessageType::ResponseDevicePresence:
+        if (!msg->payload().empty() && msg->payload()[0] == "found") {
+            task_->on_response_to_human_task(msg->payload());
+        } else {
+            task_->on_response_to_buzzer_task(msg->payload());
+        }
+        break;
+    case ProcessMessageType::CoolDownTimeout:
+        task_->on_cooldown(msg->payload());
+        break;
+    case ProcessMessageType::ScanTimeout:
+        task_->on_waiting_for_second_response(msg->payload());
+        break;
+    default:
+        break;
+    }
+}
+
+} // namespace device_reminder

--- a/tests/core/test_main_handler.cpp
+++ b/tests/core/test_main_handler.cpp
@@ -1,0 +1,72 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "main_task/main_handler.hpp"
+#include "infra/process_operation/process_message/process_message.hpp"
+
+using ::testing::StrictMock;
+
+namespace device_reminder {
+
+class MockMainTask : public IMainTask {
+public:
+    MOCK_METHOD(void, run, (const IThreadMessage&), (override));
+    MOCK_METHOD(void, on_waiting_for_human, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_response_to_buzzer_task, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_response_to_human_task, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_cooldown, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_waiting_for_second_response, (const std::vector<std::string>&), (override));
+};
+
+class DummyLogger : public ILogger {
+public:
+    void info(const std::string&) override {}
+    void error(const std::string&) override {}
+    void warn(const std::string&) override {}
+};
+
+TEST(MainHandlerTest, HumanDetectedCallsTask) {
+    auto task = std::make_shared<StrictMock<MockMainTask>>();
+    auto logger = std::make_shared<DummyLogger>();
+    MainHandler handler(logger, task, nullptr, nullptr);
+
+    EXPECT_CALL(*task, on_waiting_for_human(testing::_)).Times(1);
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::HumanDetected, std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+TEST(MainHandlerTest, DeviceFoundCallsHumanControl) {
+    auto task = std::make_shared<StrictMock<MockMainTask>>();
+    auto logger = std::make_shared<DummyLogger>();
+    MainHandler handler(logger, task, nullptr, nullptr);
+
+    EXPECT_CALL(*task, on_response_to_human_task(testing::_)).Times(1);
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::ResponseDevicePresence, std::vector<std::string>{"found"});
+    handler.handle(msg);
+}
+
+TEST(MainHandlerTest, DeviceNotFoundCallsBuzzerControl) {
+    auto task = std::make_shared<StrictMock<MockMainTask>>();
+    auto logger = std::make_shared<DummyLogger>();
+    MainHandler handler(logger, task, nullptr, nullptr);
+
+    EXPECT_CALL(*task, on_response_to_buzzer_task(testing::_)).Times(1);
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::ResponseDevicePresence, std::vector<std::string>{"none"});
+    handler.handle(msg);
+}
+
+TEST(MainHandlerTest, CooldownCallsTask) {
+    auto task = std::make_shared<StrictMock<MockMainTask>>();
+    auto logger = std::make_shared<DummyLogger>();
+    MainHandler handler(logger, task, nullptr, nullptr);
+
+    EXPECT_CALL(*task, on_cooldown(testing::_)).Times(1);
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::CoolDownTimeout, std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+} // namespace device_reminder


### PR DESCRIPTION
## Summary
- implement `MainHandler` class for `MainTask`
- add tests for `MainHandler`
- include new sources in build

## Testing
- `cmake ..` *(fails: could not fetch googletest)*

------
https://chatgpt.com/codex/tasks/task_e_688ae4fe5e5c832885cf69a69466a9d4