### PR TITLE
Refactor PIR driver interface

### DIFF
--- a/include/infra/pir_driver/i_pir_driver.hpp
+++ b/include/infra/pir_driver/i_pir_driver.hpp
@@ -6,8 +6,12 @@ class IPIRDriver {
 public:
     virtual ~IPIRDriver() = default;
 
-    // PIRセンサーの値を読み取る（0または1）
-    virtual int read() = 0;
+    // PIR センサーの監視を開始する
+    virtual void run() = 0;
+
+    // PIR センサーの監視を停止する
+    virtual void stop() = 0;
+
 };
 
 } // namespace device_reminder

--- a/include/infra/pir_driver/pir_driver.hpp
+++ b/include/infra/pir_driver/pir_driver.hpp
@@ -1,24 +1,36 @@
 #pragma once
 
 #include "pir_driver/i_pir_driver.hpp"
+#include "infra/file_loader/i_file_loader.hpp"
 #include "infra/gpio_operation/gpio_reader/i_gpio_reader.hpp"
-#include "infra/logger/logger.hpp" // ロガーのインターフェース（ILogger）を含むと仮定
+#include "infra/logger/i_logger.hpp"
+#include "infra/thread_operation/thread_sender/i_thread_sender.hpp"
 
+#include <memory>
 #include <string>
 
 namespace device_reminder {
 
 class PIRDriver : public IPIRDriver {
 public:
-    PIRDriver(IGPIOReader* gpio_driver, ILogger* logger);
+    PIRDriver(std::shared_ptr<IFileLoader> loader,
+              std::shared_ptr<ILogger> logger,
+              std::shared_ptr<IThreadSender> sender,
+              std::shared_ptr<IGPIOReader> gpio);
 
     ~PIRDriver() override;
 
-    int read() override;
+    void run() override;
+    void stop() override;
 
 private:
-    IGPIOReader* gpio_;
-    ILogger* logger_;
+    std::shared_ptr<IFileLoader> loader_;
+    std::shared_ptr<ILogger> logger_;
+    std::shared_ptr<IThreadSender> sender_;
+    std::shared_ptr<IGPIOReader> gpio_;
+    std::thread thread_;
+    std::atomic<bool> running_{false};
+    bool last_state_{false};
 };
 
 } // namespace device_reminder

