### PR TITLE
Add comprehensive logger tests

### DIFF
--- a/tests/infra/test_logger.cpp
+++ b/tests/infra/test_logger.cpp
@@ -5,6 +5,8 @@
 
 #include <spdlog/logger.h>
 #include <spdlog/sinks/sink.h>
+#include <spdlog/sinks/basic_file_sink.h>
+#include <fstream>
 
 using ::testing::StrictMock;
 
@@ -42,5 +44,58 @@ TEST(LoggerTest, ErrorOutputsToSink) {
     })));
 
     logger.error(message);
+}
+
+TEST(LoggerTest, WarnOutputsToSink) {
+    auto sink = std::make_shared<StrictMock<MockSink>>();
+    auto spdlogger = std::make_shared<spdlog::logger>("test", sink);
+    device_reminder::Logger logger(spdlogger);
+
+    const std::string message = "warn message";
+
+    EXPECT_CALL(*sink, log(testing::Truly([&](const spdlog::details::log_msg& msg) {
+        return msg.level == spdlog::level::warn && msg.payload == message;
+    })));
+
+    logger.warn(message);
+}
+
+TEST(LoggerTest, FileSinkWritesLog) {
+    const std::string filename = "log.txt";
+    auto sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(filename, true);
+    auto spdlogger = std::make_shared<spdlog::logger>("test", sink);
+    device_reminder::Logger logger(spdlogger);
+
+    const std::string message = "file output message";
+    logger.info(message);
+    spdlogger->flush();
+
+    std::ifstream ifs(filename);
+    ASSERT_TRUE(ifs.is_open());
+    std::string line;
+    bool found = false;
+    while (std::getline(ifs, line)) {
+        if (line.find(message) != std::string::npos) {
+            found = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+class ThrowSink : public spdlog::sinks::sink {
+public:
+    void log(const spdlog::details::log_msg&) override { throw std::runtime_error("boom"); }
+    void flush() override {}
+    void set_pattern(const std::string&) override {}
+    void set_formatter(std::unique_ptr<spdlog::formatter>) override {}
+};
+
+TEST(LoggerTest, PropagatesExceptionsFromSink) {
+    auto sink = std::make_shared<ThrowSink>();
+    auto spdlogger = std::make_shared<spdlog::logger>("test", sink);
+    device_reminder::Logger logger(spdlogger);
+
+    EXPECT_NO_THROW(logger.info("boom"));
 }
 


### PR DESCRIPTION
## Summary
- test logger warn output
- test file sink writes log entry
- ensure exceptions from sinks are not propagated

## Testing
- `g++ -std=c++17 -Iinclude -Iinclude/infra -Iinclude/core -Iexternal/spdlog/include -Iexternal/googletest/googletest/include -Iexternal/googletest/googlemock/include tests/infra/test_logger.cpp src/infra/logger/logger.cpp build/lib/libgtest.a build/lib/libgmock.a build/lib/libgtest_main.a build/external/spdlog/libspdlog.a -pthread -o build/bin/test_logger_manual`
- `./build/bin/test_logger_manual > /tmp/test_run.log`


------
https://chatgpt.com/codex/tasks/task_e_688b088f9a848328bedf8142ab944e58