### PR TITLE
Add TimerService tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,14 +90,18 @@ add_executable(test_infra_extra
     src/infra/thread_operation/thread_queue.cpp
     src/infra/process_operation/process_message.cpp
     src/infra/thread_operation/thread_sender.cpp
+    src/infra/thread_operation/thread_receiver.cpp
+    src/infra/thread_operation/thread_dispatcher.cpp
     src/infra/pir_driver/pir_driver.cpp
     src/infra/timer_service/timer_service.cpp
     src/infra/watch_dog/watch_dog.cpp
     src/infra/gpio_operation/gpio_setter/gpio_setter.cpp
     src/infra/buzzer_driver/buzzer_driver.cpp
     src/infra/process_operation/process_dispatcher.cpp
+    src/infra/process_operation/process_receiver.cpp
     src/infra/bluetooth_driver/bluetooth_driver.cpp
     src/infra/file_loader/file_loader.cpp
+    tests/stubs/gpiod_stub.cpp
     tests/stubs/posix_mq_stub.cpp
     tests/stubs/popen_stub.cpp
 )

--- a/tests/infra/timer_service/test_timer_service.cpp
+++ b/tests/infra/timer_service/test_timer_service.cpp
@@ -2,20 +2,20 @@
 #include <gmock/gmock.h>
 
 #include "infra/timer_service/timer_service.hpp"
-#include "infra/process_operation/process_sender/i_process_sender.hpp"
-#include "infra/process_operation/process_message/process_message.hpp"
-#include <thread>
+#include "infra/thread_operation/thread_sender/i_thread_sender.hpp"
+#include "infra/logger/i_logger.hpp"
+
 #include <chrono>
+#include <thread>
 
 using namespace device_reminder;
-using ::testing::StrictMock;
 using ::testing::NiceMock;
+using ::testing::StrictMock;
 
 namespace {
-class MockSender : public IProcessMessageSender {
+class MockSender : public IThreadSender {
 public:
-    MOCK_METHOD(bool, enqueue, (const ProcessMessage&), (override));
-    MOCK_METHOD(void, stop, (), (override));
+    MOCK_METHOD(void, send, (), (override));
 };
 class MockLogger : public ILogger {
 public:
@@ -25,16 +25,117 @@ public:
 };
 } // namespace
 
-TEST(TimerServiceTest, SendsTimeoutMessage) {
-    auto sender = std::make_shared<StrictMock<MockSender>>();
+TEST(TimerServiceTest, ConstructorAndDestructorWithLogger) {
+    StrictMock<MockSender> sender;
+    StrictMock<MockLogger> logger;
+    {
+        testing::InSequence seq;
+        EXPECT_CALL(logger, info("TimerService created"));
+        EXPECT_CALL(logger, info("TimerService stopped"));
+        EXPECT_CALL(logger, info("TimerService destroyed"));
+    }
+    {
+        TimerService timer(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                           10,
+                           std::shared_ptr<IThreadSender>(&sender, [](IThreadSender*){}));
+    }
+}
+
+TEST(TimerServiceTest, StartTriggersSendAndTimeoutLog) {
+    StrictMock<MockSender> sender;
+    StrictMock<MockLogger> logger;
+    {
+        testing::InSequence seq;
+        EXPECT_CALL(logger, info("TimerService created"));
+        EXPECT_CALL(logger, info("TimerService stopped"));
+        EXPECT_CALL(logger, info("TimerService started"));
+        EXPECT_CALL(sender, send()).Times(1);
+        EXPECT_CALL(logger, info("TimerService timeout"));
+        EXPECT_CALL(logger, info("TimerService stopped"));
+        EXPECT_CALL(logger, info("TimerService destroyed"));
+    }
+    {
+        TimerService timer(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                           10,
+                           std::shared_ptr<IThreadSender>(&sender, [](IThreadSender*){}));
+        timer.start();
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+}
+
+TEST(TimerServiceTest, StartWithNullSenderDoesNotSend) {
     NiceMock<MockLogger> logger;
-    TimerService timer(sender, std::shared_ptr<ILogger>(&logger, [](ILogger*){}));
-    ProcessMessage m{ThreadMessageType::ProcessingTimeout, false};
-    EXPECT_CALL(*sender, enqueue(testing::Field(&ProcessMessage::type_, ThreadMessageType::ProcessingTimeout))).Times(1);
-    timer.start(10, m);
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
-    while (timer.active()) {
+    {
+        testing::InSequence seq;
+        EXPECT_CALL(logger, info("TimerService created"));
+        EXPECT_CALL(logger, info("TimerService stopped"));
+        EXPECT_CALL(logger, info("TimerService started"));
+        EXPECT_CALL(logger, info("TimerService timeout")).Times(0);
+        EXPECT_CALL(logger, info("TimerService stopped"));
+        EXPECT_CALL(logger, info("TimerService destroyed"));
+    }
+    {
+        TimerService timer(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), 10, nullptr);
+        timer.start();
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+}
+
+TEST(TimerServiceTest, StartWithoutLoggerStillSends) {
+    StrictMock<MockSender> sender;
+    {
+        EXPECT_CALL(sender, send()).Times(1);
+    }
+    {
+        TimerService timer(nullptr, 5,
+                           std::shared_ptr<IThreadSender>(&sender, [](IThreadSender*){}));
+        timer.start();
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
-    timer.stop();
+}
+
+TEST(TimerServiceTest, StopBeforeTimeoutPreventsSend) {
+    StrictMock<MockSender> sender;
+    NiceMock<MockLogger> logger;
+    {
+        testing::InSequence seq;
+        EXPECT_CALL(logger, info("TimerService created"));
+        EXPECT_CALL(logger, info("TimerService stopped"));
+        EXPECT_CALL(logger, info("TimerService started"));
+        EXPECT_CALL(sender, send()).Times(0);
+        EXPECT_CALL(logger, info("TimerService stopped"));
+        EXPECT_CALL(logger, info("TimerService stopped"));
+        EXPECT_CALL(logger, info("TimerService destroyed"));
+    }
+    {
+        TimerService timer(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                           50,
+                           std::shared_ptr<IThreadSender>(&sender, [](IThreadSender*){}));
+        timer.start();
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        // stop before the 50ms timeout triggers
+        timer.stop();
+    }
+}
+
+TEST(TimerServiceTest, ZeroDurationTimeoutTriggersImmediately) {
+    StrictMock<MockSender> sender;
+    NiceMock<MockLogger> logger;
+    {
+        testing::InSequence seq;
+        EXPECT_CALL(logger, info("TimerService created"));
+        EXPECT_CALL(logger, info("TimerService stopped"));
+        EXPECT_CALL(logger, info("TimerService started"));
+        EXPECT_CALL(sender, send()).Times(1);
+        EXPECT_CALL(logger, info("TimerService timeout"));
+        EXPECT_CALL(logger, info("TimerService stopped"));
+        EXPECT_CALL(logger, info("TimerService destroyed"));
+    }
+    {
+        TimerService timer(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                           0,
+                           std::shared_ptr<IThreadSender>(&sender, [](IThreadSender*){}));
+        timer.start();
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
 }


### PR DESCRIPTION
## Summary
- implement comprehensive tests for TimerService
- update CMakeLists to include TimerService tests and required sources

## Testing
- `./test_infra_extra --gtest_filter=TimerServiceTest.*`

------
https://chatgpt.com/codex/tasks/task_e_688b12bf705c8328a23deed58e26cdeb