### PR TITLE
Implement BuzzerHandler using process messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ add_executable(test_app
     tests/core/test_human_task.cpp
     tests/core/test_human_handler.cpp
     tests/core/test_main_handler.cpp
+    tests/core/test_buzzer_handler.cpp
     tests/core/test_buzzer_task.cpp
     tests/core/test_bluetooth_task.cpp
     tests/infra/test_logger.cpp

--- a/include/core/buzzer_task/buzzer_handler.hpp
+++ b/include/core/buzzer_task/buzzer_handler.hpp
@@ -1,20 +1,25 @@
 #pragma once
 
-#include "infra/thread_message_operation/thread_message.hpp"
-#include "buzzer_task/buzzer_task.hpp"
+#include "core/interfaces/i_handler.hpp"
+#include "infra/logger/i_logger.hpp"
+#include "core/buzzer_task/i_buzzer_task.hpp"
+#include "infra/timer_service/i_timer_service.hpp"
+#include "infra/process_operation/process_message/i_process_message.hpp"
 #include <memory>
 
 namespace device_reminder {
 
-class BuzzerHandler {
+class BuzzerHandler : public IHandler {
 public:
-    explicit BuzzerHandler(std::shared_ptr<BuzzerTask> task)
-        : task_(std::move(task)) {}
-
-    void handle(const ThreadMessage& msg);
+    BuzzerHandler(std::shared_ptr<ILogger> logger,
+                 std::shared_ptr<IBuzzerTask> task,
+                 std::shared_ptr<ITimerService> timer);
+    void handle(std::shared_ptr<IProcessMessage> msg) override;
 
 private:
-    std::shared_ptr<BuzzerTask> task_;
+    std::shared_ptr<ILogger>       logger_;
+    std::shared_ptr<IBuzzerTask>   task_;
+    std::shared_ptr<ITimerService> timer_;
 };
 
 } // namespace device_reminder

--- a/src/core/buzzer_task/buzzer_handler.cpp
+++ b/src/core/buzzer_task/buzzer_handler.cpp
@@ -1,9 +1,36 @@
 #include "buzzer_task/buzzer_handler.hpp"
+#include "infra/process_operation/process_message/process_message_type.hpp"
 
 namespace device_reminder {
 
-void BuzzerHandler::handle(const ThreadMessage& msg) {
-    if (task_) task_->send_message(msg);
+BuzzerHandler::BuzzerHandler(std::shared_ptr<ILogger> logger,
+                             std::shared_ptr<IBuzzerTask> task,
+                             std::shared_ptr<ITimerService> timer)
+    : logger_(std::move(logger)), task_(std::move(task)), timer_(std::move(timer)) {
+    if (logger_) logger_->info("BuzzerHandler created");
+}
+
+void BuzzerHandler::handle(std::shared_ptr<IProcessMessage> msg) {
+    if (!msg || !task_) return;
+
+    switch (msg->type()) {
+    case ProcessMessageType::StartBuzzing:
+        if (timer_) timer_->start();
+        task_->on_buzzing(msg->payload());
+        if (logger_) logger_->info("StartBuzzing");
+        break;
+    case ProcessMessageType::StopBuzzing:
+    case ProcessMessageType::BuzzTimeout:
+        if (timer_) timer_->stop();
+        task_->on_waiting(msg->payload());
+        if (logger_) {
+            logger_->info(msg->type() == ProcessMessageType::StopBuzzing ?
+                          "StopBuzzing" : "BuzzTimeout");
+        }
+        break;
+    default:
+        break;
+    }
 }
 
 } // namespace device_reminder

--- a/tests/core/test_buzzer_handler.cpp
+++ b/tests/core/test_buzzer_handler.cpp
@@ -1,0 +1,73 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "buzzer_task/buzzer_handler.hpp"
+#include "infra/process_operation/process_message/process_message.hpp"
+
+using ::testing::StrictMock;
+using ::testing::NiceMock;
+
+namespace device_reminder {
+
+class MockBuzzerTask : public IBuzzerTask {
+public:
+    void run() override {}
+    bool send_message(const IThreadMessage&) override { return true; }
+    MOCK_METHOD(void, on_waiting, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_buzzing, (const std::vector<std::string>&), (override));
+};
+
+class MockTimer : public ITimerService {
+public:
+    MOCK_METHOD(void, start, (), (override));
+    MOCK_METHOD(void, stop, (), (override));
+};
+
+class DummyLogger : public ILogger {
+public:
+    void info(const std::string&) override {}
+    void error(const std::string&) override {}
+    void warn(const std::string&) override {}
+};
+
+TEST(BuzzerHandlerTest, StartBuzzingStartsTimerAndCallsTask) {
+    auto task = std::make_shared<StrictMock<MockBuzzerTask>>();
+    auto timer = std::make_shared<StrictMock<MockTimer>>();
+    auto logger = std::make_shared<DummyLogger>();
+    BuzzerHandler handler(logger, task, timer);
+
+    EXPECT_CALL(*task, on_buzzing(testing::_)).Times(1);
+    EXPECT_CALL(*timer, start()).Times(1);
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+TEST(BuzzerHandlerTest, StopBuzzingStopsTimerAndCallsTask) {
+    auto task = std::make_shared<StrictMock<MockBuzzerTask>>();
+    auto timer = std::make_shared<StrictMock<MockTimer>>();
+    auto logger = std::make_shared<DummyLogger>();
+    BuzzerHandler handler(logger, task, timer);
+
+    EXPECT_CALL(*task, on_waiting(testing::_)).Times(1);
+    EXPECT_CALL(*timer, stop()).Times(1);
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StopBuzzing, std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+TEST(BuzzerHandlerTest, TimeoutStopsTimerAndCallsTask) {
+    auto task = std::make_shared<StrictMock<MockBuzzerTask>>();
+    auto timer = std::make_shared<StrictMock<MockTimer>>();
+    auto logger = std::make_shared<DummyLogger>();
+    BuzzerHandler handler(logger, task, timer);
+
+    EXPECT_CALL(*task, on_waiting(testing::_)).Times(1);
+    EXPECT_CALL(*timer, stop()).Times(1);
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::BuzzTimeout, std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+} // namespace device_reminder
+


### PR DESCRIPTION
## Summary
- update BuzzerHandler to implement `IHandler`
- add timer and logger support
- create new tests for BuzzerHandler
- include the new tests in CMake build

## Testing
- `cmake -S . -B build` *(fails: unable to fetch googletest)*
- `cmake --build build` *(fails: no Makefile due to previous error)*

------
https://chatgpt.com/codex/tasks/task_e_688aeaa0561c8328b90b850bb8546d67