### PR TITLE
Add ProcessDispatcher logging tests

### DIFF
--- a/src/infra/process_operation/process_dispatcher.cpp
+++ b/src/infra/process_operation/process_dispatcher.cpp
@@ -2,6 +2,8 @@
 #include "infra/logger/i_logger.hpp"
 #include "infra/process_operation/process_message/i_process_message.hpp"
 
+#include <string>
+
 namespace device_reminder {
 
 ProcessDispatcher::ProcessDispatcher(std::shared_ptr<ILogger> logger,
@@ -17,9 +19,14 @@ void ProcessDispatcher::dispatch(std::shared_ptr<IProcessMessage> msg) {
     }
     auto it = handler_map_.find(msg->type());
     if (it != handler_map_.end()) {
-        it->second(std::move(msg));
+        if (it->second) {
+            it->second(std::move(msg));
+        } else if (logger_) {
+            logger_->error("Empty process handler");
+        }
     } else if (logger_) {
-        logger_->warn("Unhandled process message");
+        logger_->warn("Unhandled process message type " +
+                      std::to_string(static_cast<int>(msg->type())));
     }
 }
 

--- a/tests/infra/process_operation/test_process_dispatcher.cpp
+++ b/tests/infra/process_operation/test_process_dispatcher.cpp
@@ -1,7 +1,21 @@
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "infra/process_operation/process_dispatcher/process_dispatcher.hpp"
 #include "infra/process_operation/process_message/process_message.hpp"
+#include "infra/logger/i_logger.hpp"
+
+using ::testing::NiceMock;
+using ::testing::StrictMock;
+
+namespace {
+class MockLogger : public device_reminder::ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
+};
+} // namespace
 
 using namespace device_reminder;
 
@@ -29,5 +43,31 @@ TEST(ProcessDispatcherTest, IgnoresUnknownMessage) {
                                                std::vector<std::string>{});
     disp.dispatch(msg);
     EXPECT_FALSE(called);
+}
+
+TEST(ProcessDispatcherTest, LogsWarnForUnknownMessageWithType) {
+    NiceMock<MockLogger> logger;
+    ProcessDispatcher::HandlerMap map{{ProcessMessageType::StartBuzzing,
+                                       [](std::shared_ptr<IProcessMessage>) {}}};
+    ProcessDispatcher disp(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), map);
+    auto msg =
+        std::make_shared<ProcessMessage>(ProcessMessageType::StopBuzzing,
+                                         std::vector<std::string>{});
+    std::string expected =
+        "Unhandled process message type " +
+        std::to_string(static_cast<int>(ProcessMessageType::StopBuzzing));
+    EXPECT_CALL(logger, warn(expected)).Times(1);
+    disp.dispatch(msg);
+}
+
+TEST(ProcessDispatcherTest, LogsErrorWhenHandlerEmpty) {
+    NiceMock<MockLogger> logger;
+    ProcessDispatcher::HandlerMap map{{ProcessMessageType::StartBuzzing, {}}};
+    ProcessDispatcher disp(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), map);
+    auto msg =
+        std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing,
+                                         std::vector<std::string>{});
+    EXPECT_CALL(logger, error("Empty process handler")).Times(1);
+    disp.dispatch(msg);
 }
 


### PR DESCRIPTION
## Summary
- improve logging in ProcessDispatcher
- add tests for warning log and empty handler cases

## Testing
- `cmake --build build --target test_infra_extra` *(fails: error in existing tests)*
- `g++ -std=c++17 -Iinclude -Iexternal/googletest/googletest/include -Iexternal/googletest/googlemock/include -c tests/infra/process_operation/test_process_dispatcher.cpp -o /tmp/test.o`

------
https://chatgpt.com/codex/tasks/task_e_688b18de0ac4832897f74decc942d118