### PR TITLE
Add MainProcess module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ add_executable(test_app
     src/core/app/app.cpp
     src/core/main_task/main_task.cpp
     src/core/main_task/main_handler.cpp
+    src/core/main_task/main_process.cpp
     src/core/human_task/human_task.cpp
     src/core/human_task/human_handler.cpp
     src/core/human_task/human_process.cpp

--- a/include/core/main_task/i_main_process.hpp
+++ b/include/core/main_task/i_main_process.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace device_reminder {
+
+class IMainProcess {
+public:
+    virtual ~IMainProcess() = default;
+    virtual void run() = 0;
+    virtual void stop() = 0;
+};
+
+} // namespace device_reminder

--- a/include/core/main_task/main_process.hpp
+++ b/include/core/main_task/main_process.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "core/main_task/i_main_process.hpp"
+#include "infra/process_operation/process_base/process_base.hpp"
+#include "infra/watch_dog/i_watch_dog.hpp"
+#include <memory>
+
+namespace device_reminder {
+
+class MainProcess : public ProcessBase, public IMainProcess {
+public:
+    MainProcess(std::shared_ptr<IProcessReceiver> receiver,
+                std::shared_ptr<IProcessSender> sender,
+                std::shared_ptr<IProcessQueue> queue,
+                std::shared_ptr<IFileLoader> file_loader,
+                std::shared_ptr<ILogger> logger,
+                std::shared_ptr<IWatchDog> watchdog);
+
+    void run() override;
+    void stop() override;
+
+private:
+    std::shared_ptr<IWatchDog> watchdog_;
+};
+
+} // namespace device_reminder

--- a/src/core/main_task/main_process.cpp
+++ b/src/core/main_task/main_process.cpp
@@ -1,0 +1,36 @@
+#include "main_task/main_process.hpp"
+
+namespace device_reminder {
+
+MainProcess::MainProcess(std::shared_ptr<IProcessReceiver> receiver,
+                         std::shared_ptr<IProcessSender> sender,
+                         std::shared_ptr<IProcessQueue> queue,
+                         std::shared_ptr<IFileLoader> file_loader,
+                         std::shared_ptr<ILogger> logger,
+                         std::shared_ptr<IWatchDog> watchdog)
+    : ProcessBase(std::move(queue),
+                  std::move(receiver),
+                  nullptr,
+                  std::move(sender),
+                  std::move(file_loader),
+                  std::move(logger),
+                  "MainProcess")
+    , watchdog_(std::move(watchdog))
+{
+    if (logger_) logger_->info("MainProcess created");
+}
+
+void MainProcess::run()
+{
+    if (watchdog_) watchdog_->start();
+    ProcessBase::run();
+    if (watchdog_) watchdog_->stop();
+}
+
+void MainProcess::stop()
+{
+    if (watchdog_) watchdog_->stop();
+    ProcessBase::stop();
+}
+
+} // namespace device_reminder


### PR DESCRIPTION
## Summary
- implement `IMainProcess` interface
- implement `MainProcess` inheriting from `ProcessBase`
- add new source file for `MainProcess`
- include `MainProcess` in build

## Testing
- `cmake ..` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_688ae79c561483289802636d857d0403