--- a/src/core/app/app.cpp
+++ b/src/core/app/app.cpp
@@ -17,8 +17,8 @@ App::App(std::unique_ptr<IMainTask> main_task,
 int App::run() {
     try {
         main_task_->run(ThreadMessage(ThreadMessageType::StartBuzzing, {}));
-        human_task_->on_detecting(ThreadMessage(ThreadMessageType::HumanDetected, {}));
-        bluetooth_task_->on_waiting(ThreadMessage(ThreadMessageType::RequestBluetoothScan, {}));
+        human_task_->on_detecting({});
+        bluetooth_task_->on_waiting({});
         buzzer_task_->run();
     } catch (const std::exception& e) {
         logger_->error(std::string("[App::run] std::exception caught: ") + e.what());

--- a/src/core/human_task/human_task.cpp
+++ b/src/core/human_task/human_task.cpp
@@ -10,20 +10,23 @@ HumanTask::HumanTask(std::shared_ptr<ILogger> logger,
 }
 
 void HumanTask::on_detecting(const std::vector<std::string>&) {
-    if (!pir_) return;
-    int val = pir_->read();
-    if (val > 0 && sender_) {
-        sender_->send();
-        if (logger_) logger_->info("Human detected");
+    if (pir_) {
+        pir_->run();
     }
+    if (logger_) logger_->info("Human detection started");
 }
 
 void HumanTask::on_stopping(const std::vector<std::string>&) {
+    if (pir_) {
+        pir_->stop();
+    }
     if (logger_) logger_->info("Human detection stopped");
 }
 
 void HumanTask::on_cooldown(const std::vector<std::string>&) {
-    // intentionally do nothing
+    if (pir_) {
+        pir_->stop();
+    }
     if (logger_) logger_->info("Human detection cooldown");
 }
 

--- a/src/core/main_task/main_handler.cpp
+++ b/src/core/main_task/main_handler.cpp
@@ -1,5 +1,6 @@
 #include "main_task/main_handler.hpp"
 #include "infra/process_operation/process_message/process_message_type.hpp"
+#include "infra/process_operation/process_message/i_process_message.hpp"
 
 namespace device_reminder {
 

--- a/src/core/main_task/main_task.cpp
+++ b/src/core/main_task/main_task.cpp
@@ -1,5 +1,5 @@
 #include "main_task/main_task.hpp"
-#include "process_message_operation/process_message.hpp"
+#include "infra/process_operation/process_message/process_message.hpp"
 #include <algorithm>
 
 namespace device_reminder {
@@ -65,9 +65,7 @@ void MainTask::run(const IThreadMessage& msg) {
 
 void MainTask::on_waiting_for_human(const std::vector<std::string>&) {
     if (det_timer_)
-        det_timer_->start(4000,
-                          ProcessMessage{ThreadMessageType::ProcessingTimeout,
-                                         {std::to_string(static_cast<int>(TimerId::T_DET_TIMEOUT))}});
+        det_timer_->start();
     if (bluetooth_sender_)
         bluetooth_sender_->send();
     state_ = State::WaitDeviceResponse;
@@ -89,9 +87,7 @@ void MainTask::on_response_to_buzzer_task(const std::vector<std::string>& payloa
         if (buzzer_start_sender_)
             buzzer_start_sender_->send();
         if (cooldown_timer_)
-            cooldown_timer_->start(1000,
-                                   ProcessMessage{ThreadMessageType::ProcessingTimeout,
-                                                  {std::to_string(static_cast<int>(TimerId::T_COOLDOWN))}});
+            cooldown_timer_->start();
         state_ = State::ScanCooldown;
     }
     if (logger_) logger_->info("Device not found -> cooldown");
@@ -113,7 +109,7 @@ void MainTask::on_response_to_human_task(const std::vector<std::string>& payload
             human_start_sender_->send();
         if (buzzer_stop_sender_)
             buzzer_stop_sender_->send();
-        if (det_timer_ && det_timer_->active())
+        if (det_timer_)
             det_timer_->stop();
         state_ = State::WaitHumanDetect;
         if (logger_) logger_->info("Device found -> resume human detect");

--- a/tests/core/test_bluetooth_task.cpp
+++ b/tests/core/test_bluetooth_task.cpp
@@ -40,6 +40,7 @@ class DummyLogger : public ILogger {
 public:
     void info(const std::string&) override {}
     void error(const std::string&) override {}
+    void warn(const std::string&) override {}
 };
 
 TEST(BluetoothTaskTest, SendsDetectedTrueWhenDeviceFound) {

--- a/tests/core/test_buzzer_task.cpp
+++ b/tests/core/test_buzzer_task.cpp
@@ -32,6 +32,7 @@ class MockLogger : public ILogger {
 public:
     MOCK_METHOD(void, info, (const std::string&), (override));
     MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
 };
 
 TEST(BuzzerTaskTest, StartAndTimeoutStopsBuzzer) {
@@ -43,11 +44,11 @@ TEST(BuzzerTaskTest, StartAndTimeoutStopsBuzzer) {
     BuzzerTask task(logger, sender, loader, driver);
 
     EXPECT_CALL(*driver, on());
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer, {}});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 
     EXPECT_CALL(*driver, off());
-    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzer});
+    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzer, {}});
     EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
 }
 
@@ -60,10 +61,10 @@ TEST(BuzzerTaskTest, ManualStopCancelsTimer) {
     BuzzerTask task(logger, sender, loader, driver);
 
     EXPECT_CALL(*driver, on());
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer, {}});
 
     EXPECT_CALL(*driver, off());
-    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzer});
+    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzer, {}});
     EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
 }
 
@@ -76,10 +77,10 @@ TEST(BuzzerTaskTest, IgnoreDuplicateStart) {
     BuzzerTask task(logger, sender, loader, driver);
 
     EXPECT_CALL(*driver, on());
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer, {}});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer, {}});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 }
 

