### PR TITLE
Add BuzzerProcess tests and fix run signatures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(test_app
     tests/core/main_task/test_main_handler.cpp
     tests/core/buzzer_task/test_buzzer_handler.cpp
     tests/core/buzzer_task/test_buzzer_task.cpp
+    tests/core/buzzer_task/test_buzzer_process.cpp
     tests/core/bluetooth_task/test_bluetooth_handler.cpp
     tests/core/bluetooth_task/test_bluetooth_task.cpp
     tests/infra/logger/test_logger.cpp

--- a/include/core/bluetooth_task/bluetooth_process.hpp
+++ b/include/core/bluetooth_task/bluetooth_process.hpp
@@ -22,7 +22,7 @@ public:
                      std::shared_ptr<IHandler> handler,
                      std::shared_ptr<IBluetoothTask> task);
 
-    void run() override;
+    int run() override;
     void stop() override;
 
 private:

--- a/include/core/bluetooth_task/i_bluetooth_process.hpp
+++ b/include/core/bluetooth_task/i_bluetooth_process.hpp
@@ -5,7 +5,7 @@ namespace device_reminder {
 class IBluetoothProcess {
 public:
     virtual ~IBluetoothProcess() = default;
-    virtual void run() = 0;
+    virtual int run() = 0;
     virtual void stop() = 0;
 };
 

--- a/include/core/buzzer_task/buzzer_process.hpp
+++ b/include/core/buzzer_task/buzzer_process.hpp
@@ -17,7 +17,7 @@ public:
                   std::shared_ptr<ILogger> logger,
                   std::shared_ptr<IWatchDog> watch_dog);
 
-    void run() override;
+    int run() override;
     void stop() override;
 
 private:

--- a/include/core/buzzer_task/i_buzzer_process.hpp
+++ b/include/core/buzzer_task/i_buzzer_process.hpp
@@ -5,7 +5,7 @@ namespace device_reminder {
 class IBuzzerProcess {
 public:
     virtual ~IBuzzerProcess() = default;
-    virtual void run() = 0;
+    virtual int run() = 0;
     virtual void stop() = 0;
 };
 

--- a/include/core/human_task/human_process.hpp
+++ b/include/core/human_task/human_process.hpp
@@ -22,7 +22,7 @@ public:
                  std::shared_ptr<IHandler>         handler,
                  std::shared_ptr<IHumanTask>       task);
 
-    void run() override;
+    int run() override;
     void stop() override;
 
 private:

