### PR TITLE
Implement BluetoothProcess

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable(test_app
     src/core/buzzer_task/buzzer_handler.cpp
     src/core/bluetooth_task/bluetooth_task.cpp
     src/core/bluetooth_task/bluetooth_handler.cpp
+    src/core/bluetooth_task/bluetooth_process.cpp
 )
 
 # GPIODriver tests

--- a/include/core/bluetooth_task/bluetooth_process.hpp
+++ b/include/core/bluetooth_task/bluetooth_process.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "core/bluetooth_task/i_bluetooth_process.hpp"
+#include "infra/process_operation/process_base/process_base.hpp"
+#include "infra/watch_dog/i_watch_dog.hpp"
+#include "core/interfaces/i_handler.hpp"
+#include "core/bluetooth_task/i_bluetooth_task.hpp"
+
+#include <memory>
+
+namespace device_reminder {
+
+class BluetoothProcess : public ProcessBase, public IBluetoothProcess {
+public:
+    BluetoothProcess(std::shared_ptr<IProcessQueue> queue,
+                     std::shared_ptr<IProcessReceiver> receiver,
+                     std::shared_ptr<IProcessDispatcher> dispatcher,
+                     std::shared_ptr<IProcessSender> sender,
+                     std::shared_ptr<IFileLoader> file_loader,
+                     std::shared_ptr<ILogger> logger,
+                     std::shared_ptr<IWatchDog> watch_dog,
+                     std::shared_ptr<IHandler> handler,
+                     std::shared_ptr<IBluetoothTask> task);
+
+    void run() override;
+    void stop() override;
+
+private:
+    std::shared_ptr<IBluetoothTask> bluetooth_task_;
+    std::shared_ptr<IHandler>       handler_;
+    std::shared_ptr<IWatchDog>      watch_dog_;
+};
+
+} // namespace device_reminder

--- a/include/core/bluetooth_task/i_bluetooth_process.hpp
+++ b/include/core/bluetooth_task/i_bluetooth_process.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace device_reminder {
+
+class IBluetoothProcess {
+public:
+    virtual ~IBluetoothProcess() = default;
+    virtual void run() = 0;
+    virtual void stop() = 0;
+};
+
+} // namespace device_reminder

--- a/src/core/bluetooth_task/bluetooth_process.cpp
+++ b/src/core/bluetooth_task/bluetooth_process.cpp
@@ -1,0 +1,40 @@
+#include "bluetooth_task/bluetooth_process.hpp"
+#include "infra/logger/i_logger.hpp"
+
+namespace device_reminder {
+
+BluetoothProcess::BluetoothProcess(std::shared_ptr<IProcessQueue> queue,
+                                   std::shared_ptr<IProcessReceiver> receiver,
+                                   std::shared_ptr<IProcessDispatcher> dispatcher,
+                                   std::shared_ptr<IProcessSender> sender,
+                                   std::shared_ptr<IFileLoader> file_loader,
+                                   std::shared_ptr<ILogger> logger,
+                                   std::shared_ptr<IWatchDog> watch_dog,
+                                   std::shared_ptr<IHandler> handler,
+                                   std::shared_ptr<IBluetoothTask> task)
+    : ProcessBase(std::move(queue),
+                  std::move(receiver),
+                  std::move(dispatcher),
+                  std::move(sender),
+                  std::move(file_loader),
+                  std::move(logger),
+                  "BluetoothProcess")
+    , bluetooth_task_(std::move(task))
+    , handler_(std::move(handler))
+    , watch_dog_(std::move(watch_dog))
+{
+    if (logger_) logger_->info("BluetoothProcess created");
+}
+
+void BluetoothProcess::run() {
+    if (watch_dog_) watch_dog_->start();
+    ProcessBase::run();
+    if (watch_dog_) watch_dog_->stop();
+}
+
+void BluetoothProcess::stop() {
+    if (watch_dog_) watch_dog_->stop();
+    ProcessBase::stop();
+}
+
+} // namespace device_reminder


### PR DESCRIPTION
## Summary
- 新たにBluetoothProcessを追加してProcessBaseから派生
- Bluetoothスキャンプロセス用インタフェースを実装
- CMakeListsにBluetoothProcessを追加

## Testing
- `cmake ..` (失敗: 外部依存が取得できないため)


------
https://chatgpt.com/codex/tasks/task_e_688aed433b208328a52585787554d0fd