### PR TITLE
Add extended MainHandler tests

### DIFF
--- a/tests/core/main_task/test_main_handler.cpp
+++ b/tests/core/main_task/test_main_handler.cpp
@@ -70,3 +70,101 @@ TEST(MainHandlerTest, CooldownCallsTask) {
 }
 
 } // namespace device_reminder
+
+namespace device_reminder {
+
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
+};
+
+TEST(MainHandlerExtendedTest, ConstructorLogsWhenLoggerProvided) {
+    auto task = std::make_shared<StrictMock<MockMainTask>>();
+    auto logger = std::make_shared<StrictMock<MockLogger>>();
+
+    EXPECT_CALL(*logger, info(testing::StrEq("MainHandler created"))).Times(1);
+
+    MainHandler handler(logger, task, nullptr, nullptr);
+    (void)handler;
+}
+
+TEST(MainHandlerExtendedTest, ConstructorAcceptsNullLogger) {
+    auto task = std::make_shared<StrictMock<MockMainTask>>();
+    MainHandler handler(nullptr, task, nullptr, nullptr);
+    (void)handler;
+}
+
+TEST(MainHandlerExtendedTest, ScanTimeoutCallsWaitingSecondResponse) {
+    auto task = std::make_shared<StrictMock<MockMainTask>>();
+    auto logger = std::make_shared<DummyLogger>();
+    MainHandler handler(logger, task, nullptr, nullptr);
+
+    EXPECT_CALL(*task, on_waiting_for_second_response(testing::_)).Times(1);
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::ScanTimeout,
+                                                std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+TEST(MainHandlerExtendedTest, InvalidPayloadCallsBuzzerTask) {
+    auto task = std::make_shared<StrictMock<MockMainTask>>();
+    auto logger = std::make_shared<DummyLogger>();
+    MainHandler handler(logger, task, nullptr, nullptr);
+
+    EXPECT_CALL(*task, on_response_to_buzzer_task(testing::_)).Times(1);
+
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::ResponseDevicePresence,
+        std::vector<std::string>{"invalid"});
+    handler.handle(msg);
+}
+
+TEST(MainHandlerExtendedTest, UnknownMessageTypeDoesNothing) {
+    auto task = std::make_shared<StrictMock<MockMainTask>>();
+    auto logger = std::make_shared<DummyLogger>();
+    MainHandler handler(logger, task, nullptr, nullptr);
+
+    EXPECT_CALL(*task, on_waiting_for_human(testing::_)).Times(0);
+    EXPECT_CALL(*task, on_response_to_buzzer_task(testing::_)).Times(0);
+    EXPECT_CALL(*task, on_response_to_human_task(testing::_)).Times(0);
+    EXPECT_CALL(*task, on_cooldown(testing::_)).Times(0);
+    EXPECT_CALL(*task, on_waiting_for_second_response(testing::_)).Times(0);
+
+    auto msg = std::make_shared<ProcessMessage>(
+        static_cast<ProcessMessageType>(999), std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+TEST(MainHandlerExtendedTest, NullMessageDoesNothing) {
+    auto task = std::make_shared<StrictMock<MockMainTask>>();
+    auto logger = std::make_shared<DummyLogger>();
+    MainHandler handler(logger, task, nullptr, nullptr);
+
+    EXPECT_CALL(*task, on_waiting_for_human(testing::_)).Times(0);
+    EXPECT_CALL(*task, on_response_to_buzzer_task(testing::_)).Times(0);
+    EXPECT_CALL(*task, on_response_to_human_task(testing::_)).Times(0);
+    EXPECT_CALL(*task, on_cooldown(testing::_)).Times(0);
+    EXPECT_CALL(*task, on_waiting_for_second_response(testing::_)).Times(0);
+
+    handler.handle(nullptr);
+}
+
+TEST(MainHandlerExtendedTest, NullTaskCausesNoCall) {
+    auto dummy_task = std::make_shared<StrictMock<MockMainTask>>();
+    auto logger = std::make_shared<DummyLogger>();
+    MainHandler handler(logger, nullptr, nullptr, nullptr);
+
+    EXPECT_CALL(*dummy_task, on_waiting_for_human(testing::_)).Times(0);
+    EXPECT_CALL(*dummy_task, on_response_to_buzzer_task(testing::_)).Times(0);
+    EXPECT_CALL(*dummy_task, on_response_to_human_task(testing::_)).Times(0);
+    EXPECT_CALL(*dummy_task, on_cooldown(testing::_)).Times(0);
+    EXPECT_CALL(*dummy_task, on_waiting_for_second_response(testing::_)).Times(0);
+
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::HumanDetected, std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+} // namespace device_reminder


### PR DESCRIPTION
## Summary
- add more test cases for MainHandler covering constructor and error handling

## Testing
- `g++ -std=c++17 ... -o test_main_handler.out`
- `./test_main_handler.out --gtest_color=yes`

------
https://chatgpt.com/codex/tasks/task_e_688b1a0fc4e08328944ca69907243d4b