### PR TITLE
Change BuzzerDriver interface to on/off

### DIFF
--- a/include/core/buzzer_task/buzzer_task.hpp
+++ b/include/core/buzzer_task/buzzer_task.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/thread_message_operation/i_thread_message.hpp"
+#include "infra/thread_operation/thread_message/i_thread_message.hpp"
 #include "buzzer_task/i_buzzer_task.hpp"
 #include "infra/buzzer_driver/i_buzzer_driver.hpp"
 #include "infra/logger/i_logger.hpp"

--- a/include/core/buzzer_task/i_buzzer_task.hpp
+++ b/include/core/buzzer_task/i_buzzer_task.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/thread_message_operation/i_thread_message.hpp"
+#include "infra/thread_operation/thread_message/i_thread_message.hpp"
 
 namespace device_reminder {
 

--- a/include/infra/buzzer_driver/buzzer_driver.hpp
+++ b/include/infra/buzzer_driver/buzzer_driver.hpp
@@ -1,7 +1,8 @@
 #pragma once
 #include "i_buzzer_driver.hpp"
 #include "infra/logger/i_logger.hpp"
-#include "infra/gpio_driver/i_gpio_driver.hpp"
+#include "infra/gpio_operation/gpio_setter/i_gpio_setter.hpp"
+#include "infra/file_loader/i_file_loader.hpp"
 #include <memory>
 #include <string>
 
@@ -9,36 +10,18 @@ namespace device_reminder {
 
 class BuzzerDriver : public IBuzzerDriver {
 public:
-    BuzzerDriver(IGPIODriver* gpio,
-                 ILogger* logger = nullptr,
-                 std::string chip = "/dev/gpiochip0",
-                 unsigned int line = 18,
-                 double freq_hz = 261.63,
-                 double duty = 0.5,
-                 std::string sysfs_base = "/sys/class/pwm");
-    ~BuzzerDriver() override;
+    BuzzerDriver(std::shared_ptr<IFileLoader> loader,
+                 std::shared_ptr<ILogger> logger,
+                 std::shared_ptr<IGPIOSetter> gpio);
+    ~BuzzerDriver() override = default;
 
-    bool start() override;
-    bool stop() override;
+    void on() override;
+    void off() override;
 
 private:
-    bool exportPwm();
-    bool unexportPwm();
-    bool setFrequency(double hz);
-    bool setDutyCycle(double ratio);
-    bool enable(bool on);
-
-    std::string chipPath_;
-    std::string sysfsBase_;
-    unsigned int line_;
-    double freq_;
-    double duty_;
-    bool isOn_{false};
-    int pwmChip_;
-    int pwmChannel_;
-    unsigned int periodNs_{0};
-    IGPIODriver* gpio_;
-    ILogger* logger_;
-};
+    std::shared_ptr<IFileLoader> loader_;
+    std::shared_ptr<ILogger>     logger_;
+    std::shared_ptr<IGPIOSetter> gpio_;
+}; 
 
 } // namespace device_reminder

--- a/include/infra/buzzer_driver/i_buzzer_driver.hpp
+++ b/include/infra/buzzer_driver/i_buzzer_driver.hpp
@@ -6,8 +6,8 @@ namespace device_reminder {
 class IBuzzerDriver {
 public:
     virtual ~IBuzzerDriver() = default;
-    virtual bool start() = 0;   // true: 成功
-    virtual bool stop()  = 0;   // true: 成功
-}; 
+    virtual void on()  = 0;   // ブザーON
+    virtual void off() = 0;   // ブザーOFF
+};
 
 } // namespace device_reminder

--- a/include/infra/process_operation/process_base/i_process_base.hpp
+++ b/include/infra/process_operation/process_base/i_process_base.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <memory>
 
-#include "thread_message_operation/i_message_queue.hpp"
+#include "infra/thread_operation/thread_message/i_message_queue.hpp"
 
 /// 事前宣言 ― 依存インターフェース
 class IThreadMessageQueue;

