### PR TITLE
Add BluetoothDriver tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ add_executable(test_infra_extra
     src/infra/bluetooth_driver/bluetooth_driver.cpp
     src/infra/file_loader/file_loader.cpp
     tests/stubs/posix_mq_stub.cpp
+    tests/stubs/popen_stub.cpp
 )
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,17 @@ add_executable(process_queue_tests
 
 target_link_libraries(process_queue_tests gtest gmock gtest_main pthread)
 
+# BluetoothDriver のテスト
+add_executable(bluetooth_driver_tests
+    infra/bluetooth_driver/test_bluetooth_driver.cpp
+    ${PROJECT_ROOT}/src/infra/bluetooth_driver/bluetooth_driver.cpp
+    ${PROJECT_ROOT}/src/infra/logger/logger.cpp
+    ${PROJECT_ROOT}/tests/stubs/popen_stub.cpp
+)
+
+target_link_libraries(bluetooth_driver_tests gtest gmock gtest_main pthread)
+
 enable_testing()
 add_test(NAME process_queue_tests COMMAND process_queue_tests)
+add_test(NAME bluetooth_driver_tests COMMAND bluetooth_driver_tests)
 

--- a/tests/infra/bluetooth_driver/test_bluetooth_driver.cpp
+++ b/tests/infra/bluetooth_driver/test_bluetooth_driver.cpp
@@ -1,18 +1,84 @@
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#define private public
 #include "infra/bluetooth_driver/bluetooth_driver.hpp"
+#undef private
+#include "popen_stub.h"
 
 using namespace device_reminder;
+using ::testing::NiceMock;
+using ::testing::StrictMock;
 
 namespace {
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
+};
 class DummyLogger : public ILogger {
 public:
     void info(const std::string&) override {}
     void error(const std::string&) override {}
+    void warn(const std::string&) override {}
 };
 } // namespace
 
-TEST(BluetoothDriverTest, ScanRunsWithoutThrow) {
+TEST(BluetoothDriverTest, PointerArgNormal) {
+    popen_stub_reset();
+    popen_stub_set_output("Scanning ...\nAA:BB\tdev\n");
     DummyLogger logger;
     BluetoothDriver driver(logger);
-    EXPECT_NO_THROW({ auto res = driver.scan(); (void)res; });
+    EXPECT_NO_THROW({ auto r = driver.scan(); (void)r; });
 }
+
+TEST(BluetoothDriverTest, ValueArgNormal) {
+    popen_stub_reset();
+    popen_stub_set_output("Scanning ...\nAA:BB\tphone\n");
+    DummyLogger logger;
+    BluetoothDriver driver(logger);
+    auto res = driver.scan();
+    ASSERT_EQ(res.size(), 1u);
+    EXPECT_EQ(res[0], "phone");
+}
+
+TEST(BluetoothDriverTest, ValueArgAbnormal) {
+    popen_stub_reset();
+    popen_stub_set_output("Scanning ...\n\ninvalid\n");
+    DummyLogger logger;
+    BluetoothDriver driver(logger);
+    auto res = driver.scan();
+    EXPECT_TRUE(res.empty());
+}
+
+TEST(BluetoothDriverTest, PointerArgAbnormal) {
+    popen_stub_reset();
+    popen_stub_set_output("Scanning ...\nAA:BB\tdev\n");
+    NiceMock<MockLogger> logger;
+    BluetoothDriver driver(logger);
+    driver.logger_ = nullptr;
+    auto res = driver.scan();
+    EXPECT_EQ(res.size(), 1u);
+}
+
+TEST(BluetoothDriverTest, MockArgNormal) {
+    popen_stub_reset();
+    popen_stub_set_output("Scanning ...\n11:22\tdev1\n22:33\tdev2\n");
+    StrictMock<MockLogger> logger;
+    EXPECT_CALL(logger, info(testing::HasSubstr("dev1"))).Times(1);
+    EXPECT_CALL(logger, info(testing::HasSubstr("dev2"))).Times(1);
+    BluetoothDriver driver(logger);
+    auto res = driver.scan();
+    EXPECT_EQ(res.size(), 2u);
+}
+
+TEST(BluetoothDriverTest, MockArgAbnormal) {
+    popen_stub_reset();
+    popen_stub_set_fail(1);
+    StrictMock<MockLogger> logger;
+    EXPECT_CALL(logger, error(testing::HasSubstr("hcitool"))).Times(1);
+    BluetoothDriver driver(logger);
+    EXPECT_THROW(driver.scan(), BluetoothDriverError);
+}
+

--- a/tests/stubs/popen_stub.cpp
+++ b/tests/stubs/popen_stub.cpp
@@ -1,0 +1,35 @@
+#include "popen_stub.h"
+#include <cstdio>
+#include <string>
+#include <cerrno>
+
+static std::string g_output;
+static int g_fail = 0;
+
+extern "C" FILE* popen(const char* command, const char* type) {
+    (void)command; (void)type;
+    if (g_fail) { errno = EINVAL; return nullptr; }
+    FILE* fp = tmpfile();
+    if (!fp) return nullptr;
+    fwrite(g_output.c_str(), 1, g_output.size(), fp);
+    rewind(fp);
+    return fp;
+}
+
+extern "C" int pclose(FILE* stream) {
+    return fclose(stream);
+}
+
+extern "C" void popen_stub_reset(void) {
+    g_output.clear();
+    g_fail = 0;
+}
+
+extern "C" void popen_stub_set_fail(int v) {
+    g_fail = v;
+}
+
+extern "C" void popen_stub_set_output(const char* str) {
+    g_output = str ? str : "";
+}
+

--- a/tests/stubs/popen_stub.h
+++ b/tests/stubs/popen_stub.h
@@ -1,0 +1,13 @@
+#ifndef POPEN_STUB_H
+#define POPEN_STUB_H
+#include <stdio.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+void popen_stub_reset(void);
+void popen_stub_set_fail(int v);
+void popen_stub_set_output(const char* str);
+#ifdef __cplusplus
+}
+#endif
+#endif // POPEN_STUB_H


### PR DESCRIPTION
## Summary
- popenをスタブ化するヘッダと実装を追加
- BluetoothDriverのテストを拡充
- 新テスト用にCMakeを更新

## Testing
- `cmake -S tests -B build_tests`
- `cmake --build build_tests`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688b1464985083289ed51755580e7185