### PR TITLE
Add ProcessMessage unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ add_executable(test_infra_extra
     tests/infra/test_timer_service.cpp
     tests/infra/test_watch_dog.cpp
     tests/infra/test_process_dispatcher.cpp
+    tests/infra/process_operation/test_process_message.cpp
     tests/infra/test_gpio_setter.cpp
     tests/infra/test_buzzer_driver.cpp
     tests/infra/test_bluetooth_driver.cpp

--- a/tests/infra/process_operation/test_process_message.cpp
+++ b/tests/infra/process_operation/test_process_message.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+#include "infra/process_operation/process_message/process_message.hpp"
+
+using namespace device_reminder;
+
+TEST(ProcessMessageTest, ConstructorStoresValues) {
+    ProcessMessage msg(ProcessMessageType::StartBuzzing, {"arg1", "arg2"});
+    EXPECT_EQ(msg.type(), ProcessMessageType::StartBuzzing);
+    std::vector<std::string> expected{"arg1", "arg2"};
+    EXPECT_EQ(msg.payload(), expected);
+}
+
+TEST(ProcessMessageTest, HandlesEmptyPayload) {
+    ProcessMessage msg(ProcessMessageType::ScanTimeout, {});
+    EXPECT_EQ(msg.type(), ProcessMessageType::ScanTimeout);
+    EXPECT_TRUE(msg.payload().empty());
+}
+
+TEST(ProcessMessageTest, HandlesInvalidEnum) {
+    ProcessMessage msg(static_cast<ProcessMessageType>(999), {"x"});
+    EXPECT_EQ(static_cast<int>(msg.type()), 999);
+    std::vector<std::string> expected{"x"};
+    EXPECT_EQ(msg.payload(), expected);
+    EXPECT_EQ(msg.to_string(), std::string("ProcessMessage{999,[x]}"));
+}
+
+TEST(ProcessMessageTest, CloneCreatesEqualCopy) {
+    ProcessMessage original(ProcessMessageType::StopBuzzing, {"stop"});
+    auto copy = original.clone();
+    ASSERT_NE(copy, nullptr);
+    EXPECT_EQ(copy->type(), original.type());
+    EXPECT_EQ(copy->payload(), original.payload());
+}
+
+TEST(ProcessMessageTest, ToStringFormatsCorrectly) {
+    ProcessMessage msg(ProcessMessageType::StartBuzzing, {"1"});
+    EXPECT_EQ(msg.to_string(), std::string("ProcessMessage{5,[1]}"));
+}


### PR DESCRIPTION
## Summary
- add tests for ProcessMessage class
- register new test file in the build

## Testing
- `g++ ../tests/infra/process_operation/test_process_message.cpp ../src/infra/process_operation/process_message.cpp ../external/googletest/googletest/src/gtest_main.cc ../external/googletest/googletest/src/gtest-all.cc -I../include -I../include/infra -I../external/googletest/googletest -I../external/googletest/googletest/include -pthread -std=c++17 -o test_process_message`
- `./test_process_message --gtest_color=yes`

------
https://chatgpt.com/codex/tasks/task_e_688b0edc40fc832884fe588b1237c99d