### PR TITLE
Add HumanProcess tests and update file loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(test_app
     tests/core/main_task/test_main_task.cpp
     tests/core/human_task/test_human_task.cpp
     tests/core/human_task/test_human_handler.cpp
+    tests/core/human_task/test_human_process.cpp
     tests/core/main_task/test_main_handler.cpp
     tests/core/buzzer_task/test_buzzer_handler.cpp
     tests/core/buzzer_task/test_buzzer_task.cpp
@@ -52,6 +53,7 @@ add_executable(test_app
     src/core/human_task/human_task.cpp
     src/core/human_task/human_handler.cpp
     src/core/human_task/human_process.cpp
+    src/infra/process_operation/process_base.cpp
 
 
     src/core/buzzer_task/buzzer_task.cpp
@@ -60,6 +62,7 @@ add_executable(test_app
     src/core/bluetooth_task/bluetooth_task.cpp
     src/core/bluetooth_task/bluetooth_handler.cpp
     src/core/bluetooth_task/bluetooth_process.cpp
+    src/infra/process_operation/process_message.cpp
 )
 
 # GPIOReader tests
@@ -96,6 +99,7 @@ add_executable(test_infra_extra
     src/infra/gpio_operation/gpio_setter/gpio_setter.cpp
     src/infra/buzzer_driver/buzzer_driver.cpp
     src/infra/process_operation/process_dispatcher.cpp
+    src/infra/process_operation/process_base.cpp
     src/infra/bluetooth_driver/bluetooth_driver.cpp
     src/infra/file_loader/file_loader.cpp
     tests/stubs/posix_mq_stub.cpp

--- a/include/infra/file_loader/file_loader.hpp
+++ b/include/infra/file_loader/file_loader.hpp
@@ -11,19 +11,17 @@ namespace device_reminder {
 class FileLoader : public IFileLoader {
 public:
     FileLoader(std::shared_ptr<ILogger> logger,
-               const std::string& file_path,
-               const std::string& key);
+               const std::string& file_path);
 
-    int load_int() const override;
-    std::string load_string() const override;
-    std::vector<std::string> load_string_list() const override;
+    int load_int(const std::string& key) const override;
+    std::string load_string(const std::string& key) const override;
+    std::vector<std::string> load_string_list(const std::string& key) const override;
 
 private:
-    std::string load_value() const;
+    std::string load_value(const std::string& key) const;
 
     std::shared_ptr<ILogger> logger_;
     std::string              file_path_;
-    std::string              key_;
 };
 
 } // namespace device_reminder

--- a/include/infra/file_loader/i_file_loader.hpp
+++ b/include/infra/file_loader/i_file_loader.hpp
@@ -9,9 +9,9 @@ class IFileLoader {
 public:
     virtual ~IFileLoader() = default;
 
-    virtual int load_int() const = 0;
-    virtual std::string load_string() const = 0;
-    virtual std::vector<std::string> load_string_list() const = 0;
+    virtual int load_int(const std::string& key) const = 0;
+    virtual std::string load_string(const std::string& key) const = 0;
+    virtual std::vector<std::string> load_string_list(const std::string& key) const = 0;
 };
 
 } // namespace device_reminder

--- a/include/infra/process_operation/process_base/i_process_base.hpp
+++ b/include/infra/process_operation/process_base/i_process_base.hpp
@@ -18,7 +18,7 @@ public:
      * - 実装は内部スレッドを起動して待機し、
      *   終了要求を受け取ったら join して戻る。
      */
-    virtual int run() = 0;
+    virtual void run() = 0;
 
     /// 非同期に終了要求を出す（Ctrl‑C 以外でも停止できるように）
     virtual void stop() = 0;

--- a/include/infra/process_operation/process_base/process_base.hpp
+++ b/include/infra/process_operation/process_base/process_base.hpp
@@ -12,29 +12,35 @@
 #include <memory>
 #include <string>
 
+namespace device_reminder {
+
+class IProcessDispatcher;
+
 class ProcessBase : public IProcessBase {
 public:
     ProcessBase(std::shared_ptr<IProcessQueue>    queue,
                 std::shared_ptr<IProcessReceiver> receiver,
-                std::shared_ptr<IWorkerDispatcher>       dispatcher,
+                std::shared_ptr<IProcessDispatcher> dispatcher,
                 std::shared_ptr<IProcessSender>   sender,
                 std::shared_ptr<IFileLoader>             file_loader,
                 std::shared_ptr<ILogger>                 logger,
                 std::string                              process_name);
 
-    int  run()  override;  ///< メインループ
+    void run() override;  ///< メインループ
     void stop() override;  ///< 外部停止
     int  priority() const noexcept override;
 
-private:
+protected:
     static std::atomic<bool> g_stop_flag;           ///< 全スレッド共通の終了フラグ
 
     std::shared_ptr<IProcessQueue>    queue_;
     std::shared_ptr<IProcessReceiver> receiver_;
-    std::shared_ptr<IWorkerDispatcher>       dispatcher_;
+    std::shared_ptr<IProcessDispatcher> dispatcher_;
     std::shared_ptr<IProcessSender>   sender_;
     std::shared_ptr<IFileLoader>             file_loader_;
     std::shared_ptr<ILogger>                 logger_;
     std::string                              process_name_;
     int                                      priority_{0};
 };
+
+} // namespace device_reminder

--- a/src/core/bluetooth_task/bluetooth_task.cpp
+++ b/src/core/bluetooth_task/bluetooth_task.cpp
@@ -30,7 +30,7 @@ void BluetoothTask::on_waiting(const std::vector<std::string>&) {
         if (driver_) {
             auto devices = driver_->scan();
             if (loader_) {
-                auto regs = loader_->load_string_list();
+                auto regs = loader_->load_string_list("device_list");
                 for (const auto& name : devices) {
                     if (std::find(regs.begin(), regs.end(), name) != regs.end()) {
                         detected = true;

--- a/src/core/main_task/main_task.cpp
+++ b/src/core/main_task/main_task.cpp
@@ -75,7 +75,7 @@ void MainTask::on_waiting_for_human(const std::vector<std::string>&) {
 void MainTask::on_response_to_buzzer_task(const std::vector<std::string>& payload) {
     bool found = false;
     if (file_loader_) {
-        auto regs = file_loader_->load_string_list();
+        auto regs = file_loader_->load_string_list("device_list");
         for (const auto& d : payload) {
             if (std::find(regs.begin(), regs.end(), d) != regs.end()) {
                 found = true;
@@ -96,7 +96,7 @@ void MainTask::on_response_to_buzzer_task(const std::vector<std::string>& payloa
 void MainTask::on_response_to_human_task(const std::vector<std::string>& payload) {
     bool found = false;
     if (file_loader_) {
-        auto regs = file_loader_->load_string_list();
+        auto regs = file_loader_->load_string_list("device_list");
         for (const auto& d : payload) {
             if (std::find(regs.begin(), regs.end(), d) != regs.end()) {
                 found = true;
@@ -126,7 +126,7 @@ void MainTask::on_cooldown(const std::vector<std::string>&) {
 void MainTask::on_waiting_for_second_response(const std::vector<std::string>& payload) {
     bool found = false;
     if (file_loader_) {
-        auto regs = file_loader_->load_string_list();
+        auto regs = file_loader_->load_string_list("device_list");
         for (const auto& d : payload) {
             if (std::find(regs.begin(), regs.end(), d) != regs.end()) {
                 found = true;

--- a/src/infra/buzzer_driver/buzzer_driver.cpp
+++ b/src/infra/buzzer_driver/buzzer_driver.cpp
@@ -12,7 +12,7 @@ BuzzerDriver::BuzzerDriver(std::shared_ptr<IFileLoader> loader,
     if (logger_) logger_->info("BuzzerDriver created");
     if (loader_) {
         try {
-            loader_->load_int(); // 設定値読み込み (エラー確認のみ)
+            loader_->load_int("buzz_duration_ms"); // 設定値読み込み (エラー確認のみ)
         } catch (...) {
             if (logger_) logger_->error("Failed to load buzzer config");
         }

--- a/src/infra/file_loader/file_loader.cpp
+++ b/src/infra/file_loader/file_loader.cpp
@@ -8,32 +8,30 @@
 namespace device_reminder {
 
 FileLoader::FileLoader(std::shared_ptr<ILogger> logger,
-                       const std::string& file_path,
-                       const std::string& key)
+                       const std::string& file_path)
     : logger_(std::move(logger))
     , file_path_(file_path)
-    , key_(key)
 {}
 
-int FileLoader::load_int() const
+int FileLoader::load_int(const std::string& key) const
 {
-    std::string value = load_value();
+    std::string value = load_value(key);
     try {
         return std::stoi(value);
     } catch (const std::exception&) {
-        if (logger_) logger_->error(std::string("invalid int value for ") + key_);
+        if (logger_) logger_->error(std::string("invalid int value for ") + key);
         throw;
     }
 }
 
-std::string FileLoader::load_string() const
+std::string FileLoader::load_string(const std::string& key) const
 {
-    return load_value();
+    return load_value(key);
 }
 
-std::vector<std::string> FileLoader::load_string_list() const
+std::vector<std::string> FileLoader::load_string_list(const std::string& key) const
 {
-    std::string value = load_value();
+    std::string value = load_value(key);
     std::vector<std::string> result;
     std::istringstream iss(value);
     std::string item;
@@ -46,7 +44,7 @@ std::vector<std::string> FileLoader::load_string_list() const
     return result;
 }
 
-std::string FileLoader::load_value() const
+std::string FileLoader::load_value(const std::string& key) const
 {
     std::ifstream ifs(file_path_);
     if (!ifs) {
@@ -78,12 +76,12 @@ std::string FileLoader::load_value() const
         auto value_start = value.find_first_not_of(" \t");
         if (value_start != std::string::npos) value = value.substr(value_start);
 
-        if (k == key_) {
+        if (k == key) {
             return value;
         }
     }
-    if (logger_) logger_->error("key not found: " + key_);
-    throw std::runtime_error("key not found: " + key_);
+    if (logger_) logger_->error("key not found: " + key);
+    throw std::runtime_error("key not found: " + key);
 }
 
 } // namespace device_reminder

--- a/src/infra/process_operation/process_base.cpp
+++ b/src/infra/process_operation/process_base.cpp
@@ -10,11 +10,13 @@
 #include "infra/file_loader/i_file_loader.hpp"
 #include "infra/logger/i_logger.hpp"
 
+namespace device_reminder {
+
 std::atomic<bool> ProcessBase::g_stop_flag{false};
 
 ProcessBase::ProcessBase(std::shared_ptr<IProcessQueue>    queue,
                          std::shared_ptr<IProcessReceiver> receiver,
-                         std::shared_ptr<IWorkerDispatcher>       dispatcher,
+                         std::shared_ptr<IProcessDispatcher> dispatcher,
                          std::shared_ptr<IProcessSender>   sender,
                          std::shared_ptr<IFileLoader>             file_loader,
                          std::shared_ptr<ILogger>                 logger,
@@ -36,10 +38,9 @@ ProcessBase::ProcessBase(std::shared_ptr<IProcessQueue>    queue,
     if (logger_) logger_->info("ProcessBase initialized");
 }
 
-int ProcessBase::run()
+void ProcessBase::run()
 {
     if (receiver_) receiver_->run();
-    if (dispatcher_) dispatcher_->start();
 
     if (logger_) logger_->info("ProcessBase run start");
 
@@ -48,11 +49,7 @@ int ProcessBase::run()
     }
 
     if (receiver_) receiver_->stop();
-    if (dispatcher_) dispatcher_->stop();
-    if (sender_) sender_->stop();
-    if (dispatcher_) dispatcher_->join();
     if (logger_) logger_->info("ProcessBase run end");
-    return 0;
 }
 
 void ProcessBase::stop()
@@ -65,3 +62,5 @@ int ProcessBase::priority() const noexcept
 {
     return priority_;
 }
+
+} // namespace device_reminder

--- a/tests/core/bluetooth_task/test_bluetooth_task.cpp
+++ b/tests/core/bluetooth_task/test_bluetooth_task.cpp
@@ -31,9 +31,9 @@ public:
 class StubLoader : public IFileLoader {
 public:
     std::vector<std::string> list;
-    int load_int() const override { return 0; }
-    std::string load_string() const override { return {}; }
-    std::vector<std::string> load_string_list() const override { return list; }
+    int load_int(const std::string&) const override { return 0; }
+    std::string load_string(const std::string&) const override { return {}; }
+    std::vector<std::string> load_string_list(const std::string&) const override { return list; }
 };
 
 class DummyLogger : public ILogger {

--- a/tests/core/buzzer_task/test_buzzer_task.cpp
+++ b/tests/core/buzzer_task/test_buzzer_task.cpp
@@ -23,9 +23,9 @@ public:
 
 class MockFileLoader : public IFileLoader {
 public:
-    MOCK_METHOD(int, load_int, (), (const, override));
-    MOCK_METHOD(std::string, load_string, (), (const, override));
-    MOCK_METHOD(std::vector<std::string>, load_string_list, (), (const, override));
+    MOCK_METHOD(int, load_int, (const std::string&), (const, override));
+    MOCK_METHOD(std::string, load_string, (const std::string&), (const, override));
+    MOCK_METHOD(std::vector<std::string>, load_string_list, (const std::string&), (const, override));
 };
 
 class MockLogger : public ILogger {

--- a/tests/core/human_task/test_human_process.cpp
+++ b/tests/core/human_task/test_human_process.cpp
@@ -1,0 +1,180 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "human_task/human_process.hpp"
+#include "infra/logger/i_logger.hpp"
+#include "infra/watch_dog/i_watch_dog.hpp"
+#include "infra/process_operation/process_queue/i_process_queue.hpp"
+#include "infra/process_operation/process_message/i_process_message.hpp"
+#include "infra/process_operation/process_receiver/i_process_receiver.hpp"
+#include "infra/process_operation/process_dispatcher/i_process_dispatcher.hpp"
+#include "infra/process_operation/process_sender/i_process_sender.hpp"
+#include "infra/file_loader/i_file_loader.hpp"
+#include "core/interfaces/i_handler.hpp"
+#include "core/human_task/i_human_task.hpp"
+#include <thread>
+#include <chrono>
+
+using ::testing::StrictMock;
+using ::testing::NiceMock;
+
+namespace device_reminder {
+
+class DummyQueue : public IProcessQueue {
+public:
+    void push(std::shared_ptr<IProcessMessage>) override {}
+    std::shared_ptr<IProcessMessage> pop() override { return nullptr; }
+    std::size_t size() const override { return 0; }
+};
+
+class MockReceiver : public IProcessReceiver {
+public:
+    MOCK_METHOD(void, run, (), (override));
+    MOCK_METHOD(void, stop, (), (override));
+};
+
+class MockDispatcher : public IProcessDispatcher {
+public:
+    MOCK_METHOD(void, dispatch, (std::shared_ptr<IProcessMessage>), (override));
+};
+
+class MockSender : public IProcessSender {
+public:
+    MOCK_METHOD(void, send, (), (override));
+};
+
+class MockLoader : public IFileLoader {
+public:
+    MOCK_METHOD(int, load_int, (const std::string&), (const, override));
+    MOCK_METHOD(std::string, load_string, (const std::string&), (const, override));
+    MOCK_METHOD(std::vector<std::string>, load_string_list, (const std::string&), (const, override));
+};
+
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
+};
+
+class MockWatchDog : public IWatchDog {
+public:
+    MOCK_METHOD(void, start, (), (override));
+    MOCK_METHOD(void, stop, (), (override));
+    MOCK_METHOD(void, kick, (), (override));
+};
+
+class MockHandler : public IHandler {
+public:
+    MOCK_METHOD(void, handle, (std::shared_ptr<IProcessMessage>), (override));
+};
+
+class MockTask : public IHumanTask {
+public:
+    MOCK_METHOD(void, on_detecting, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_stopping, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_cooldown, (const std::vector<std::string>&), (override));
+};
+
+TEST(HumanProcessTest, ConstructLogsWhenLoggerProvided) {
+    auto queue = std::make_shared<DummyQueue>();
+    auto receiver = std::make_shared<StrictMock<MockReceiver>>();
+    auto dispatcher = std::make_shared<StrictMock<MockDispatcher>>();
+    auto sender = std::make_shared<StrictMock<MockSender>>();
+    auto loader = std::make_shared<StrictMock<MockLoader>>();
+    auto logger = std::make_shared<StrictMock<MockLogger>>();
+    auto watchdog = std::make_shared<StrictMock<MockWatchDog>>();
+    auto handler = std::make_shared<StrictMock<MockHandler>>();
+    auto task = std::make_shared<StrictMock<MockTask>>();
+
+    EXPECT_CALL(*logger, info("HumanProcess created")).Times(1);
+    HumanProcess proc(queue, receiver, dispatcher, sender, loader, logger, watchdog, handler, task);
+}
+
+TEST(HumanProcessTest, ConstructNoLogger) {
+    auto queue = std::make_shared<DummyQueue>();
+    auto receiver = std::make_shared<StrictMock<MockReceiver>>();
+    auto dispatcher = std::make_shared<StrictMock<MockDispatcher>>();
+    auto sender = std::make_shared<StrictMock<MockSender>>();
+    auto loader = std::make_shared<StrictMock<MockLoader>>();
+    auto watchdog = std::make_shared<StrictMock<MockWatchDog>>();
+    auto handler = std::make_shared<StrictMock<MockHandler>>();
+    auto task = std::make_shared<StrictMock<MockTask>>();
+
+    HumanProcess proc(queue, receiver, dispatcher, sender, loader, nullptr, watchdog, handler, task);
+}
+
+TEST(HumanProcessTest, RunStartsAndStopsWatchDog) {
+    auto queue = std::make_shared<DummyQueue>();
+    auto receiver = std::make_shared<NiceMock<MockReceiver>>();
+    auto dispatcher = std::make_shared<NiceMock<MockDispatcher>>();
+    auto sender = std::make_shared<NiceMock<MockSender>>();
+    auto loader = std::make_shared<NiceMock<MockLoader>>();
+    auto logger = std::make_shared<NiceMock<MockLogger>>();
+    auto watchdog = std::make_shared<StrictMock<MockWatchDog>>();
+    auto handler = std::make_shared<NiceMock<MockHandler>>();
+    auto task = std::make_shared<NiceMock<MockTask>>();
+
+    HumanProcess proc(queue, receiver, dispatcher, sender, loader, logger, watchdog, handler, task);
+    std::thread th([&]{
+        proc.run();
+    });
+    EXPECT_CALL(*watchdog, start()).Times(1);
+    EXPECT_CALL(*receiver, run()).Times(1);
+    EXPECT_CALL(*receiver, stop()).Times(1);
+    EXPECT_CALL(*watchdog, stop()).Times(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    proc.stop();
+    th.join();
+}
+
+TEST(HumanProcessTest, RunWithoutWatchDog) {
+    auto queue = std::make_shared<DummyQueue>();
+    auto receiver = std::make_shared<NiceMock<MockReceiver>>();
+    auto dispatcher = std::make_shared<NiceMock<MockDispatcher>>();
+    auto sender = std::make_shared<NiceMock<MockSender>>();
+    auto loader = std::make_shared<NiceMock<MockLoader>>();
+    auto logger = std::make_shared<NiceMock<MockLogger>>();
+    auto handler = std::make_shared<NiceMock<MockHandler>>();
+    auto task = std::make_shared<NiceMock<MockTask>>();
+
+    HumanProcess proc(queue, receiver, dispatcher, sender, loader, logger, nullptr, handler, task);
+    std::thread th([&]{ proc.run(); });
+    EXPECT_CALL(*receiver, run()).Times(1);
+    EXPECT_CALL(*receiver, stop()).Times(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    proc.stop();
+    th.join();
+}
+
+TEST(HumanProcessTest, StopCallsWatchDog) {
+    auto queue = std::make_shared<DummyQueue>();
+    auto receiver = std::make_shared<NiceMock<MockReceiver>>();
+    auto dispatcher = std::make_shared<NiceMock<MockDispatcher>>();
+    auto sender = std::make_shared<NiceMock<MockSender>>();
+    auto loader = std::make_shared<NiceMock<MockLoader>>();
+    auto logger = std::make_shared<NiceMock<MockLogger>>();
+    auto watchdog = std::make_shared<StrictMock<MockWatchDog>>();
+    auto handler = std::make_shared<NiceMock<MockHandler>>();
+    auto task = std::make_shared<NiceMock<MockTask>>();
+
+    HumanProcess proc(queue, receiver, dispatcher, sender, loader, logger, watchdog, handler, task);
+    EXPECT_CALL(*watchdog, stop()).Times(1);
+    proc.stop();
+}
+
+TEST(HumanProcessTest, StopWithoutWatchDog) {
+    auto queue = std::make_shared<DummyQueue>();
+    auto receiver = std::make_shared<NiceMock<MockReceiver>>();
+    auto dispatcher = std::make_shared<NiceMock<MockDispatcher>>();
+    auto sender = std::make_shared<NiceMock<MockSender>>();
+    auto loader = std::make_shared<NiceMock<MockLoader>>();
+    auto logger = std::make_shared<NiceMock<MockLogger>>();
+    auto handler = std::make_shared<NiceMock<MockHandler>>();
+    auto task = std::make_shared<NiceMock<MockTask>>();
+
+    HumanProcess proc(queue, receiver, dispatcher, sender, loader, logger, nullptr, handler, task);
+    EXPECT_NO_THROW(proc.stop());
+}
+
+} // namespace device_reminder

--- a/tests/core/main_task/test_main_task.cpp
+++ b/tests/core/main_task/test_main_task.cpp
@@ -25,9 +25,9 @@ public:
 
 class MockFileLoader : public IFileLoader {
 public:
-    MOCK_METHOD(int, load_int, (), (const, override));
-    MOCK_METHOD(std::string, load_string, (), (const, override));
-    MOCK_METHOD(std::vector<std::string>, load_string_list, (), (const, override));
+    MOCK_METHOD(int, load_int, (const std::string&), (const, override));
+    MOCK_METHOD(std::string, load_string, (const std::string&), (const, override));
+    MOCK_METHOD(std::vector<std::string>, load_string_list, (const std::string&), (const, override));
 };
 
 class MockLogger : public ILogger {
@@ -68,7 +68,7 @@ TEST(MainTaskTest, DeviceDetectedStopsTimerAndNotifies) {
     auto buz_stop = std::make_shared<StrictMock<MockSender>>();
     auto logger = std::make_shared<NiceMock<MockLogger>>();
 
-    EXPECT_CALL(*file_loader, load_string_list()).WillOnce(testing::Return(std::vector<std::string>{"phone"}));
+    EXPECT_CALL(*file_loader, load_string_list("device_list")).WillOnce(testing::Return(std::vector<std::string>{"phone"}));
 
     MainTask task(logger, file_loader, human_start, human_stop, bt_sender, buz_start, buz_stop, det_timer, cd_timer);
 
@@ -93,7 +93,7 @@ TEST(MainTaskTest, DeviceNotDetectedStartsCooldown) {
     auto buz_stop = std::make_shared<StrictMock<MockSender>>();
     auto logger = std::make_shared<NiceMock<MockLogger>>();
 
-    EXPECT_CALL(*file_loader, load_string_list()).WillOnce(testing::Return(std::vector<std::string>{"phone"}));
+    EXPECT_CALL(*file_loader, load_string_list("device_list")).WillOnce(testing::Return(std::vector<std::string>{"phone"}));
 
     MainTask task(logger, file_loader, human_start, human_stop, bt_sender, buz_start, buz_stop, det_timer, cd_timer);
     task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}});
@@ -115,7 +115,7 @@ TEST(MainTaskTest, CooldownTimeoutRestartsScan) {
     auto buz_stop = std::make_shared<NiceMock<MockSender>>();
     auto logger = std::make_shared<NiceMock<MockLogger>>();
 
-    EXPECT_CALL(*file_loader, load_string_list()).WillRepeatedly(testing::Return(std::vector<std::string>{"phone"}));
+    EXPECT_CALL(*file_loader, load_string_list("device_list")).WillRepeatedly(testing::Return(std::vector<std::string>{"phone"}));
 
     MainTask task(logger, file_loader, human_start, human_stop, bt_sender, buz_start, buz_stop, det_timer, cd_timer);
     task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}});

--- a/tests/infra/buzzer_driver/test_buzzer_driver.cpp
+++ b/tests/infra/buzzer_driver/test_buzzer_driver.cpp
@@ -27,9 +27,9 @@ public:
 
 class MockLoader : public IFileLoader {
 public:
-    MOCK_METHOD(int, load_int, (), (const, override));
-    MOCK_METHOD(std::string, load_string, (), (const, override));
-    MOCK_METHOD(std::vector<std::string>, load_string_list, (), (const, override));
+    MOCK_METHOD(int, load_int, (const std::string&), (const, override));
+    MOCK_METHOD(std::string, load_string, (const std::string&), (const, override));
+    MOCK_METHOD(std::vector<std::string>, load_string_list, (const std::string&), (const, override));
 };
 
 } // namespace
@@ -40,7 +40,7 @@ TEST(BuzzerDriverTest, ConstructorAllValid) {
     auto gpio   = std::make_shared<StrictMock<MockGPIO>>();
 
     EXPECT_CALL(*logger, info("BuzzerDriver created")).Times(1);
-    EXPECT_CALL(*loader, load_int()).Times(1);
+    EXPECT_CALL(*loader, load_int("buzz_duration_ms")).Times(1);
 
     BuzzerDriver driver(loader, logger, gpio);
 }
@@ -58,7 +58,7 @@ TEST(BuzzerDriverTest, ConstructorLoggerNull) {
     auto loader = std::make_shared<StrictMock<MockLoader>>();
     auto gpio   = std::make_shared<StrictMock<MockGPIO>>();
 
-    EXPECT_CALL(*loader, load_int()).Times(1);
+    EXPECT_CALL(*loader, load_int("buzz_duration_ms")).Times(1);
 
     BuzzerDriver driver(loader, nullptr, gpio);
 }
@@ -72,7 +72,7 @@ TEST(BuzzerDriverTest, ConstructorLoadIntThrowsLogsError) {
     auto logger = std::make_shared<StrictMock<MockLogger>>();
 
     EXPECT_CALL(*logger, info("BuzzerDriver created")).Times(1);
-    EXPECT_CALL(*loader, load_int()).WillOnce(Throw(std::runtime_error("err")));
+    EXPECT_CALL(*loader, load_int("buzz_duration_ms")).WillOnce(Throw(std::runtime_error("err")));
     EXPECT_CALL(*logger, error("Failed to load buzzer config")).Times(1);
 
     BuzzerDriver driver(loader, logger, nullptr);

--- a/tests/infra/file_loader/test_file_loader.cpp
+++ b/tests/infra/file_loader/test_file_loader.cpp
@@ -26,9 +26,9 @@ TEST(FileLoaderTest, LoadIntSuccess) {
     ofs.close();
 
     NiceMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt", "buzz_duration_ms");
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt");
 
-    EXPECT_EQ(loader.load_int(), 5000);
+    EXPECT_EQ(loader.load_int("buzz_duration_ms"), 5000);
 }
 
 TEST(FileLoaderTest, LoadIntThrowsIfMissing) {
@@ -37,9 +37,9 @@ TEST(FileLoaderTest, LoadIntThrowsIfMissing) {
     ofs.close();
 
     StrictMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt", "b");
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt");
     EXPECT_CALL(logger, error(testing::HasSubstr("key not found"))).Times(1);
-    EXPECT_THROW(loader.load_int(), std::runtime_error);
+    EXPECT_THROW(loader.load_int("b"), std::runtime_error);
 }
 
 TEST(FileLoaderTest, LoadIntThrowsIfInvalid) {
@@ -48,16 +48,16 @@ TEST(FileLoaderTest, LoadIntThrowsIfInvalid) {
     ofs.close();
 
     StrictMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt", "buzz_duration_ms");
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt");
     EXPECT_CALL(logger, error(testing::HasSubstr("invalid int value"))).Times(1);
-    EXPECT_THROW(loader.load_int(), std::invalid_argument);
+    EXPECT_THROW(loader.load_int("buzz_duration_ms"), std::invalid_argument);
 }
 
 TEST(FileLoaderTest, LoadIntThrowsIfFileMissing) {
     StrictMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/does_not_exist.txt", "buzz_duration_ms");
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/does_not_exist.txt");
     EXPECT_CALL(logger, error(testing::HasSubstr("failed to open file"))).Times(1);
-    EXPECT_THROW(loader.load_int(), std::runtime_error);
+    EXPECT_THROW(loader.load_int("buzz_duration_ms"), std::runtime_error);
 }
 
 TEST(FileLoaderTest, LoadIntInvalidWithoutLogger) {
@@ -65,8 +65,8 @@ TEST(FileLoaderTest, LoadIntInvalidWithoutLogger) {
     ofs << "buzz_duration_ms=bad\n";
     ofs.close();
 
-    FileLoader loader(nullptr, "/tmp/test_settings.txt", "buzz_duration_ms");
-    EXPECT_THROW(loader.load_int(), std::invalid_argument);
+    FileLoader loader(nullptr, "/tmp/test_settings.txt");
+    EXPECT_THROW(loader.load_int("buzz_duration_ms"), std::invalid_argument);
 }
 
 TEST(FileLoaderTest, LoadStringSuccess) {
@@ -75,15 +75,15 @@ TEST(FileLoaderTest, LoadStringSuccess) {
     ofs.close();
 
     NiceMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt", "device_name");
-    EXPECT_EQ(loader.load_string(), "reminder");
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt");
+    EXPECT_EQ(loader.load_string("device_name"), "reminder");
 }
 
 TEST(FileLoaderTest, LoadStringFileMissing) {
     StrictMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/missing.txt", "device_name");
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/missing.txt");
     EXPECT_CALL(logger, error(testing::HasSubstr("failed to open file"))).Times(1);
-    EXPECT_THROW(loader.load_string(), std::runtime_error);
+    EXPECT_THROW(loader.load_string("device_name"), std::runtime_error);
 }
 
 TEST(FileLoaderTest, LoadStringKeyMissing) {
@@ -92,9 +92,9 @@ TEST(FileLoaderTest, LoadStringKeyMissing) {
     ofs.close();
 
     StrictMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt", "device_name");
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt");
     EXPECT_CALL(logger, error(testing::HasSubstr("key not found"))).Times(1);
-    EXPECT_THROW(loader.load_string(), std::runtime_error);
+    EXPECT_THROW(loader.load_string("device_name"), std::runtime_error);
 }
 
 TEST(FileLoaderTest, LoadStringListSuccess) {
@@ -103,8 +103,8 @@ TEST(FileLoaderTest, LoadStringListSuccess) {
     ofs.close();
 
     NiceMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt", "device_list");
-    auto list = loader.load_string_list();
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt");
+    auto list = loader.load_string_list("device_list");
     ASSERT_EQ(list.size(), 3);
     EXPECT_EQ(list[0], "phone");
     EXPECT_EQ(list[1], "watch");
@@ -117,7 +117,7 @@ TEST(FileLoaderTest, LoadStringListKeyMissing) {
     ofs.close();
 
     StrictMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt", "device_list");
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt");
     EXPECT_CALL(logger, error(testing::HasSubstr("key not found"))).Times(1);
-    EXPECT_THROW(loader.load_string_list(), std::runtime_error);
+    EXPECT_THROW(loader.load_string_list("device_list"), std::runtime_error);
 }

--- a/tests/infra/pir_driver/test_pir_driver.cpp
+++ b/tests/infra/pir_driver/test_pir_driver.cpp
@@ -29,9 +29,9 @@ public:
 };
 class DummyLoader : public IFileLoader {
 public:
-    int load_int() const override { return 0; }
-    std::string load_string() const override { return ""; }
-    std::vector<std::string> load_string_list() const override { return {}; }
+    int load_int(const std::string&) const override { return 0; }
+    std::string load_string(const std::string&) const override { return ""; }
+    std::vector<std::string> load_string_list(const std::string&) const override { return {}; }
 };
 } // namespace
 


### PR DESCRIPTION
## Summary
- Add test_human_process.cpp covering constructor, run, and stop behaviors
- Update file loader API to accept key parameters
- Modify infrastructure and tests to use new file loader interface
- Include ProcessBase implementation in test build targets

## Testing
- `cmake --build build --target test_app test_gpio_reader test_infra_extra -j$(nproc)` *(fails: undefined references and compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b193743dc83288b69de8c55292029