### PR TITLE
Add ThreadMessage unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ add_executable(test_infra_extra
     tests/infra/test_thread_sender.cpp
     tests/infra/test_thread_queue.cpp
     tests/infra/test_thread_dispatcher.cpp
+    tests/infra/test_thread_message.cpp
     tests/infra/test_pir_driver.cpp
     tests/infra/test_timer_service.cpp
     tests/infra/test_watch_dog.cpp

--- a/tests/infra/test_thread_message.cpp
+++ b/tests/infra/test_thread_message.cpp
@@ -1,0 +1,39 @@
+#include <gtest/gtest.h>
+#include "infra/thread_operation/thread_message/thread_message.hpp"
+
+using namespace device_reminder;
+
+TEST(ThreadMessageTest, ConstructorStoresValues) {
+    ThreadMessage msg(ThreadMessageType::StartBuzzing, {"1"});
+    EXPECT_EQ(msg.type(), ThreadMessageType::StartBuzzing);
+    std::vector<std::string> expected{"1"};
+    EXPECT_EQ(msg.payload(), expected);
+}
+
+TEST(ThreadMessageTest, HandlesUnknownType) {
+    ThreadMessage msg(ThreadMessageType::Unknown, {});
+    EXPECT_EQ(msg.type(), ThreadMessageType::Unknown);
+    EXPECT_TRUE(msg.payload().empty());
+}
+
+TEST(ThreadMessageTest, HandlesInvalidEnum) {
+    ThreadMessage msg(static_cast<ThreadMessageType>(999), {"x"});
+    EXPECT_EQ(static_cast<int>(msg.type()), 999);
+    std::vector<std::string> expected{"x"};
+    EXPECT_EQ(msg.payload(), expected);
+    EXPECT_EQ(msg.to_string(), std::string("ThreadMessage{999,[x]}"));
+}
+
+TEST(ThreadMessageTest, CloneCreatesEqualCopy) {
+    ThreadMessage original(ThreadMessageType::RespondDeviceFound, {"phone", "watch"});
+    auto copy = original.clone();
+    ASSERT_NE(copy, nullptr);
+    EXPECT_EQ(copy->type(), original.type());
+    EXPECT_EQ(copy->payload(), original.payload());
+}
+
+TEST(ThreadMessageTest, ToStringFormatsCorrectly) {
+    ThreadMessage msg(ThreadMessageType::StartBuzzing, {"1"});
+    EXPECT_EQ(msg.to_string(), std::string("ThreadMessage{7,[1]}"));
+}
+


### PR DESCRIPTION
## Summary
- add new unit tests for ThreadMessage class covering constructor, clone and to_string
- register the new test source in the build system

## Testing
- `g++ -std=c++17 tests/infra/test_thread_message.cpp ... -lgtest -lgtest_main -pthread`
- `./test_thread_message`

------
https://chatgpt.com/codex/tasks/task_e_688b0e33ca488328a144c8c80d257007