### PR TITLE
Add extensive tests for HumanTask

### DIFF
--- a/tests/core/human_task/test_human_task.cpp
+++ b/tests/core/human_task/test_human_task.cpp
@@ -26,6 +26,13 @@ public:
     void warn(const std::string&) override {}
 };
 
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
+};
+
 TEST(HumanTaskTest, DetectingStartsDriver) {
     auto pir = std::make_shared<StrictMock<MockPIR>>();
     auto sender = std::make_shared<StrictMock<MockSender>>();
@@ -57,6 +64,105 @@ TEST(HumanTaskTest, CooldownDoesNothing) {
     HumanTask task(logger, pir, sender);
 
     EXPECT_CALL(*sender, send()).Times(0);
+    EXPECT_CALL(*pir, stop()).Times(1);
+
+    task.on_cooldown({});
+}
+
+// --- Additional tests for pointer and logger behaviours ---
+
+TEST(HumanTaskTest, ConstructorLogsWhenLoggerProvided) {
+    auto logger = std::make_shared<StrictMock<MockLogger>>();
+    EXPECT_CALL(*logger, info(testing::_)).Times(1);
+    HumanTask task(logger, nullptr, nullptr);
+}
+
+TEST(HumanTaskTest, ConstructorNoLogWhenLoggerNull) {
+    EXPECT_NO_THROW(HumanTask(nullptr, nullptr, nullptr));
+}
+
+TEST(HumanTaskTest, DetectingRunsAndLogs) {
+    auto pir = std::make_shared<StrictMock<MockPIR>>();
+    auto logger = std::make_shared<StrictMock<MockLogger>>();
+    HumanTask task(logger, pir, nullptr);
+
+    EXPECT_CALL(*pir, run()).Times(1);
+    EXPECT_CALL(*logger, info(testing::_)).Times(1);
+
+    task.on_detecting({"a"});
+}
+
+TEST(HumanTaskTest, DetectingWithoutPirOnlyLogs) {
+    auto logger = std::make_shared<StrictMock<MockLogger>>();
+    HumanTask task(logger, nullptr, nullptr);
+
+    EXPECT_CALL(*logger, info(testing::_)).Times(1);
+
+    task.on_detecting({});
+}
+
+TEST(HumanTaskTest, DetectingWithoutLoggerOnlyRuns) {
+    auto pir = std::make_shared<StrictMock<MockPIR>>();
+    HumanTask task(nullptr, pir, nullptr);
+
+    EXPECT_CALL(*pir, run()).Times(1);
+
+    task.on_detecting({});
+}
+
+TEST(HumanTaskTest, StoppingStopsAndLogs) {
+    auto pir = std::make_shared<StrictMock<MockPIR>>();
+    auto logger = std::make_shared<StrictMock<MockLogger>>();
+    HumanTask task(logger, pir, nullptr);
+
+    EXPECT_CALL(*pir, stop()).Times(1);
+    EXPECT_CALL(*logger, info(testing::_)).Times(1);
+
+    task.on_stopping({"b"});
+}
+
+TEST(HumanTaskTest, StoppingWithoutPirOnlyLogs) {
+    auto logger = std::make_shared<StrictMock<MockLogger>>();
+    HumanTask task(logger, nullptr, nullptr);
+
+    EXPECT_CALL(*logger, info(testing::_)).Times(1);
+
+    task.on_stopping({});
+}
+
+TEST(HumanTaskTest, StoppingWithoutLoggerOnlyStops) {
+    auto pir = std::make_shared<StrictMock<MockPIR>>();
+    HumanTask task(nullptr, pir, nullptr);
+
+    EXPECT_CALL(*pir, stop()).Times(1);
+
+    task.on_stopping({});
+}
+
+TEST(HumanTaskTest, CooldownStopsAndLogs) {
+    auto pir = std::make_shared<StrictMock<MockPIR>>();
+    auto logger = std::make_shared<StrictMock<MockLogger>>();
+    HumanTask task(logger, pir, nullptr);
+
+    EXPECT_CALL(*pir, stop()).Times(1);
+    EXPECT_CALL(*logger, info(testing::_)).Times(1);
+
+    task.on_cooldown({});
+}
+
+TEST(HumanTaskTest, CooldownWithoutPirOnlyLogs) {
+    auto logger = std::make_shared<StrictMock<MockLogger>>();
+    HumanTask task(logger, nullptr, nullptr);
+
+    EXPECT_CALL(*logger, info(testing::_)).Times(1);
+
+    task.on_cooldown({});
+}
+
+TEST(HumanTaskTest, CooldownWithoutLoggerOnlyStops) {
+    auto pir = std::make_shared<StrictMock<MockPIR>>();
+    HumanTask task(nullptr, pir, nullptr);
+
     EXPECT_CALL(*pir, stop()).Times(1);
 
     task.on_cooldown({});


### PR DESCRIPTION
## Summary
- add mock logger definition
- expand test coverage of `HumanTask` constructor and handlers

## Testing
- `cmake ..` *(fails: IProcessQueue not declared in ProcessBase)*

------
https://chatgpt.com/codex/tasks/task_e_688b19234570832898b4989d3fa5957a