### PR TITLE
Add extensive HumanHandler tests

### DIFF
--- a/tests/core/human_task/test_human_handler.cpp
+++ b/tests/core/human_task/test_human_handler.cpp
@@ -29,6 +29,13 @@ public:
     void warn(const std::string&) override {}
 };
 
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
+};
+
 TEST(HumanHandlerTest, StopDetectionStartsTimer) {
     auto task = std::make_shared<StrictMock<MockHumanTask>>();
     auto timer = std::make_shared<StrictMock<MockTimer>>();
@@ -64,6 +71,84 @@ TEST(HumanHandlerTest, CooldownCallsTask) {
     EXPECT_CALL(*task, on_cooldown(testing::_)).Times(1);
 
     auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::CoolDownTimeout, std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+TEST(HumanHandlerTest, ConstructorLogsCreation) {
+    auto task = std::make_shared<NiceMock<MockHumanTask>>();
+    auto timer = std::make_shared<NiceMock<MockTimer>>();
+    auto logger = std::make_shared<StrictMock<MockLogger>>();
+
+    EXPECT_CALL(*logger, info("HumanHandler created")).Times(1);
+
+    HumanHandler handler(logger, task, timer);
+}
+
+TEST(HumanHandlerTest, ConstructorNullLoggerDoesNotThrow) {
+    auto task = std::make_shared<NiceMock<MockHumanTask>>();
+    auto timer = std::make_shared<NiceMock<MockTimer>>();
+
+    EXPECT_NO_THROW({ HumanHandler handler(nullptr, task, timer); });
+}
+
+TEST(HumanHandlerTest, HandleNullMessageDoesNothing) {
+    auto task = std::make_shared<StrictMock<MockHumanTask>>();
+    auto timer = std::make_shared<StrictMock<MockTimer>>();
+    auto logger = std::make_shared<DummyLogger>();
+    HumanHandler handler(logger, task, timer);
+
+    EXPECT_CALL(*timer, start()).Times(0);
+    EXPECT_CALL(*timer, stop()).Times(0);
+
+    handler.handle(nullptr);
+}
+
+TEST(HumanHandlerTest, HandleWithNullTaskDoesNothing) {
+    auto timer = std::make_shared<StrictMock<MockTimer>>();
+    auto logger = std::make_shared<DummyLogger>();
+    HumanHandler handler(logger, nullptr, timer);
+
+    EXPECT_CALL(*timer, start()).Times(0);
+    EXPECT_CALL(*timer, stop()).Times(0);
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartHumanDetection, std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+TEST(HumanHandlerTest, StartDetectionWithNullTimerOnlyCallsTask) {
+    auto task = std::make_shared<StrictMock<MockHumanTask>>();
+    auto logger = std::make_shared<DummyLogger>();
+    HumanHandler handler(logger, task, nullptr);
+
+    EXPECT_CALL(*task, on_detecting(testing::_)).Times(1);
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartHumanDetection, std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+TEST(HumanHandlerTest, StopDetectionWithNullLoggerWorks) {
+    auto task = std::make_shared<StrictMock<MockHumanTask>>();
+    auto timer = std::make_shared<StrictMock<MockTimer>>();
+    HumanHandler handler(nullptr, task, timer);
+
+    EXPECT_CALL(*timer, start()).Times(1);
+    EXPECT_CALL(*task, on_stopping(testing::_)).Times(1);
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StopHumanDetection, std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+TEST(HumanHandlerTest, UnknownMessageKeepsDetectingState) {
+    auto task = std::make_shared<StrictMock<MockHumanTask>>();
+    auto timer = std::make_shared<StrictMock<MockTimer>>();
+    auto logger = std::make_shared<DummyLogger>();
+    HumanHandler handler(logger, task, timer);
+
+    EXPECT_CALL(*timer, start()).Times(0);
+    EXPECT_CALL(*timer, stop()).Times(0);
+    EXPECT_CALL(*task, on_detecting(testing::_)).Times(1);
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
     handler.handle(msg);
 }
 


### PR DESCRIPTION
## Summary
- 拡張した `HumanHandler` のテストを追加
- 既存のテストファイルにコンストラクタと異常系などのケースを網羅

## Testing
- `cmake --build . --target test_app` (途中でビルドエラー)

------
https://chatgpt.com/codex/tasks/task_e_688b192e65d883289985ea9c3d017ad0