### PR TITLE
Add BuzzerHandler tests

### DIFF
--- a/tests/core/buzzer_task/test_buzzer_handler.cpp
+++ b/tests/core/buzzer_task/test_buzzer_handler.cpp
@@ -30,6 +30,13 @@ public:
     void warn(const std::string&) override {}
 };
 
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
+};
+
 TEST(BuzzerHandlerTest, StartBuzzingStartsTimerAndCallsTask) {
     auto task = std::make_shared<StrictMock<MockBuzzerTask>>();
     auto timer = std::make_shared<StrictMock<MockTimer>>();
@@ -68,6 +75,70 @@ TEST(BuzzerHandlerTest, TimeoutStopsTimerAndCallsTask) {
     auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::BuzzTimeout, std::vector<std::string>{});
     handler.handle(msg);
 }
+
+TEST(BuzzerHandlerTest, ConstructorLogsCreation) {
+    StrictMock<MockLogger> logger;
+    auto task = std::make_shared<NiceMock<MockBuzzerTask>>();
+    auto timer = std::make_shared<NiceMock<MockTimer>>();
+    EXPECT_CALL(logger, info("BuzzerHandler created")).Times(1);
+    BuzzerHandler handler(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), task, timer);
+}
+
+TEST(BuzzerHandlerTest, HandleNullMessageDoesNothing) {
+    StrictMock<MockLogger> logger;
+    StrictMock<MockBuzzerTask> task;
+    StrictMock<MockTimer> timer;
+    BuzzerHandler handler(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                          std::shared_ptr<IBuzzerTask>(&task, [](IBuzzerTask*){}),
+                          std::shared_ptr<ITimerService>(&timer, [](ITimerService*){}));
+
+    EXPECT_CALL(timer, start()).Times(0);
+    EXPECT_CALL(timer, stop()).Times(0);
+    EXPECT_CALL(task, on_buzzing(testing::_)).Times(0);
+    EXPECT_CALL(task, on_waiting(testing::_)).Times(0);
+    EXPECT_CALL(logger, info(testing::_)).Times(1); // constructor only
+
+    handler.handle(nullptr);
+}
+
+TEST(BuzzerHandlerTest, StartBuzzingWithoutTimer) {
+    StrictMock<MockLogger> logger;
+    StrictMock<MockBuzzerTask> task;
+    BuzzerHandler handler(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                          std::shared_ptr<IBuzzerTask>(&task, [](IBuzzerTask*){}),
+                          nullptr);
+
+    {
+        testing::InSequence seq;
+        EXPECT_CALL(logger, info("BuzzerHandler created")).Times(1);
+        EXPECT_CALL(task, on_buzzing(testing::_)).Times(1);
+        EXPECT_CALL(logger, info("StartBuzzing")).Times(1);
+    }
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    handler.handle(msg);
+}
+
+TEST(BuzzerHandlerTest, StartBuzzingLogsMessage) {
+    StrictMock<MockLogger> logger;
+    StrictMock<MockBuzzerTask> task;
+    StrictMock<MockTimer> timer;
+    {
+        testing::InSequence seq;
+        EXPECT_CALL(logger, info("BuzzerHandler created")).Times(1);
+        EXPECT_CALL(timer, start()).Times(1);
+        EXPECT_CALL(task, on_buzzing(testing::_)).Times(1);
+        EXPECT_CALL(logger, info("StartBuzzing")).Times(1);
+    }
+
+    BuzzerHandler handler(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                          std::shared_ptr<IBuzzerTask>(&task, [](IBuzzerTask*){}),
+                          std::shared_ptr<ITimerService>(&timer, [](ITimerService*){}));
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    handler.handle(msg);
+}
+
 
 } // namespace device_reminder
 


### PR DESCRIPTION
## Summary
- extend BuzzerHandler tests for constructor and null cases

## Testing
- `cmake ..`
- `cmake --build . --target test_app` *(fails: di/app_injector.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688b1a58ec6083288d09cb05ffb2a29f