### PR TITLE
Unify timeout enum names

### DIFF
--- a/include/infra/process_operation/process_message/process_message_type.hpp
+++ b/include/infra/process_operation/process_message/process_message_type.hpp
@@ -11,7 +11,7 @@ enum class ProcessMessageType {
     StartBuzzing,
     StopBuzzing,
     BuzzTimeout,
-    CoolDownTimeout,
+    CooldownTimeout,
     ScanTimeout
 };
 

--- a/include/infra/thread_operation/thread_message/thread_message_type.hpp
+++ b/include/infra/thread_operation/thread_message/thread_message_type.hpp
@@ -14,7 +14,7 @@ enum class ThreadMessageType {
     RespondDeviceNotFound,
     StartBuzzing,
     StopBuzzing,
-    BuzzingTimeout,
+    BuzzTimeout,
     CooldownTimeout,
     ProcessingTimeout,
 

--- a/src/core/human_task/human_handler.cpp
+++ b/src/core/human_task/human_handler.cpp
@@ -24,10 +24,10 @@ void HumanHandler::handle(std::shared_ptr<IProcessMessage> msg) {
         if (timer_) timer_->start();
         if (logger_) logger_->info("StopHumanDetection");
         break;
-    case ProcessMessageType::CoolDownTimeout:
+    case ProcessMessageType::CooldownTimeout:
         state_ = State::Cooldown;
         if (timer_) timer_->stop();
-        if (logger_) logger_->info("CoolDownTimeout");
+        if (logger_) logger_->info("CooldownTimeout");
         break;
     default:
         break;

--- a/src/core/main_task/main_handler.cpp
+++ b/src/core/main_task/main_handler.cpp
@@ -29,7 +29,7 @@ void MainHandler::handle(std::shared_ptr<IProcessMessage> msg) {
             task_->on_response_to_buzzer_task(msg->payload());
         }
         break;
-    case ProcessMessageType::CoolDownTimeout:
+    case ProcessMessageType::CooldownTimeout:
         task_->on_cooldown(msg->payload());
         break;
     case ProcessMessageType::ScanTimeout:

--- a/tests/core/human_task/test_human_handler.cpp
+++ b/tests/core/human_task/test_human_handler.cpp
@@ -70,7 +70,7 @@ TEST(HumanHandlerTest, CooldownCallsTask) {
 
     EXPECT_CALL(*task, on_cooldown(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::CoolDownTimeout, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::CooldownTimeout, std::vector<std::string>{});
     handler.handle(msg);
 }
 

--- a/tests/core/main_task/test_main_handler.cpp
+++ b/tests/core/main_task/test_main_handler.cpp
@@ -65,7 +65,7 @@ TEST(MainHandlerTest, CooldownCallsTask) {
 
     EXPECT_CALL(*task, on_cooldown(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::CoolDownTimeout, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::CooldownTimeout, std::vector<std::string>{});
     handler.handle(msg);
 }
 


### PR DESCRIPTION
## Summary
- rename `CoolDownTimeout` to `CooldownTimeout`
- use the same `BuzzTimeout` value for thread messages
- adjust handlers and tests for the renamed enum

## Testing
- `cmake -S . -B build`
- `cmake --build build -- VERBOSE=1` *(fails: conflicting return type in human_process.cpp)*
- `ctest --test-dir build` *(fails: executables not built)*

------
https://chatgpt.com/codex/tasks/task_e_688c24559f688328a5eca2b6f626492a