### PR TITLE
Fix include paths and ProcessBase interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,13 +21,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/include/infra
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/di
     ${CMAKE_SOURCE_DIR}/tests
     ${CMAKE_SOURCE_DIR}/tests/stubs
-    ${CMAKE_SOURCE_DIR}/main_task
-    ${CMAKE_SOURCE_DIR}/human_task
-    ${CMAKE_SOURCE_DIR}/bluetooth_task
-    ${CMAKE_SOURCE_DIR}/buzzer_task
     ${SPDLOG_INCLUDE_DIR}
     ${BOOST_DI_INCLUDE_DIR}
 )

--- a/include/infra/process_operation/process_base/i_process_base.hpp
+++ b/include/infra/process_operation/process_base/i_process_base.hpp
@@ -18,7 +18,7 @@ public:
      * - 実装は内部スレッドを起動して待機し、
      *   終了要求を受け取ったら join して戻る。
      */
-    virtual void run() = 0;
+    virtual int run() = 0;
 
     /// 非同期に終了要求を出す（Ctrl‑C 以外でも停止できるように）
     virtual void stop() = 0;

--- a/include/infra/process_operation/process_base/process_base.hpp
+++ b/include/infra/process_operation/process_base/process_base.hpp
@@ -26,7 +26,7 @@ public:
                 std::shared_ptr<ILogger>                 logger,
                 std::string                              process_name);
 
-    void run() override;  ///< メインループ
+    int  run() override;  ///< メインループ
     void stop() override;  ///< 外部停止
     int  priority() const noexcept override;
 

--- a/src/infra/process_operation/process_base.cpp
+++ b/src/infra/process_operation/process_base.cpp
@@ -38,7 +38,7 @@ ProcessBase::ProcessBase(std::shared_ptr<IProcessQueue>    queue,
     if (logger_) logger_->info("ProcessBase initialized");
 }
 
-void ProcessBase::run()
+int ProcessBase::run()
 {
     if (receiver_) receiver_->run();
 
@@ -50,6 +50,7 @@ void ProcessBase::run()
 
     if (receiver_) receiver_->stop();
     if (logger_) logger_->info("ProcessBase run end");
+    return 0;
 }
 
 void ProcessBase::stop()


### PR DESCRIPTION
## Summary
- clean up include directories in CMakeLists.txt
- add project root include path
- harmonize ProcessBase interface to return int

## Testing
- `cmake ..` *(passes)*
- `cmake --build .` *(fails: no matching function for call to `App::App`)*

------
https://chatgpt.com/codex/tasks/task_e_688c246e20b08328830c78949e817d4c