--- a/tests/core/test_human_task.cpp
+++ b/tests/core/test_human_task.cpp
@@ -10,7 +10,8 @@ namespace device_reminder {
 
 class MockPIR : public IPIRDriver {
 public:
-    MOCK_METHOD(int, read, (), (override));
+    MOCK_METHOD(void, run, (), (override));
+    MOCK_METHOD(void, stop, (), (override));
 };
 
 class MockSender : public IProcessSender {
@@ -25,14 +26,14 @@ public:
     void warn(const std::string&) override {}
 };
 
-TEST(HumanTaskTest, DetectingSendsMessageOnDetection) {
+TEST(HumanTaskTest, DetectingStartsDriver) {
     auto pir = std::make_shared<StrictMock<MockPIR>>();
     auto sender = std::make_shared<StrictMock<MockSender>>();
     auto logger = std::make_shared<DummyLogger>();
     HumanTask task(logger, pir, sender);
 
-    EXPECT_CALL(*pir, read()).WillOnce(::testing::Return(1));
-    EXPECT_CALL(*sender, send()).Times(1);
+    EXPECT_CALL(*pir, run()).Times(1);
+    EXPECT_CALL(*sender, send()).Times(0);
 
     task.on_detecting({});
 }
@@ -44,7 +45,7 @@ TEST(HumanTaskTest, StoppingDoesNotSend) {
     HumanTask task(logger, pir, sender);
 
     EXPECT_CALL(*sender, send()).Times(0);
-    EXPECT_CALL(*pir, read()).Times(0);
+    EXPECT_CALL(*pir, stop()).Times(1);
 
     task.on_stopping({});
 }
@@ -56,7 +57,7 @@ TEST(HumanTaskTest, CooldownDoesNothing) {
     HumanTask task(logger, pir, sender);
 
     EXPECT_CALL(*sender, send()).Times(0);
-    EXPECT_CALL(*pir, read()).Times(0);
+    EXPECT_CALL(*pir, stop()).Times(1);
 
     task.on_cooldown({});
 }

--- a/tests/core/test_main_task.cpp
+++ b/tests/core/test_main_task.cpp
@@ -13,9 +13,9 @@ namespace device_reminder {
 
 class MockTimer : public ITimerService {
 public:
-    MOCK_METHOD(void, start, (uint32_t, const ProcessMessage&), (override));
+    MOCK_METHOD(void, start, (), (override));
     MOCK_METHOD(void, stop, (), (override));
-    MOCK_METHOD(bool, active, (), (const, noexcept, override));
+    MOCK_METHOD(bool, active, (), (const, noexcept));
 };
 
 class MockSender : public IProcessSender {
@@ -34,6 +34,7 @@ class MockLogger : public ILogger {
 public:
     MOCK_METHOD(void, info, (const std::string&), (override));
     MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
 };
 
 TEST(MainTaskTest, HumanDetectedStartsScanAndTimer) {
@@ -49,7 +50,7 @@ TEST(MainTaskTest, HumanDetectedStartsScanAndTimer) {
 
     MainTask task(logger, file_loader, human_start, human_stop, bt_sender, buz_start, buz_stop, det_timer, cd_timer);
 
-    EXPECT_CALL(*det_timer, start(4000, testing::_));
+    EXPECT_CALL(*det_timer, start());
     EXPECT_CALL(*bt_sender, send());
 
     task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}});
@@ -75,7 +76,6 @@ TEST(MainTaskTest, DeviceDetectedStopsTimerAndNotifies) {
 
     EXPECT_CALL(*human_start, send());
     EXPECT_CALL(*buz_stop, send());
-    EXPECT_CALL(*det_timer, active()).WillOnce(testing::Return(true));
     EXPECT_CALL(*det_timer, stop());
 
     task.run(ThreadMessage{ThreadMessageType::RespondDeviceFound, {"phone"}});
@@ -99,7 +99,7 @@ TEST(MainTaskTest, DeviceNotDetectedStartsCooldown) {
     task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}});
 
     EXPECT_CALL(*buz_start, send());
-    EXPECT_CALL(*cd_timer, start(1000, testing::_));
+    EXPECT_CALL(*cd_timer, start());
     task.run(ThreadMessage{ThreadMessageType::RespondDeviceNotFound, {"other"}});
     EXPECT_EQ(task.state(), MainTask::State::ScanCooldown);
 }

--- a/tests/infra/test_buzzer_driver.cpp
+++ b/tests/infra/test_buzzer_driver.cpp
@@ -12,6 +12,7 @@ class MockLogger : public ILogger {
 public:
     MOCK_METHOD(void, info, (const std::string&), (override));
     MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
 };
 class MockGPIO : public IGPIOSetter {
 public:

--- a/tests/infra/test_local_message_queue.cpp
+++ b/tests/infra/test_local_message_queue.cpp
@@ -12,6 +12,7 @@ class MockLogger : public ILogger {
 public:
     MOCK_METHOD(void, info, (const std::string&), (override));
     MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
 };
 } // namespace
 

--- a/tests/infra/test_pir_driver.cpp
+++ b/tests/infra/test_pir_driver.cpp
@@ -2,7 +2,9 @@
 #include <gmock/gmock.h>
 
 #include "infra/pir_driver/pir_driver.hpp"
+#include "infra/file_loader/i_file_loader.hpp"
 #include "infra/gpio_operation/gpio_reader/i_gpio_reader.hpp"
+#include "infra/thread_operation/thread_sender/i_thread_sender.hpp"
 #include "infra/logger/i_logger.hpp"
 
 using namespace device_reminder;
@@ -17,16 +19,43 @@ class MockLogger : public ILogger {
 public:
     MOCK_METHOD(void, info, (const std::string&), (override));
     MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
+};
+class MockSender : public IThreadSender {
+public:
+    MOCK_METHOD(void, send, (), (override));
+};
+class DummyLoader : public IFileLoader {
+public:
+    int load_int() const override { return 0; }
+    std::string load_string() const override { return ""; }
+    std::vector<std::string> load_string_list() const override { return {}; }
 };
 } // namespace
 