--- a/include/core/human_task/i_human_process.hpp
+++ b/include/core/human_task/i_human_process.hpp
@@ -5,7 +5,7 @@ namespace device_reminder {
 class IHumanProcess {
 public:
     virtual ~IHumanProcess() = default;
-    virtual void run() = 0;
+    virtual int run() = 0;
     virtual void stop() = 0;
 };
 

--- a/include/core/main_task/i_main_process.hpp
+++ b/include/core/main_task/i_main_process.hpp
@@ -5,7 +5,7 @@ namespace device_reminder {
 class IMainProcess {
 public:
     virtual ~IMainProcess() = default;
-    virtual void run() = 0;
+    virtual int run() = 0;
     virtual void stop() = 0;
 };
 

--- a/include/core/main_task/main_process.hpp
+++ b/include/core/main_task/main_process.hpp
@@ -16,7 +16,7 @@ public:
                 std::shared_ptr<ILogger> logger,
                 std::shared_ptr<IWatchDog> watchdog);
 
-    void run() override;
+    int run() override;
     void stop() override;
 
 private:

--- a/src/core/bluetooth_task/bluetooth_process.cpp
+++ b/src/core/bluetooth_task/bluetooth_process.cpp
@@ -26,10 +26,11 @@ BluetoothProcess::BluetoothProcess(std::shared_ptr<IProcessQueue> queue,
     if (logger_) logger_->info("BluetoothProcess created");
 }
 
-void BluetoothProcess::run() {
+int BluetoothProcess::run() {
     if (watch_dog_) watch_dog_->start();
-    ProcessBase::run();
+    auto result = ProcessBase::run();
     if (watch_dog_) watch_dog_->stop();
+    return result;
 }
 
 void BluetoothProcess::stop() {

--- a/src/core/buzzer_task/buzzer_process.cpp
+++ b/src/core/buzzer_task/buzzer_process.cpp
@@ -20,11 +20,12 @@ BuzzerProcess::BuzzerProcess(std::shared_ptr<IProcessReceiver> receiver,
     if (logger_) logger_->info("BuzzerProcess created");
 }
 
-void BuzzerProcess::run()
+int BuzzerProcess::run()
 {
     if (watch_dog_) watch_dog_->start();
-    ProcessBase::run();
+    auto result = ProcessBase::run();
     if (watch_dog_) watch_dog_->stop();
+    return result;
 }
 
 void BuzzerProcess::stop()

--- a/src/core/human_task/human_process.cpp
+++ b/src/core/human_task/human_process.cpp
@@ -26,10 +26,11 @@ HumanProcess::HumanProcess(std::shared_ptr<IProcessQueue>    queue,
     if (logger_) logger_->info("HumanProcess created");
 }
 
-void HumanProcess::run() {
+int HumanProcess::run() {
     if (watch_dog_) watch_dog_->start();
-    ProcessBase::run();
+    auto result = ProcessBase::run();
     if (watch_dog_) watch_dog_->stop();
+    return result;
 }
 
 void HumanProcess::stop() {

--- a/src/core/main_task/main_process.cpp
+++ b/src/core/main_task/main_process.cpp
@@ -20,11 +20,12 @@ MainProcess::MainProcess(std::shared_ptr<IProcessReceiver> receiver,
     if (logger_) logger_->info("MainProcess created");
 }
 
-void MainProcess::run()
+int MainProcess::run()
 {
     if (watchdog_) watchdog_->start();
-    ProcessBase::run();
+    auto result = ProcessBase::run();
     if (watchdog_) watchdog_->stop();
+    return result;
 }
 
 void MainProcess::stop()

--- a/tests/core/buzzer_task/test_buzzer_process.cpp
+++ b/tests/core/buzzer_task/test_buzzer_process.cpp
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace device_reminder {}
+using namespace device_reminder;
+#include "buzzer_task/buzzer_process.hpp"
+
+using ::testing::StrictMock;
+
+namespace device_reminder {
+
+class MockWatchDog : public IWatchDog {
+public:
+    MOCK_METHOD(void, start, (), (override));
+    MOCK_METHOD(void, stop, (), (override));
+    MOCK_METHOD(void, kick, (), (override));
+};
+
+class DummyLogger : public ILogger {
+public:
+    void info(const std::string&) override {}
+    void error(const std::string&) override {}
+    void warn(const std::string&) override {}
+};
+
+} // namespace device_reminder
+
+TEST(BuzzerProcessTest, RunStartsAndStopsWatchDog) {
+    using namespace device_reminder;
+
+    auto wd = std::make_shared<StrictMock<MockWatchDog>>();
+    // Set stop flag so ProcessBase::run exits immediately
+    BuzzerProcess flag_setter(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+    flag_setter.stop();
+
+    BuzzerProcess proc(nullptr, nullptr, nullptr, nullptr, nullptr, wd);
+
+    EXPECT_CALL(*wd, start()).Times(1);
+    EXPECT_CALL(*wd, stop()).Times(1);
+
+    EXPECT_EQ(proc.run(), 0);
+}
+
+TEST(BuzzerProcessTest, StopCallsWatchDogStop) {
+    using namespace device_reminder;
+
+    auto wd = std::make_shared<StrictMock<MockWatchDog>>();
+    BuzzerProcess proc(nullptr, nullptr, nullptr, nullptr, nullptr, wd);
+
+    EXPECT_CALL(*wd, stop()).Times(1);
+    proc.stop();
+}
+
+TEST(BuzzerProcessTest, RunWithoutWatchDogWorks) {
+    using namespace device_reminder;
+
+    BuzzerProcess flag_setter(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+    flag_setter.stop();
+
+    BuzzerProcess proc(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+    EXPECT_EQ(proc.run(), 0);
+}
+
+TEST(BuzzerProcessTest, StopWithoutWatchDogDoesNothing) {
+    using namespace device_reminder;
+
+    BuzzerProcess proc(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+    EXPECT_NO_THROW(proc.stop());
+}
+


### PR DESCRIPTION
## Summary
- ProcessBase 派生クラスの run 戻り値を `int` に修正
- BuzzerProcess, MainProcess 等の実装を更新
- BuzzerProcess の単体テストを追加
- CMakeLists にテストファイルを登録

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: `IWorkerDispatcher` was not declared)*

------
https://chatgpt.com/codex/tasks/task_e_688b1a621bd083288fbaa596420702b1