### PR TITLE
Add tests for ThreadDispatcher logs

### DIFF
--- a/tests/infra/thread_operation/test_thread_dispatcher.cpp
+++ b/tests/infra/thread_operation/test_thread_dispatcher.cpp
@@ -1,8 +1,22 @@
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
 #include "infra/thread_operation/thread_dispatcher/thread_dispatcher.hpp"
 #include "infra/thread_operation/thread_message/thread_message.hpp"
+#include "infra/logger/i_logger.hpp"
+
+using ::testing::NiceMock;
 
 using namespace device_reminder;
+
+namespace {
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
+};
+} // namespace
 
 TEST(ThreadDispatcherTest, CallsRegisteredHandler) {
     bool called = false;
@@ -28,4 +42,32 @@ TEST(ThreadDispatcherTest, IgnoresUnknownMessage) {
                                                std::vector<std::string>{});
     disp.dispatch(msg);
     EXPECT_FALSE(called);
+}
+
+TEST(ThreadDispatcherTest, ConstructorLogsCreation) {
+    NiceMock<MockLogger> logger;
+    EXPECT_CALL(logger, info("ThreadDispatcher created")).Times(1);
+
+    ThreadDispatcher::HandlerMap map{};
+    ThreadDispatcher disp(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), map);
+}
+
+TEST(ThreadDispatcherTest, DispatchLogsErrorOnNullMessage) {
+    NiceMock<MockLogger> logger;
+    EXPECT_CALL(logger, error("Null thread message")).Times(1);
+
+    ThreadDispatcher::HandlerMap map{};
+    ThreadDispatcher disp(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), map);
+    disp.dispatch(nullptr);
+}
+
+TEST(ThreadDispatcherTest, DispatchLogsInfoOnUnhandledMessage) {
+    NiceMock<MockLogger> logger;
+    EXPECT_CALL(logger, info("Unhandled thread message")).Times(1);
+
+    ThreadDispatcher::HandlerMap map{};
+    ThreadDispatcher disp(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), map);
+    auto msg = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing,
+                                               std::vector<std::string>{});
+    disp.dispatch(msg);
 }


### PR DESCRIPTION
## Summary
- ThreadDispatcherのモックロガーを用意
- 生成時と未処理メッセージ、Nullメッセージ時のログ出力を確認するテストを追加

## Testing
- `cmake -S . -B build` *(fails: build/test_infra_extra due to unrelated errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b11823c248328a36da6f0ef003233