### PR TITLE
Add ProcessBase priority tests

### DIFF
--- a/include/infra/process_operation/process_base/process_base.hpp
+++ b/include/infra/process_operation/process_base/process_base.hpp
@@ -12,6 +12,14 @@
 #include <memory>
 #include <string>
 
+class IWorkerDispatcher {
+public:
+    virtual ~IWorkerDispatcher() = default;
+    virtual void start() = 0;
+    virtual void stop() = 0;
+    virtual void join() = 0;
+};
+
 class ProcessBase : public IProcessBase {
 public:
     ProcessBase(std::shared_ptr<IProcessQueue>    queue,

--- a/src/infra/process_operation/process_base.cpp
+++ b/src/infra/process_operation/process_base.cpp
@@ -26,7 +26,7 @@ ProcessBase::ProcessBase(std::shared_ptr<IProcessQueue>    queue,
     , file_loader_(std::move(file_loader))
     , logger_(std::move(logger))
     , process_name_(std::move(process_name))
-    , priority_{file_loader_ ? file_loader_->load_int("priority") : 0}
+    , priority_{file_loader_ ? file_loader_->load_int() : 0}
 
 {
     // Ctrl‑C (SIGINT) を捕捉して終了フラグを立てる

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,14 @@ add_executable(process_sender_tests
     ${PROJECT_ROOT}/tests/stubs/posix_mq_stub.cpp
 )
 
+# ProcessBase のテスト
+add_executable(process_base_tests
+    infra/process_operation/test_process_base.cpp
+    ${PROJECT_ROOT}/src/infra/process_operation/process_base.cpp
+)
+
+target_link_libraries(process_base_tests gtest gmock gtest_main pthread)
+
 target_link_libraries(process_queue_tests gtest gmock gtest_main pthread)
 
 # MessageCodec のテスト
@@ -53,6 +61,7 @@ target_link_libraries(message_codec_tests gtest gmock gtest_main pthread)
 enable_testing()
 add_test(NAME process_queue_tests COMMAND process_queue_tests)
 add_test(NAME message_codec_tests COMMAND message_codec_tests)
+add_test(NAME process_base_tests COMMAND process_base_tests)
 
 
 # PIRDriver テスト

--- a/tests/infra/process_operation/test_process_base.cpp
+++ b/tests/infra/process_operation/test_process_base.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "infra/logger/i_logger.hpp"
+#include "infra/file_loader/i_file_loader.hpp"
+#include "infra/process_operation/process_queue/i_process_queue.hpp"
+#include "infra/process_operation/process_receiver/i_process_receiver.hpp"
+#include "infra/process_operation/process_sender/i_process_sender.hpp"
+
+// 未定義の IWorkerDispatcher をテスト用に定義
+class IWorkerDispatcher {
+public:
+    virtual ~IWorkerDispatcher() = default;
+    virtual void start() = 0;
+    virtual void stop() = 0;
+    virtual void join() = 0;
+};
+
+using namespace device_reminder;
+
+#include "infra/process_operation/process_base/process_base.hpp"
+
+using ::testing::NiceMock;
+using ::testing::StrictMock;
+using ::testing::Return;
+using ::testing::Throw;
+
+namespace {
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
+};
+
+class MockFileLoader : public IFileLoader {
+public:
+    MOCK_METHOD(int, load_int, (), (const, override));
+    MOCK_METHOD(std::string, load_string, (), (const, override));
+    MOCK_METHOD(std::vector<std::string>, load_string_list, (), (const, override));
+};
+} // namespace
+
+TEST(ProcessBaseTest, MockNormal_PriorityFromLoader) {
+    NiceMock<MockLogger> logger;
+    NiceMock<MockFileLoader> loader;
+    EXPECT_CALL(loader, load_int()).WillOnce(Return(5));
+
+    ProcessBase p(nullptr, nullptr, nullptr, nullptr,
+                  std::shared_ptr<IFileLoader>(&loader, [](IFileLoader*){}),
+                  std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                  "TestProcess");
+
+    EXPECT_EQ(p.priority(), 5);
+}
+
+TEST(ProcessBaseTest, PointerAbnormal_NullFileLoader) {
+    NiceMock<MockLogger> logger;
+
+    ProcessBase p(nullptr, nullptr, nullptr, nullptr,
+                  nullptr,
+                  std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                  "TestProcess");
+
+    EXPECT_EQ(p.priority(), 0);
+}
+
+TEST(ProcessBaseTest, MockAbnormal_FileLoaderThrows) {
+    NiceMock<MockLogger> logger;
+    StrictMock<MockFileLoader> loader;
+    EXPECT_CALL(loader, load_int()).WillOnce(Throw(std::runtime_error("fail")));
+
+    EXPECT_THROW(ProcessBase(nullptr, nullptr, nullptr, nullptr,
+                             std::shared_ptr<IFileLoader>(&loader, [](IFileLoader*){}),
+                             std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                             "TestProcess"),
+                 std::runtime_error);
+}


### PR DESCRIPTION
## Summary
- fix `ProcessBase` to call `load_int()` with no argument
- define `IWorkerDispatcher` interface in header for compilation
- add unit tests for `ProcessBase` priority handling
- wire new test into `tests/CMakeLists.txt`

## Testing
- `cmake ..` *(fails: di/app_injector.hpp not found when building full project)*
- `cmake ..` in `tests` directory *(fails: duplicate test names)*

------
https://chatgpt.com/codex/tasks/task_e_688b1911ce808328bd431e717829fcbb