### PR TITLE
Add BluetoothHandler module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(test_app
     tests/core/test_human_handler.cpp
     tests/core/test_main_handler.cpp
     tests/core/test_buzzer_task.cpp
+    tests/core/test_bluetooth_handler.cpp
     tests/core/test_bluetooth_task.cpp
     tests/infra/test_logger.cpp
     src/infra/logger/logger.cpp
@@ -55,6 +56,7 @@ add_executable(test_app
     src/core/buzzer_task/buzzer_task.cpp
     src/core/buzzer_task/buzzer_handler.cpp
     src/core/bluetooth_task/bluetooth_task.cpp
+    src/core/bluetooth_task/bluetooth_handler.cpp
 )
 
 # GPIODriver tests

--- a/include/core/bluetooth_task/bluetooth_handler.hpp
+++ b/include/core/bluetooth_task/bluetooth_handler.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "core/interfaces/i_handler.hpp"
+#include "core/bluetooth_task/i_bluetooth_task.hpp"
+#include "infra/logger/i_logger.hpp"
+#include "infra/process_operation/process_message/i_process_message.hpp"
+
+#include <memory>
+
+namespace device_reminder {
+
+class BluetoothHandler : public IHandler {
+public:
+    BluetoothHandler(std::shared_ptr<ILogger> logger,
+                     std::shared_ptr<IBluetoothTask> task);
+
+    void handle(std::shared_ptr<IProcessMessage> msg) override;
+
+private:
+    std::shared_ptr<ILogger>       logger_;
+    std::shared_ptr<IBluetoothTask> task_;
+};
+
+} // namespace device_reminder

--- a/src/core/bluetooth_task/bluetooth_handler.cpp
+++ b/src/core/bluetooth_task/bluetooth_handler.cpp
@@ -1,0 +1,21 @@
+#include "bluetooth_task/bluetooth_handler.hpp"
+#include "infra/process_operation/process_message/process_message_type.hpp"
+
+namespace device_reminder {
+
+BluetoothHandler::BluetoothHandler(std::shared_ptr<ILogger> logger,
+                                   std::shared_ptr<IBluetoothTask> task)
+    : logger_(std::move(logger)), task_(std::move(task)) {
+    if (logger_) logger_->info("BluetoothHandler created");
+}
+
+void BluetoothHandler::handle(std::shared_ptr<IProcessMessage> msg) {
+    if (!msg || !task_) return;
+
+    if (msg->type() == ProcessMessageType::RequestBluetoothScan) {
+        if (logger_) logger_->info("RequestBluetoothScan");
+        task_->on_waiting(msg->payload());
+    }
+}
+
+} // namespace device_reminder

--- a/tests/core/test_bluetooth_handler.cpp
+++ b/tests/core/test_bluetooth_handler.cpp
@@ -1,0 +1,45 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "bluetooth_task/bluetooth_handler.hpp"
+#include "infra/process_operation/process_message/process_message.hpp"
+
+using ::testing::StrictMock;
+
+namespace device_reminder {
+
+class MockBluetoothTask : public IBluetoothTask {
+public:
+    MOCK_METHOD(void, on_waiting, (const std::vector<std::string>&), (override));
+};
+
+class DummyLogger : public ILogger {
+public:
+    void info(const std::string&) override {}
+    void error(const std::string&) override {}
+    void warn(const std::string&) override {}
+};
+
+TEST(BluetoothHandlerTest, RequestScanCallsTask) {
+    auto task = std::make_shared<StrictMock<MockBluetoothTask>>();
+    auto logger = std::make_shared<DummyLogger>();
+    BluetoothHandler handler(logger, task);
+
+    EXPECT_CALL(*task, on_waiting(testing::_)).Times(1);
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::RequestBluetoothScan, std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+TEST(BluetoothHandlerTest, OtherMessageIgnored) {
+    auto task = std::make_shared<StrictMock<MockBluetoothTask>>();
+    auto logger = std::make_shared<DummyLogger>();
+    BluetoothHandler handler(logger, task);
+
+    EXPECT_CALL(*task, on_waiting(testing::_)).Times(0);
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartHumanDetection, std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+} // namespace device_reminder


### PR DESCRIPTION
## Summary
- implement `BluetoothHandler` to manage Bluetooth scan requests
- add unit tests for the new handler
- build updates for new sources and tests

## Testing
- `cmake ..` *(fails: source directory external/googletest does not contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_688aeb780aa48328ad1f0c081f597ce5