--- a/src/core/buzzer_task/buzzer_task.cpp
+++ b/src/core/buzzer_task/buzzer_task.cpp
@@ -34,12 +34,12 @@ void BuzzerTask::onMessage(const IThreadMessage& msg) {
 }
 
 void BuzzerTask::startBuzzer() {
-    if (driver_) driver_->start();
+    if (driver_) driver_->on();
     state_ = State::Buzzing;
 }
 
 void BuzzerTask::stopBuzzer() {
-    if (driver_) driver_->stop();
+    if (driver_) driver_->off();
     state_ = State::WaitStart;
 }
 

--- a/src/infra/buzzer_driver/buzzer_driver.cpp
+++ b/src/infra/buzzer_driver/buzzer_driver.cpp
@@ -1,122 +1,36 @@
 #include "buzzer_driver/buzzer_driver.hpp"
-#include <filesystem>
-#include <fstream>
-#include <cmath>
-#include <stdexcept>
 
 namespace device_reminder {
-namespace fs = std::filesystem;
 
-BuzzerDriver::BuzzerDriver(IGPIODriver* gpio,
-                           ILogger* logger,
-                           std::string chip,
-                           unsigned int line,
-                           double freq_hz,
-                           double duty,
-                           std::string sysfs_base)
-    : chipPath_(std::move(chip)),
-      sysfsBase_(std::move(sysfs_base)),
-      line_(line),
-      freq_(freq_hz),
-      duty_(duty),
-      pwmChip_(0),
-      pwmChannel_(0),
-      gpio_(gpio),
-      logger_(logger)
+BuzzerDriver::BuzzerDriver(std::shared_ptr<IFileLoader> loader,
+                           std::shared_ptr<ILogger> logger,
+                           std::shared_ptr<IGPIOSetter> gpio)
+    : loader_(std::move(loader)),
+      logger_(std::move(logger)),
+      gpio_(std::move(gpio))
 {
-    try {
-        if (logger_) logger_->info("BuzzerDriver created");
-        exportPwm();
-        setFrequency(freq_);
-        setDutyCycle(duty_);
-        enable(false);
-    } catch (const std::exception& ex) {
-        if (logger_) logger_->error(std::string("BuzzerDriver init failed: ") + ex.what());
-        throw;
+    if (logger_) logger_->info("BuzzerDriver created");
+    if (loader_) {
+        try {
+            loader_->load_int(); // 設定値読み込み (エラー確認のみ)
+        } catch (...) {
+            if (logger_) logger_->error("Failed to load buzzer config");
+        }
     }
 }
 
-BuzzerDriver::~BuzzerDriver() {
-    stop();
-    unexportPwm();
-    if (logger_) logger_->info("BuzzerDriver destroyed");
-}
-
-bool BuzzerDriver::start() {
-    if (isOn_) return true;
-    if (!setFrequency(freq_)) return false;
-    if (!setDutyCycle(duty_)) return false;
-    if (!enable(true)) return false;
-    isOn_ = true;
-    return true;
-}
-
-bool BuzzerDriver::stop() {
-    if (!isOn_) return true;
-    if (!enable(false)) return false;
-    isOn_ = false;
-    return true;
-}
-
-bool BuzzerDriver::exportPwm() {
-    fs::path path = fs::path(sysfsBase_) / ("pwmchip" + std::to_string(pwmChip_)) / "export";
-    std::ofstream ofs(path);
-    if (!ofs) {
-        if (logger_) logger_->error("failed to open " + path.string());
-        return false;
+void BuzzerDriver::on() {
+    if (gpio_) {
+        gpio_->write(true);
     }
-    ofs << pwmChannel_;
-    return ofs.good();
+    if (logger_) logger_->info("buzzer on");
 }
 
-bool BuzzerDriver::unexportPwm() {
-    fs::path path = fs::path(sysfsBase_) / ("pwmchip" + std::to_string(pwmChip_)) / "unexport";
-    std::ofstream ofs(path);
-    if (!ofs) {
-        if (logger_) logger_->error("failed to open " + path.string());
-        return false;
+void BuzzerDriver::off() {
+    if (gpio_) {
+        gpio_->write(false);
     }
-    ofs << pwmChannel_;
-    return ofs.good();
-}
-
-bool BuzzerDriver::setFrequency(double hz) {
-    if (hz <= 0) return false;
-    periodNs_ = static_cast<unsigned int>(std::round(1e9 / hz));
-    fs::path path = fs::path(sysfsBase_) / ("pwmchip" + std::to_string(pwmChip_)) /
-                    ("pwm" + std::to_string(pwmChannel_)) / "period";
-    std::ofstream ofs(path);
-    if (!ofs) {
-        if (logger_) logger_->error("failed to open " + path.string());
-        return false;
-    }
-    ofs << periodNs_;
-    return ofs.good();
-}
-
-bool BuzzerDriver::setDutyCycle(double ratio) {
-    unsigned int duty_ns = static_cast<unsigned int>(periodNs_ * ratio);
-    fs::path path = fs::path(sysfsBase_) / ("pwmchip" + std::to_string(pwmChip_)) /
-                    ("pwm" + std::to_string(pwmChannel_)) / "duty_cycle";
-    std::ofstream ofs(path);
-    if (!ofs) {
-        if (logger_) logger_->error("failed to open " + path.string());
-        return false;
-    }
-    ofs << duty_ns;
-    return ofs.good();
-}
-
-bool BuzzerDriver::enable(bool on) {
-    fs::path path = fs::path(sysfsBase_) / ("pwmchip" + std::to_string(pwmChip_)) /
-                    ("pwm" + std::to_string(pwmChannel_)) / "enable";
-    std::ofstream ofs(path);
-    if (!ofs) {
-        if (logger_) logger_->error("failed to open " + path.string());
-        return false;
-    }
-    ofs << (on ? 1 : 0);
-    return ofs.good();
+    if (logger_) logger_->info("buzzer off");
 }
 
 } // namespace device_reminder

--- a/tests/core/test_app.cpp
+++ b/tests/core/test_app.cpp
@@ -12,6 +12,11 @@ namespace device_reminder {
 class MockMainTask : public device_reminder::IMainTask {
 public:
     MOCK_METHOD(void, run, (const device_reminder::IThreadMessage& msg), (override));
+    MOCK_METHOD(void, on_waiting_for_human, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_response_to_buzzer_task, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_response_to_human_task, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_cooldown, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_waiting_for_second_response, (const std::vector<std::string>&), (override));
 };
 
 class MockHumanTask : public device_reminder::IHumanTask {

--- a/tests/core/test_buzzer_task.cpp
+++ b/tests/core/test_buzzer_task.cpp
@@ -11,8 +11,8 @@ namespace device_reminder {
 
 class MockDriver : public IBuzzerDriver {
 public:
-    MOCK_METHOD(bool, start, (), (override));
-    MOCK_METHOD(bool, stop, (), (override));
+    MOCK_METHOD(void, on, (), (override));
+    MOCK_METHOD(void, off, (), (override));
 };
 
 
@@ -42,11 +42,11 @@ TEST(BuzzerTaskTest, StartAndTimeoutStopsBuzzer) {
 
     BuzzerTask task(logger, sender, loader, driver);
 
-    EXPECT_CALL(*driver, start());
+    EXPECT_CALL(*driver, on());
     task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 
-    EXPECT_CALL(*driver, stop());
+    EXPECT_CALL(*driver, off());
     task.send_message(ThreadMessage{ThreadMessageType::StopBuzzer});
     EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
 }
@@ -59,10 +59,10 @@ TEST(BuzzerTaskTest, ManualStopCancelsTimer) {
 
     BuzzerTask task(logger, sender, loader, driver);
 
-    EXPECT_CALL(*driver, start());
+    EXPECT_CALL(*driver, on());
     task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer});
 
-    EXPECT_CALL(*driver, stop());
+    EXPECT_CALL(*driver, off());
     task.send_message(ThreadMessage{ThreadMessageType::StopBuzzer});
     EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
 }
@@ -75,7 +75,7 @@ TEST(BuzzerTaskTest, IgnoreDuplicateStart) {
 
     BuzzerTask task(logger, sender, loader, driver);
 
-    EXPECT_CALL(*driver, start());
+    EXPECT_CALL(*driver, on());
     task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 

--- a/tests/infra/test_buzzer_driver.cpp
+++ b/tests/infra/test_buzzer_driver.cpp
@@ -2,9 +2,7 @@
 #include <gmock/gmock.h>
 
 #include "infra/buzzer_driver/buzzer_driver.hpp"
-#include "infra/gpio_driver/i_gpio_driver.hpp"
-#include <filesystem>
-#include <fstream>
+#include "infra/gpio_operation/gpio_setter/i_gpio_setter.hpp"
 
 using namespace device_reminder;
 using ::testing::NiceMock;
@@ -15,43 +13,20 @@ public:
     MOCK_METHOD(void, info, (const std::string&), (override));
     MOCK_METHOD(void, error, (const std::string&), (override));
 };
-class MockGPIO : public IGPIODriver {
+class MockGPIO : public IGPIOSetter {
 public:
     MOCK_METHOD(void, write, (bool), (override));
-    MOCK_METHOD(bool, read, (), (override));
-    MOCK_METHOD(void, setEdge, (EdgeType), (override));
-    MOCK_METHOD(void, waitForEdge, (), (override));
 };
 } // namespace
 
-TEST(BuzzerDriverTest, StartStopWritesSysfs) {
-    namespace fs = std::filesystem;
-    fs::path base = fs::temp_directory_path() / "pwm_test";
-    fs::remove_all(base);
-    fs::create_directories(base / "pwmchip0" / "pwm0");
-    std::ofstream(base / "pwmchip0" / "export");
-    std::ofstream(base / "pwmchip0" / "unexport");
-    std::ofstream(base / "pwmchip0" / "pwm0" / "period");
-    std::ofstream(base / "pwmchip0" / "pwm0" / "duty_cycle");
-    std::ofstream(base / "pwmchip0" / "pwm0" / "enable");
+TEST(BuzzerDriverTest, OnOffCallsGPIOWrite) {
+    auto gpio = std::make_shared<NiceMock<MockGPIO>>();
+    auto logger = std::make_shared<NiceMock<MockLogger>>();
+    BuzzerDriver driver(nullptr, logger, gpio);
 
-    NiceMock<MockGPIO> gpio;
-    NiceMock<MockLogger> logger;
-    BuzzerDriver driver(&gpio, &logger, "/dev/gpiochip0", 18, 261.63, 0.5, base.string());
+    EXPECT_CALL(*gpio, write(true)).Times(1);
+    driver.on();
 
-    std::string val;
-    std::ifstream(base / "pwmchip0" / "pwm0" / "enable") >> val;
-    EXPECT_EQ(val, "0");
-
-    EXPECT_TRUE(driver.start());
-    val.clear();
-    std::ifstream(base / "pwmchip0" / "pwm0" / "enable") >> val;
-    EXPECT_EQ(val, "1");
-
-    EXPECT_TRUE(driver.stop());
-    val.clear();
-    std::ifstream(base / "pwmchip0" / "pwm0" / "enable") >> val;
-    EXPECT_EQ(val, "0");
-
-    fs::remove_all(base);
+    EXPECT_CALL(*gpio, write(false)).Times(1);
+    driver.off();
 }


### PR DESCRIPTION
## Summary
- update `IBuzzerDriver` interface to `on()` and `off()`
- refactor `BuzzerDriver` to use `IGPIOSetter` and configuration loader
- adapt `BuzzerTask` and its tests to new interface
- simplify `BuzzerDriver` test
- fix include paths referencing thread_operation
- supplement missing mock methods in test_app

## Testing
- `bash run/setup.sh` *(fails: 403 Forbidden apt repositories)*
- `cmake --build .` *(fails to compile tests)*

------
https://chatgpt.com/codex/tasks/task_e_688b055dada08328935b809a4c04e95e