### PR TITLE
Add ProcessBase tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ add_executable(test_infra_extra
     tests/infra/timer_service/test_timer_service.cpp
     tests/infra/watch_dog/test_watch_dog.cpp
     tests/infra/process_operation/test_process_dispatcher.cpp
+    tests/infra/process_operation/test_process_base.cpp
     tests/infra/gpio_operation/gpio_setter/test_gpio_setter.cpp
     tests/infra/buzzer_driver/test_buzzer_driver.cpp
     tests/infra/bluetooth_driver/test_bluetooth_driver.cpp

--- a/tests/core/bluetooth_task/test_bluetooth_process.cpp
+++ b/tests/core/bluetooth_task/test_bluetooth_process.cpp
@@ -19,17 +19,16 @@ using ::testing::StrictMock;
 using ::testing::Return;
 using ::testing::_;
 
-using namespace device_reminder;
-class IWorkerDispatcher;  // forward declaration for ProcessBase
 #include "bluetooth_task/bluetooth_process.hpp"
+using namespace device_reminder;
 
 namespace device_reminder {
 
 class MockFileLoader : public IFileLoader {
 public:
-    MOCK_METHOD(int, load_int, (), (const, override));
-    MOCK_METHOD(std::string, load_string, (), (const, override));
-    MOCK_METHOD(std::vector<std::string>, load_string_list, (), (const, override));
+    MOCK_METHOD(int, load_int, (const std::string&), (const, override));
+    MOCK_METHOD(std::string, load_string, (const std::string&), (const, override));
+    MOCK_METHOD(std::vector<std::string>, load_string_list, (const std::string&), (const, override));
 };
 
 class MockLogger : public ILogger {
@@ -90,7 +89,7 @@ TEST(BluetoothProcessTest, ConstructorLogsAndSetsPriority) {
     auto handler = std::make_shared<DummyHandler>();
     auto task = std::make_shared<DummyTask>();
 
-    EXPECT_CALL(*file_loader, load_int()).WillOnce(Return(5));
+    EXPECT_CALL(*file_loader, load_int("priority")).WillOnce(Return(5));
     EXPECT_CALL(*logger, info("BluetoothProcess created")).Times(1);
 
     BluetoothProcess proc(queue, receiver, dispatcher, sender, file_loader, logger,
@@ -101,7 +100,7 @@ TEST(BluetoothProcessTest, ConstructorLogsAndSetsPriority) {
 
 TEST(BluetoothProcessTest, ConstructorNullLoggerDoesNotThrow) {
     auto file_loader = std::make_shared<NiceMock<MockFileLoader>>();
-    EXPECT_CALL(*file_loader, load_int()).WillOnce(Return(-1));
+    EXPECT_CALL(*file_loader, load_int("priority")).WillOnce(Return(-1));
 
     EXPECT_NO_THROW({
         BluetoothProcess proc(nullptr, nullptr, nullptr, nullptr, file_loader,

--- a/tests/core/main_task/test_main_process.cpp
+++ b/tests/core/main_task/test_main_process.cpp
@@ -2,7 +2,7 @@
 #include <gmock/gmock.h>
 
 namespace device_reminder {
-class IProcessQueue; class IProcessReceiver; class IWorkerDispatcher;
+class IProcessQueue; class IProcessReceiver;
 class IProcessSender; class IFileLoader; class ILogger; class IWatchDog;
 }
 

--- a/tests/infra/process_operation/test_process_base.cpp
+++ b/tests/infra/process_operation/test_process_base.cpp
@@ -1,0 +1,146 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "infra/process_operation/process_base/process_base.hpp"
+#include "infra/process_operation/process_queue/i_process_queue.hpp"
+#include "infra/process_operation/process_receiver/i_process_receiver.hpp"
+#include "infra/process_operation/process_dispatcher/i_process_dispatcher.hpp"
+#include "infra/process_operation/process_sender/i_process_sender.hpp"
+#include "infra/file_loader/i_file_loader.hpp"
+#include "infra/logger/i_logger.hpp"
+
+#include <thread>
+#include <memory>
+
+using ::testing::StrictMock;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::InSequence;
+
+using namespace device_reminder;
+
+namespace device_reminder {
+
+class MockReceiver : public IProcessReceiver {
+public:
+    MOCK_METHOD(void, run, (), (override));
+    MOCK_METHOD(void, stop, (), (override));
+};
+
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
+};
+
+class MockFileLoader : public IFileLoader {
+public:
+    MOCK_METHOD(int, load_int, (const std::string&), (const, override));
+    MOCK_METHOD(std::string, load_string, (const std::string&), (const, override));
+    MOCK_METHOD(std::vector<std::string>, load_string_list, (const std::string&), (const, override));
+};
+
+class DummyQueue : public IProcessQueue {
+public:
+    void push(std::shared_ptr<IProcessMessage>) override {}
+    std::shared_ptr<IProcessMessage> pop() override { return nullptr; }
+    std::size_t size() const override { return 0; }
+};
+
+class DummyDispatcher : public IProcessDispatcher {
+public:
+    void dispatch(std::shared_ptr<IProcessMessage>) override {}
+};
+
+class DummySender : public IProcessSender {
+public:
+    void send() override {}
+};
+
+class TestProcessBase : public ProcessBase {
+public:
+    using ProcessBase::g_stop_flag;
+    TestProcessBase(std::shared_ptr<IProcessQueue> queue,
+                    std::shared_ptr<IProcessReceiver> receiver,
+                    std::shared_ptr<IProcessDispatcher> dispatcher,
+                    std::shared_ptr<IProcessSender> sender,
+                    std::shared_ptr<IFileLoader> file_loader,
+                    std::shared_ptr<ILogger> logger)
+        : ProcessBase(std::move(queue), std::move(receiver), std::move(dispatcher),
+                      std::move(sender), std::move(file_loader), std::move(logger),
+                      "TestProcess") {}
+};
+
+} // namespace device_reminder
+
+TEST(ProcessBaseTest, ConstructorLogsAndSetsPriority) {
+    auto queue = std::make_shared<DummyQueue>();
+    auto receiver = std::make_shared<MockReceiver>();
+    auto dispatcher = std::make_shared<DummyDispatcher>();
+    auto sender = std::make_shared<DummySender>();
+    auto loader = std::make_shared<StrictMock<MockFileLoader>>();
+    auto logger = std::make_shared<StrictMock<MockLogger>>();
+
+    EXPECT_CALL(*loader, load_int("priority")).WillOnce(Return(3));
+    EXPECT_CALL(*logger, info("ProcessBase initialized")).Times(1);
+
+    TestProcessBase::g_stop_flag.store(false);
+    TestProcessBase proc(queue, receiver, dispatcher, sender, loader, logger);
+
+    EXPECT_EQ(proc.priority(), 3);
+}
+
+TEST(ProcessBaseTest, ConstructorNullLoggerDoesNotThrow) {
+    auto loader = std::make_shared<NiceMock<MockFileLoader>>();
+    EXPECT_CALL(*loader, load_int("priority")).WillOnce(Return(-1));
+
+    TestProcessBase::g_stop_flag.store(false);
+    EXPECT_NO_THROW({
+        TestProcessBase proc(nullptr, nullptr, nullptr, nullptr, loader, nullptr);
+        EXPECT_EQ(proc.priority(), -1);
+    });
+}
+
+TEST(ProcessBaseTest, RunCallsReceiverAndLogs) {
+    auto queue = std::make_shared<DummyQueue>();
+    auto receiver = std::make_shared<StrictMock<MockReceiver>>();
+    auto loader = std::make_shared<NiceMock<MockFileLoader>>();
+    auto logger = std::make_shared<StrictMock<MockLogger>>();
+
+    EXPECT_CALL(*loader, load_int("priority")).WillOnce(Return(1));
+    EXPECT_CALL(*logger, info("ProcessBase initialized")).Times(1);
+    {
+        InSequence seq;
+        EXPECT_CALL(*receiver, run()).Times(1);
+        EXPECT_CALL(*logger, info("ProcessBase run start")).Times(1);
+        EXPECT_CALL(*receiver, stop()).Times(1);
+        EXPECT_CALL(*logger, info("ProcessBase run end")).Times(1);
+    }
+
+    TestProcessBase::g_stop_flag.store(false);
+    TestProcessBase proc(queue, receiver, nullptr, nullptr, loader, logger);
+
+    std::thread th([&] { proc.run(); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    proc.stop();
+    th.join();
+}
+
+TEST(ProcessBaseTest, StopSetsFlagAndLogs) {
+    auto loader = std::make_shared<NiceMock<MockFileLoader>>();
+    auto logger = std::make_shared<StrictMock<MockLogger>>();
+    EXPECT_CALL(*loader, load_int("priority")).WillOnce(Return(0));
+    {
+        InSequence s;
+        EXPECT_CALL(*logger, info("ProcessBase initialized")).Times(1);
+        EXPECT_CALL(*logger, info("ProcessBase stop requested")).Times(1);
+    }
+
+    TestProcessBase::g_stop_flag.store(false);
+    TestProcessBase proc(nullptr, nullptr, nullptr, nullptr, loader, logger);
+
+    proc.stop();
+    EXPECT_TRUE(TestProcessBase::g_stop_flag.load());
+}
+


### PR DESCRIPTION
## Summary
- add new `ProcessBase` test suite covering constructor, run and stop
- include new test file in `test_infra_extra` target

## Testing
- `cmake --build build --target test_app`
- `cmake --build build --target test_gpio_reader`
- `cmake --build build --target test_infra_extra`
- `ctest --output-on-failure` *(fails: 7 tests)*

------
https://chatgpt.com/codex/tasks/task_e_688b1911ce808328bd431e717829fcbb