### PR TITLE
Add WatchDog tests

### DIFF
--- a/tests/infra/watch_dog/test_watch_dog.cpp
+++ b/tests/infra/watch_dog/test_watch_dog.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "watch_dog/watch_dog.hpp"
+#include "infra/watch_dog/watch_dog.hpp"
 
 using ::testing::StrictMock;
 
@@ -12,6 +12,64 @@ public:
     MOCK_METHOD(void, start, (), (override));
     MOCK_METHOD(void, stop, (), (override));
 };
+
+TEST(WatchDogTest, ConstructWithValidTimer) {
+    auto timer = std::make_shared<StrictMock<MockTimer>>();
+    WatchDog wd(timer);
+
+    EXPECT_CALL(*timer, start()).Times(1);
+    wd.start();
+}
+
+TEST(WatchDogTest, ConstructWithNullptr) {
+    WatchDog wd(nullptr);
+    EXPECT_NO_THROW(wd.start());
+}
+
+TEST(WatchDogTest, StartStartsTimerOnce) {
+    auto timer = std::make_shared<StrictMock<MockTimer>>();
+    WatchDog wd(timer);
+
+    EXPECT_CALL(*timer, start()).Times(1);
+    wd.start();
+}
+
+TEST(WatchDogTest, StartWhenRunningDoesNothing) {
+    auto timer = std::make_shared<StrictMock<MockTimer>>();
+    WatchDog wd(timer);
+
+    EXPECT_CALL(*timer, start()).Times(1);
+    wd.start();
+    wd.start();
+}
+
+TEST(WatchDogTest, StartWithNullTimerDoesNothing) {
+    WatchDog wd(nullptr);
+    EXPECT_NO_THROW(wd.start());
+}
+
+TEST(WatchDogTest, StopStopsTimer) {
+    auto timer = std::make_shared<StrictMock<MockTimer>>();
+    WatchDog wd(timer);
+
+    EXPECT_CALL(*timer, start()).Times(1);
+    EXPECT_CALL(*timer, stop()).Times(1);
+    wd.start();
+    wd.stop();
+}
+
+TEST(WatchDogTest, StopWithNullTimerDoesNothing) {
+    WatchDog wd(nullptr);
+    EXPECT_NO_THROW(wd.stop());
+}
+
+TEST(WatchDogTest, StopWhenNotRunningDoesNothing) {
+    auto timer = std::make_shared<StrictMock<MockTimer>>();
+    WatchDog wd(timer);
+
+    EXPECT_CALL(*timer, stop()).Times(0);
+    wd.stop();
+}
 
 TEST(WatchDogTest, KickRestartsTimer) {
     auto timer = std::make_shared<StrictMock<MockTimer>>();
@@ -28,24 +86,9 @@ TEST(WatchDogTest, KickRestartsTimer) {
     wd.kick();
 }
 
-TEST(WatchDogTest, StartPreventsDoubleStart) {
-    auto timer = std::make_shared<StrictMock<MockTimer>>();
-    WatchDog wd(timer);
-
-    EXPECT_CALL(*timer, start()).Times(1);
-    wd.start();
-    wd.start();
-}
-
-TEST(WatchDogTest, StopStopsTimer) {
-    auto timer = std::make_shared<StrictMock<MockTimer>>();
-    WatchDog wd(timer);
-
-    EXPECT_CALL(*timer, start()).Times(1);
-    EXPECT_CALL(*timer, stop()).Times(1);
-
-    wd.start();
-    wd.stop();
+TEST(WatchDogTest, KickWithNullTimerDoesNothing) {
+    WatchDog wd(nullptr);
+    EXPECT_NO_THROW(wd.kick());
 }
 
 } // namespace device_reminder


### PR DESCRIPTION
## Summary
- add detailed WatchDog tests covering constructor and start/stop/kick
- include header path using infra/watch_dog

## Testing
- `cmake ..` *(fails: ProcessBase related errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b12cfe64c832898c3b8725b94e939