### PR TITLE
Unify message type wording

### DIFF
--- a/src/core/buzzer_task/buzzer_task.cpp
+++ b/src/core/buzzer_task/buzzer_task.cpp
@@ -22,10 +22,10 @@ bool BuzzerTask::send_message(const IThreadMessage& msg) {
 
 void BuzzerTask::onMessage(const IThreadMessage& msg) {
     switch (msg.type()) {
-    case ThreadMessageType::StartBuzzer:
+    case ThreadMessageType::StartBuzzing:
         if (state_ == State::WaitStart) startBuzzer();
         break;
-    case ThreadMessageType::StopBuzzer:
+    case ThreadMessageType::StopBuzzing:
         if (state_ == State::Buzzing) stopBuzzer();
         break;
     default:

--- a/tests/core/buzzer_task/test_buzzer_task.cpp
+++ b/tests/core/buzzer_task/test_buzzer_task.cpp
@@ -44,11 +44,11 @@ TEST(BuzzerTaskTest, StartAndTimeoutStopsBuzzer) {
     BuzzerTask task(logger, sender, loader, driver);
 
     EXPECT_CALL(*driver, on());
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 
     EXPECT_CALL(*driver, off());
-    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzer, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzing, {}});
     EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
 }
 
@@ -61,10 +61,10 @@ TEST(BuzzerTaskTest, ManualStopCancelsTimer) {
     BuzzerTask task(logger, sender, loader, driver);
 
     EXPECT_CALL(*driver, on());
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}});
 
     EXPECT_CALL(*driver, off());
-    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzer, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzing, {}});
     EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
 }
 
@@ -77,10 +77,10 @@ TEST(BuzzerTaskTest, IgnoreDuplicateStart) {
     BuzzerTask task(logger, sender, loader, driver);
 
     EXPECT_CALL(*driver, on());
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzer, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 }
 

--- a/tests/infra/process_operation/test_process_queue.cpp
+++ b/tests/infra/process_operation/test_process_queue.cpp
@@ -17,7 +17,7 @@ TEST(MessageQueueTest, PushAndPop) {
     auto logger = std::make_shared<Logger>();
     auto codec = std::make_shared<MessageCodec>();
     ProcessQueue mq(logger, codec, name);
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzer,
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing,
                                                std::vector<std::string>{"1"});
     mq.push(msg);
     auto res = mq.pop();

--- a/tests/infra/process_operation/test_process_sender.cpp
+++ b/tests/infra/process_operation/test_process_sender.cpp
@@ -19,7 +19,7 @@ TEST(MessageSenderTest, EnqueueSendsMessage) {
     auto logger = std::make_shared<Logger>();
     auto codec = std::make_shared<MessageCodec>();
     auto queue = std::make_shared<ProcessQueue>(logger, codec, name);
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzer, std::vector<std::string>{"1"});
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{"1"});
     ProcessSender sender(queue, msg);
 
     sender.send();

--- a/tests/infra/thread_operation/test_thread_receiver.cpp
+++ b/tests/infra/thread_operation/test_thread_receiver.cpp
@@ -31,7 +31,7 @@ TEST(ThreadReceiverTest, DispatchesMessages) {
 
     std::thread th{[&]{ receiver.run(); }};
 
-    ThreadMessage msg{ThreadMessageType::StartBuzzer, true};
+    ThreadMessage msg{ThreadMessageType::StartBuzzing, true};
     queue->push(msg);
 
     {

--- a/tests/infra/thread_operation/test_thread_sender.cpp
+++ b/tests/infra/thread_operation/test_thread_sender.cpp
@@ -21,7 +21,7 @@ public:
 TEST(ThreadSenderTest, SendPushesMessageToQueue) {
     auto queue = std::make_shared<ThreadQueue>(nullptr);
     NiceMock<MockLogger> logger;
-    auto message = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzer, std::vector<std::string>{"1"});
+    auto message = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing, std::vector<std::string>{"1"});
 
     ThreadSender sender(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), queue, message);
 

--- a/tests/infra/timer_service/test_timer_service.cpp
+++ b/tests/infra/timer_service/test_timer_service.cpp
@@ -29,8 +29,8 @@ TEST(TimerServiceTest, SendsTimeoutMessage) {
     auto sender = std::make_shared<StrictMock<MockSender>>();
     NiceMock<MockLogger> logger;
     TimerService timer(sender, std::shared_ptr<ILogger>(&logger, [](ILogger*){}));
-    ProcessMessage m{ThreadMessageType::Timeout, false};
-    EXPECT_CALL(*sender, enqueue(testing::Field(&ProcessMessage::type_, ThreadMessageType::Timeout))).Times(1);
+    ProcessMessage m{ThreadMessageType::ProcessingTimeout, false};
+    EXPECT_CALL(*sender, enqueue(testing::Field(&ProcessMessage::type_, ThreadMessageType::ProcessingTimeout))).Times(1);
     timer.start(10, m);
     std::this_thread::sleep_for(std::chrono::milliseconds(30));
     while (timer.active()) {


### PR DESCRIPTION
## Summary
- remove old aliases like `StartBuzzer`
- use `StartBuzzing`, `StopBuzzing` and `ProcessingTimeout` consistently

## Testing
- `cmake -S . -B build` *(fails: cannot find test sources)*

------
https://chatgpt.com/codex/tasks/task_e_688b6d3feef483288d122917afd2fc05