### PR TITLE
Implement BuzzerProcess

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ add_executable(test_app
 
     src/core/buzzer_task/buzzer_task.cpp
     src/core/buzzer_task/buzzer_handler.cpp
+    src/core/buzzer_task/buzzer_process.cpp
     src/core/bluetooth_task/bluetooth_task.cpp
     src/core/bluetooth_task/bluetooth_handler.cpp
 )

--- a/include/core/buzzer_task/buzzer_process.hpp
+++ b/include/core/buzzer_task/buzzer_process.hpp
@@ -1,20 +1,27 @@
 #pragma once
 
-#include "infra/process/process_base.hpp"
-#include "buzzer_task/buzzer_handler.hpp"
+#include "core/buzzer_task/i_buzzer_process.hpp"
+#include "infra/process_operation/process_base/process_base.hpp"
+#include "infra/watch_dog/i_watch_dog.hpp"
+
 #include <memory>
 
 namespace device_reminder {
 
-class BuzzerProcess : public ProcessBase {
+class BuzzerProcess : public ProcessBase, public IBuzzerProcess {
 public:
-    BuzzerProcess(const std::string& mq_name,
-                  std::shared_ptr<BuzzerTask> task,
-                  std::shared_ptr<ILogger> logger)
-        : ProcessBase(mq_name,
-                      std::make_shared<BuzzerHandler>(std::move(task)),
-                      std::move(logger),
-                      2) {}
+    BuzzerProcess(std::shared_ptr<IProcessReceiver> receiver,
+                  std::shared_ptr<IProcessSender> sender,
+                  std::shared_ptr<IProcessQueue> queue,
+                  std::shared_ptr<IFileLoader> file_loader,
+                  std::shared_ptr<ILogger> logger,
+                  std::shared_ptr<IWatchDog> watch_dog);
+
+    void run() override;
+    void stop() override;
+
+private:
+    std::shared_ptr<IWatchDog> watch_dog_;
 };
 
 } // namespace device_reminder

--- a/include/core/buzzer_task/i_buzzer_process.hpp
+++ b/include/core/buzzer_task/i_buzzer_process.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace device_reminder {
+
+class IBuzzerProcess {
+public:
+    virtual ~IBuzzerProcess() = default;
+    virtual void run() = 0;
+    virtual void stop() = 0;
+};
+
+} // namespace device_reminder

--- a/src/core/buzzer_task/buzzer_process.cpp
+++ b/src/core/buzzer_task/buzzer_process.cpp
@@ -1,0 +1,36 @@
+#include "buzzer_task/buzzer_process.hpp"
+
+namespace device_reminder {
+
+BuzzerProcess::BuzzerProcess(std::shared_ptr<IProcessReceiver> receiver,
+                             std::shared_ptr<IProcessSender> sender,
+                             std::shared_ptr<IProcessQueue> queue,
+                             std::shared_ptr<IFileLoader> file_loader,
+                             std::shared_ptr<ILogger> logger,
+                             std::shared_ptr<IWatchDog> watch_dog)
+    : ProcessBase(std::move(queue),
+                  std::move(receiver),
+                  nullptr,
+                  std::move(sender),
+                  std::move(file_loader),
+                  std::move(logger),
+                  "BuzzerProcess"),
+      watch_dog_(std::move(watch_dog))
+{
+    if (logger_) logger_->info("BuzzerProcess created");
+}
+
+void BuzzerProcess::run()
+{
+    if (watch_dog_) watch_dog_->start();
+    ProcessBase::run();
+    if (watch_dog_) watch_dog_->stop();
+}
+
+void BuzzerProcess::stop()
+{
+    if (watch_dog_) watch_dog_->stop();
+    ProcessBase::stop();
+}
+
+} // namespace device_reminder


### PR DESCRIPTION
## Summary
- BuzzerProcess用インタフェース `IBuzzerProcess` を追加
- `BuzzerProcess` を `ProcessBase` 継承型として実装
- 実装に対応するソースファイルを新規作成
- CMakeLists に BuzzerProcess ソースを追加

## Testing
- `cmake ..` *(失敗: 依存ライブラリ取得のためのネットワークアクセスが遮断)*

------
https://chatgpt.com/codex/tasks/task_e_688aecf2fa70832890f37fcdf61e57bb