### PR TITLE
Add BluetoothTask test coverage

### DIFF
--- a/tests/core/bluetooth_task/test_bluetooth_task.cpp
+++ b/tests/core/bluetooth_task/test_bluetooth_task.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <vector>
 
 #include "bluetooth_task/bluetooth_task.hpp"
@@ -43,6 +44,13 @@ public:
     void warn(const std::string&) override {}
 };
 
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
+};
+
 TEST(BluetoothTaskTest, SendsDetectedTrueWhenDeviceFound) {
     auto driver = std::make_shared<StubDriver>();
     auto sender = std::make_shared<StubSender>();
@@ -85,6 +93,93 @@ TEST(BluetoothTaskTest, DriverErrorLogsAndSendsFalse) {
     task.on_waiting({});
 
     EXPECT_EQ(sender->call_count, 0);
+}
+
+TEST(BluetoothTaskTest, ConstructorLogsWhenLoggerGiven) {
+    auto driver = std::make_shared<StubDriver>();
+    auto sender = std::make_shared<StubSender>();
+    auto loader = std::make_shared<StubLoader>();
+    auto logger = std::make_shared<testing::StrictMock<MockLogger>>();
+
+    EXPECT_CALL(*logger, info("BluetoothTask created")).Times(1);
+    BluetoothTask task(logger, sender, loader, driver);
+}
+
+TEST(BluetoothTaskTest, DestructorLogsWhenLoggerGiven) {
+    auto driver = std::make_shared<StubDriver>();
+    auto sender = std::make_shared<StubSender>();
+    auto loader = std::make_shared<StubLoader>();
+    auto logger = std::make_shared<testing::StrictMock<MockLogger>>();
+
+    {
+        EXPECT_CALL(*logger, info("BluetoothTask created")).Times(1);
+        EXPECT_CALL(*logger, info("BluetoothTask destroyed")).Times(1);
+        BluetoothTask task(logger, sender, loader, driver);
+    }
+}
+
+TEST(BluetoothTaskTest, OnWaitingSendsWhenLoaderNull) {
+    auto driver = std::make_shared<StubDriver>();
+    auto sender = std::make_shared<StubSender>();
+    std::shared_ptr<StubLoader> loader = nullptr;
+    auto logger = std::make_shared<DummyLogger>();
+
+    BluetoothTask task(logger, sender, loader, driver);
+    driver->names = {"phone"};
+
+    task.on_waiting({});
+
+    EXPECT_EQ(sender->call_count, 1);
+}
+
+TEST(BluetoothTaskTest, OnWaitingNoSendWhenDriverNull) {
+    std::shared_ptr<StubDriver> driver = nullptr;
+    auto sender = std::make_shared<StubSender>();
+    auto loader = std::make_shared<StubLoader>();
+    auto logger = std::make_shared<DummyLogger>();
+
+    BluetoothTask task(logger, sender, loader, driver);
+    task.on_waiting({});
+
+    EXPECT_EQ(sender->call_count, 0);
+}
+
+TEST(BluetoothTaskTest, OnWaitingNoSendWhenSenderNull) {
+    auto driver = std::make_shared<StubDriver>();
+    std::shared_ptr<StubSender> sender = nullptr;
+    auto loader = std::make_shared<StubLoader>();
+    auto logger = std::make_shared<DummyLogger>();
+
+    BluetoothTask task(logger, sender, loader, driver);
+    driver->names = {"phone"};
+    loader->list = {"phone"};
+
+    EXPECT_NO_THROW(task.on_waiting({}));
+}
+
+TEST(BluetoothTaskTest, DriverExceptionLogsError) {
+    auto driver = std::make_shared<StubDriver>();
+    auto sender = std::make_shared<StubSender>();
+    auto loader = std::make_shared<StubLoader>();
+    auto logger = std::make_shared<testing::StrictMock<MockLogger>>();
+    BluetoothTask task(logger, sender, loader, driver);
+
+    driver->fail = true;
+    EXPECT_CALL(*logger, error("fail"));
+    task.on_waiting({});
+
+    EXPECT_EQ(sender->call_count, 0);
+}
+
+TEST(BluetoothTaskTest, DriverExceptionWithoutLogger) {
+    auto driver = std::make_shared<StubDriver>();
+    auto sender = std::make_shared<StubSender>();
+    auto loader = std::make_shared<StubLoader>();
+    std::shared_ptr<ILogger> logger = nullptr;
+    BluetoothTask task(logger, sender, loader, driver);
+
+    driver->fail = true;
+    EXPECT_NO_THROW(task.on_waiting({}));
 }
 
 } // namespace device_reminder


### PR DESCRIPTION
## Summary
- add gmock-based logger mock for BluetoothTask tests
- extend tests to cover constructor and destructor log calls
- cover additional pointer cases for `on_waiting`
- ensure exceptions are handled when no logger is present

## Testing
- `cmake --build . --target test_app` *(fails: ProcessBase related compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b1a2e6b90832881317901f9b33e19