### PR TITLE
Implement BuzzerTask waiting/buzzing API

### DIFF
--- a/include/core/buzzer_task/buzzer_task.hpp
+++ b/include/core/buzzer_task/buzzer_task.hpp
@@ -3,8 +3,9 @@
 #include "infra/thread_message_operation/i_thread_message.hpp"
 #include "buzzer_task/i_buzzer_task.hpp"
 #include "infra/buzzer_driver/i_buzzer_driver.hpp"
-#include "infra/timer_service/i_timer_service.hpp"
 #include "infra/logger/i_logger.hpp"
+#include "infra/process_operation/process_sender/i_process_sender.hpp"
+#include "infra/file_loader/i_file_loader.hpp"
 
 #include <memory>
 #include <cstdint>
@@ -15,25 +16,28 @@ class BuzzerTask : public IBuzzerTask {
 public:
     enum class State { WaitStart, Buzzing };
 
-    BuzzerTask(std::shared_ptr<IBuzzerDriver> driver,
-               std::shared_ptr<ITimerService> timer,
-               std::shared_ptr<ILogger> logger = nullptr);
+    BuzzerTask(std::shared_ptr<ILogger> logger,
+               std::shared_ptr<IProcessSender> sender,
+               std::shared_ptr<IFileLoader> file_loader,
+               std::shared_ptr<IBuzzerDriver> driver);
 
     void run() override {}
     bool send_message(const IThreadMessage& msg) override;
 
     void onMessage(const IThreadMessage& msg);
+    void on_waiting(const std::vector<std::string>& payload) override;
+    void on_buzzing(const std::vector<std::string>& payload) override;
+
     State state() const noexcept { return state_; }
 
 private:
     void startBuzzer();
-    void stopBuzzer(bool cancelTimer);
+    void stopBuzzer();
 
-    static constexpr uint32_t kBuzzDurationMs = 4000;
-
-    std::shared_ptr<IBuzzerDriver>  driver_;
-    std::shared_ptr<ITimerService>  timer_;
     std::shared_ptr<ILogger>        logger_;
+    std::shared_ptr<IProcessSender> sender_;
+    std::shared_ptr<IFileLoader>    file_loader_;
+    std::shared_ptr<IBuzzerDriver>  driver_;
     State                           state_{State::WaitStart};
 };
 

--- a/include/core/buzzer_task/i_buzzer_task.hpp
+++ b/include/core/buzzer_task/i_buzzer_task.hpp
@@ -10,6 +10,9 @@ public:
 
     virtual void run() = 0;
     virtual bool send_message(const IThreadMessage& msg) = 0;
+
+    virtual void on_waiting(const std::vector<std::string>& payload) = 0;
+    virtual void on_buzzing(const std::vector<std::string>& payload) = 0;
 };
 
 } // namespace device_reminder

--- a/tests/core/test_app.cpp
+++ b/tests/core/test_app.cpp
@@ -32,6 +32,8 @@ class MockBuzzerTask : public device_reminder::IBuzzerTask {
 public:
     MOCK_METHOD(void, run, (), (override));
     MOCK_METHOD(bool, send_message, (const device_reminder::IThreadMessage& msg), (override));
+    MOCK_METHOD(void, on_waiting, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_buzzing, (const std::vector<std::string>&), (override));
 };
 
 // ロガーのモック


### PR DESCRIPTION
## Summary
- add `on_waiting`/`on_buzzing` APIs to `IBuzzerTask`
- refactor `BuzzerTask` to expose the new behaviour methods
- adapt tests and mocks for the new interface

## Testing
- `cmake ..` *(fails: unable to download googletest)*

------
https://chatgpt.com/codex/tasks/task_e_688ae7ed1220832899a30a1b8651e162