### PR TITLE
Add comprehensive ProcessSender tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,8 +28,22 @@ add_executable(process_queue_tests
     ${PROJECT_ROOT}/tests/stubs/posix_mq_stub.cpp
 )
 
+# ProcessSender のテスト
+add_executable(process_sender_tests
+    infra/process_operation/test_process_sender.cpp
+    ${PROJECT_ROOT}/src/infra/process_operation/process_sender.cpp
+    ${PROJECT_ROOT}/src/infra/process_operation/process_queue.cpp
+    ${PROJECT_ROOT}/src/infra/process_operation/message_codec.cpp
+    ${PROJECT_ROOT}/src/infra/process_operation/process_message.cpp
+    ${PROJECT_ROOT}/src/infra/logger/logger.cpp
+    ${PROJECT_ROOT}/tests/stubs/posix_mq_stub.cpp
+)
+
 target_link_libraries(process_queue_tests gtest gmock gtest_main pthread)
+
+target_link_libraries(process_sender_tests gtest gmock gtest_main pthread)
 
 enable_testing()
 add_test(NAME process_queue_tests COMMAND process_queue_tests)
+add_test(NAME process_sender_tests COMMAND process_sender_tests)
 

--- a/tests/infra/process_operation/test_process_sender.cpp
+++ b/tests/infra/process_operation/test_process_sender.cpp
@@ -2,32 +2,97 @@
 #include <gmock/gmock.h>
 
 #include "infra/process_operation/process_sender/process_sender.hpp"
+#include "infra/process_operation/process_queue/i_process_queue.hpp"
 #include "infra/process_operation/process_queue/process_queue.hpp"
 #include "infra/process_operation/process_message/process_message.hpp"
 #include "infra/process_operation/message_codec/message_codec.hpp"
 #include "infra/logger/logger.hpp"
-#include <mqueue.h>
+#include "posix_mq_stub.h"
 
 using namespace device_reminder;
+using ::testing::StrictMock;
+using ::testing::Return;
+using ::testing::Throw;
 
-static std::string unique_name(const std::string& base) {
+namespace {
+
+class MockQueue : public IProcessQueue {
+public:
+    MOCK_METHOD(void, push, (std::shared_ptr<IProcessMessage>), (override));
+    MOCK_METHOD(std::shared_ptr<IProcessMessage>, pop, (), (override));
+    MOCK_METHOD(std::size_t, size, (), (const, override));
+};
+
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
+};
+
+std::string unique_name(const std::string& base) {
     return "/" + base + std::to_string(::getpid()) + std::to_string(::time(nullptr));
 }
 
-TEST(MessageSenderTest, EnqueueSendsMessage) {
-    std::string name = unique_name("sender_test_");
-    auto logger = std::make_shared<Logger>();
-    auto codec = std::make_shared<MessageCodec>();
-    auto queue = std::make_shared<ProcessQueue>(logger, codec, name);
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{"1"});
+} // namespace
+
+TEST(ProcessSenderTest, ValueNormal_EnqueuesMessage) {
+    mq_stub_reset();
+    std::shared_ptr<ILogger> logger{};
+    auto codec = std::make_shared<MessageCodec>(nullptr);
+    auto queue = std::make_shared<ProcessQueue>(logger, codec, unique_name("sender1_"));
+    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{"1"});
     ProcessSender sender(queue, msg);
 
     sender.send();
 
-    mqd_t mq = mq_open(name.c_str(), O_RDONLY);
-    ASSERT_NE(mq, static_cast<mqd_t>(-1));
-    std::vector<uint8_t> buf(512);
-    ssize_t n = mq_receive(mq, reinterpret_cast<char*>(buf.data()), 512, nullptr);
-    EXPECT_GT(n, 0);
-    mq_close(mq);
+    auto popped = queue->pop();
+    ASSERT_NE(popped, nullptr);
+    EXPECT_EQ(popped->type(), msg->type());
+    EXPECT_EQ(popped->payload(), msg->payload());
+}
+
+TEST(ProcessSenderTest, ValueAbnormal_LongPayload) {
+    mq_stub_reset();
+    std::shared_ptr<ILogger> logger{};
+    auto codec = std::make_shared<MessageCodec>(nullptr);
+    auto queue = std::make_shared<ProcessQueue>(logger, codec, unique_name("sender2_"));
+    std::string long_str(1024, 'x');
+    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{long_str});
+    ProcessSender sender(queue, msg);
+    EXPECT_NO_THROW(sender.send());
+}
+
+TEST(ProcessSenderTest, PointerNormal_NullQueue) {
+    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    ProcessSender sender(nullptr, msg);
+    EXPECT_NO_THROW(sender.send());
+}
+
+TEST(ProcessSenderTest, PointerAbnormal_NullMessage) {
+    StrictMock<MockQueue> queue;
+    EXPECT_CALL(queue, push(::testing::IsNull())).Times(1);
+    ProcessSender sender(std::shared_ptr<IProcessQueue>(&queue, [](IProcessQueue*){}), nullptr);
+    sender.send();
+}
+
+TEST(ProcessSenderTest, PointerAbnormal_BothNull) {
+    ProcessSender sender(nullptr, nullptr);
+    EXPECT_NO_THROW(sender.send());
+}
+
+TEST(ProcessSenderTest, MockNormal_PushCalledOnce) {
+    StrictMock<MockQueue> queue;
+    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    EXPECT_CALL(queue, push(msg)).Times(1);
+    ProcessSender sender(std::shared_ptr<IProcessQueue>(&queue, [](IProcessQueue*){}), msg);
+    sender.send();
+}
+
+TEST(ProcessSenderTest, MockAbnormal_ThrowsFromQueue) {
+    StrictMock<MockQueue> queue;
+    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    EXPECT_CALL(queue, push(msg)).WillOnce(Throw(std::runtime_error("fail")));
+    ProcessSender sender(std::shared_ptr<IProcessQueue>(&queue, [](IProcessQueue*){}), msg);
+    EXPECT_THROW(sender.send(), std::runtime_error);
 }


### PR DESCRIPTION
## Summary
- expand tests for ProcessSender according to organized test scenarios
- compile the new tests via `process_sender_tests` target

## Testing
- `cmake -S tests -B build`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688b18d21b808328afe2a3406eeb7605