-TEST(PIRDriverTest, InitCallsGPIO) {
+TEST(PIRDriverTest, RunDetectsChangeAndSendsMessage) {
     StrictMock<MockGPIO> gpio;
     StrictMock<MockLogger> logger;
+    StrictMock<MockSender> sender;
+    DummyLoader loader;
+
     EXPECT_CALL(logger, info(testing::_)).Times(testing::AtLeast(1));
+
+    auto driver = std::make_unique<PIRDriver>(
+        std::shared_ptr<IFileLoader>(&loader, [](IFileLoader*){}),
+        std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+        std::shared_ptr<IThreadSender>(&sender, [](IThreadSender*){}),
+        std::shared_ptr<IGPIOReader>(&gpio, [](IGPIOReader*){}));
+
     {
-        PIRDriver driver(&gpio, &logger);
+        testing::InSequence seq;
+        EXPECT_CALL(gpio, read()).WillOnce(testing::Return(false));
         EXPECT_CALL(gpio, read()).WillOnce(testing::Return(true));
-        EXPECT_EQ(driver.read(), 1);
+        EXPECT_CALL(gpio, read()).WillRepeatedly(testing::Return(true));
     }
+    EXPECT_CALL(sender, send()).Times(1);
+
+    driver->run();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    driver->stop();
 }

--- a/tests/infra/test_process_receiver.cpp
+++ b/tests/infra/test_process_receiver.cpp
@@ -15,6 +15,7 @@ class MockLogger : public ILogger {
 public:
     MOCK_METHOD(void, info, (const std::string&), (override));
     MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
 };
 
 class MockQueue : public IProcessQueue {

--- a/tests/infra/test_thread_queue.cpp
+++ b/tests/infra/test_thread_queue.cpp
@@ -13,6 +13,7 @@ class MockLogger : public ILogger {
 public:
   MOCK_METHOD(void, info, (const std::string &), (override));
   MOCK_METHOD(void, error, (const std::string &), (override));
+  MOCK_METHOD(void, warn, (const std::string &), (override));
 };
 } // namespace
 

--- a/tests/infra/test_thread_sender.cpp
+++ b/tests/infra/test_thread_sender.cpp
@@ -14,6 +14,7 @@ class MockLogger : public ILogger {
 public:
     MOCK_METHOD(void, info, (const std::string&), (override));
     MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
 };
 } // namespace
 

--- a/tests/infra/test_timer_service.cpp
+++ b/tests/infra/test_timer_service.cpp
@@ -21,6 +21,7 @@ class MockLogger : public ILogger {
 public:
     MOCK_METHOD(void, info, (const std::string&), (override));
     MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
 };
 } // namespace
 


### PR DESCRIPTION
## Summary
- update `IPIRDriver` and `PIRDriver` to expose only `run`/`stop`
- adjust `HumanTask` to start/stop driver instead of direct reads
- fix includes and build errors related to new paths
- update tests to match new driver behaviour and add missing `warn` mocks

## Testing
- `cmake --build .` *(fails: error in main_process.cpp and others)*

------
https://chatgpt.com/codex/tasks/task_e_688b0eb672b08328b516bcab987cf0be