### PR TITLE
Run core tests and fix expectations

### DIFF
--- a/di/logger_injector.hpp
+++ b/di/logger_injector.hpp
@@ -20,7 +20,7 @@ inline auto make_logger_injector() {
     // バインディングの束を返す（injectorは返さない）
     return std::tuple{
         di::bind<ILogger>.to<Logger>(),
-        di::bind<std::shared_ptr<spdlog::logger>>.to(spd_logger).in(di::singleton)
+        di::bind<spdlog::logger>.to(spd_logger).in(di::singleton)
     };
 }
 

--- a/src/core/app_builder/app_builder.cpp
+++ b/src/core/app_builder/app_builder.cpp
@@ -11,11 +11,11 @@ std::unique_ptr<App> AppBuilder::build() {
     auto injector = make_app_injector();
 
     
-    std::shared_ptr<IMainTask> main_process;
-    std::shared_ptr<IHumanTask> human_process;
-    std::shared_ptr<IBluetoothTask> bluetooth_process;
-    std::shared_ptr<IBuzzerTask> buzzer_process;
-    std::shared_ptr<ILogger> logger;
+    std::unique_ptr<IMainTask> main_process;
+    std::unique_ptr<IHumanTask> human_process;
+    std::unique_ptr<IBluetoothTask> bluetooth_process;
+    std::unique_ptr<IBuzzerTask> buzzer_process;
+    std::unique_ptr<ILogger> logger;
 
     try{
         main_process = injector.create<std::unique_ptr<IMainTask>>();

--- a/src/core/human_task/human_process.cpp
+++ b/src/core/human_task/human_process.cpp
@@ -29,7 +29,6 @@ HumanProcess::HumanProcess(std::shared_ptr<IProcessQueue>    queue,
 int HumanProcess::run() {
     if (watch_dog_) watch_dog_->start();
     auto result = ProcessBase::run();
-    if (watch_dog_) watch_dog_->stop();
     return result;
 }
 

--- a/tests/core/human_task/test_human_process.cpp
+++ b/tests/core/human_task/test_human_process.cpp
@@ -17,6 +17,7 @@
 
 using ::testing::StrictMock;
 using ::testing::NiceMock;
+using ::testing::Return;
 
 namespace device_reminder {
 
@@ -87,6 +88,10 @@ TEST(HumanProcessTest, ConstructLogsWhenLoggerProvided) {
     auto handler = std::make_shared<StrictMock<MockHandler>>();
     auto task = std::make_shared<StrictMock<MockTask>>();
 
+    EXPECT_CALL(*loader, load_int("priority")).WillOnce(Return(0));
+
+    EXPECT_CALL(*loader, load_int("priority")).WillOnce(Return(0));
+    EXPECT_CALL(*logger, info("ProcessBase initialized")).Times(1);
     EXPECT_CALL(*logger, info("HumanProcess created")).Times(1);
     HumanProcess proc(queue, receiver, dispatcher, sender, loader, logger, watchdog, handler, task);
 }
@@ -116,13 +121,13 @@ TEST(HumanProcessTest, RunStartsAndStopsWatchDog) {
     auto task = std::make_shared<NiceMock<MockTask>>();
 
     HumanProcess proc(queue, receiver, dispatcher, sender, loader, logger, watchdog, handler, task);
-    std::thread th([&]{
-        proc.run();
-    });
     EXPECT_CALL(*watchdog, start()).Times(1);
     EXPECT_CALL(*receiver, run()).Times(1);
     EXPECT_CALL(*receiver, stop()).Times(1);
     EXPECT_CALL(*watchdog, stop()).Times(1);
+    std::thread th([&]{
+        proc.run();
+    });
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     proc.stop();
     th.join();
@@ -139,9 +144,9 @@ TEST(HumanProcessTest, RunWithoutWatchDog) {
     auto task = std::make_shared<NiceMock<MockTask>>();
 
     HumanProcess proc(queue, receiver, dispatcher, sender, loader, logger, nullptr, handler, task);
-    std::thread th([&]{ proc.run(); });
     EXPECT_CALL(*receiver, run()).Times(1);
     EXPECT_CALL(*receiver, stop()).Times(1);
+    std::thread th([&]{ proc.run(); });
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     proc.stop();
     th.join();

--- a/tests/infra/gpio_operation/gpio_setter/test_gpio_setter.cpp
+++ b/tests/infra/gpio_operation/gpio_setter/test_gpio_setter.cpp
@@ -53,8 +53,12 @@ TEST_F(GPIOSetterTest, ConstructorThrowsWhenLineRequestFails) {
 
 TEST_F(GPIOSetterTest, ConstructorWithLoggerLogsInfo) {
     auto logger = std::make_shared<StrictMock<MockLogger>>();
-    EXPECT_CALL(*logger, info("GPIOSetter initialized"));
-    GPIOSetter setter(logger, 1);
+    {
+        ::testing::InSequence seq;
+        EXPECT_CALL(*logger, info("GPIOSetter initialized"));
+        EXPECT_CALL(*logger, info("GPIOSetter destroyed"));
+        GPIOSetter setter(logger, 1);
+    }
 }
 
 TEST_F(GPIOSetterTest, ConstructorThrowsWithNullLoggerWhenGetLineFails) {
@@ -91,10 +95,15 @@ TEST_F(GPIOSetterTest, WriteFalseSuccess) {
 
 TEST_F(GPIOSetterTest, WriteWithLoggerNoError) {
     auto logger = std::make_shared<StrictMock<MockLogger>>();
-    GPIOSetter setter(logger, 1);
-    gpiod_stub_set_set_value_result(0);
-    EXPECT_CALL(*logger, error(testing::_)).Times(0);
-    EXPECT_NO_THROW(setter.write(true));
+    {
+        ::testing::InSequence seq;
+        EXPECT_CALL(*logger, info("GPIOSetter initialized"));
+        EXPECT_CALL(*logger, info("GPIOSetter destroyed"));
+        GPIOSetter setter(logger, 1);
+        gpiod_stub_set_set_value_result(0);
+        EXPECT_CALL(*logger, error(testing::_)).Times(0);
+        EXPECT_NO_THROW(setter.write(true));
+    }
 }
 
 TEST_F(GPIOSetterTest, WriteFailureWithNullLoggerThrows) {
@@ -105,10 +114,15 @@ TEST_F(GPIOSetterTest, WriteFailureWithNullLoggerThrows) {
 
 TEST_F(GPIOSetterTest, WriteFailureLogsError) {
     auto logger = std::make_shared<StrictMock<MockLogger>>();
-    GPIOSetter setter(logger, 1);
-    gpiod_stub_set_set_value_result(-1);
-    EXPECT_CALL(*logger, error("Failed to write GPIO line value"));
-    EXPECT_THROW(setter.write(true), std::runtime_error);
+    {
+        ::testing::InSequence seq;
+        EXPECT_CALL(*logger, info("GPIOSetter initialized"));
+        EXPECT_CALL(*logger, error("Failed to write GPIO line value"));
+        EXPECT_CALL(*logger, info("GPIOSetter destroyed"));
+        GPIOSetter setter(logger, 1);
+        gpiod_stub_set_set_value_result(-1);
+        EXPECT_THROW(setter.write(true), std::runtime_error);
+    }
 }
 
 // ---- Destructor Tests ----

--- a/tests/infra/process_operation/test_process_base.cpp
+++ b/tests/infra/process_operation/test_process_base.cpp
@@ -114,6 +114,7 @@ TEST(ProcessBaseTest, RunCallsReceiverAndLogs) {
         InSequence seq;
         EXPECT_CALL(*receiver, run()).Times(1);
         EXPECT_CALL(*logger, info("ProcessBase run start")).Times(1);
+        EXPECT_CALL(*logger, info("ProcessBase stop requested")).Times(1);
         EXPECT_CALL(*receiver, stop()).Times(1);
         EXPECT_CALL(*logger, info("ProcessBase run end")).Times(1);
     }

--- a/tests/infra/process_operation/test_process_receiver.cpp
+++ b/tests/infra/process_operation/test_process_receiver.cpp
@@ -69,6 +69,7 @@ TEST(ProcessReceiverTest, ConstructorWithoutLogger) {
 
 TEST(ProcessReceiverTest, RunWithNullQueueLogsLoopEnd) {
     NiceMock<MockLogger> logger;
+    EXPECT_CALL(logger, info("ProcessReceiver created")).Times(1);
     EXPECT_CALL(logger, info("ProcessReceiver loop end")).Times(1);
     EXPECT_CALL(logger, info("ProcessReceiver stopped")).Times(1);
 
@@ -84,6 +85,7 @@ TEST(ProcessReceiverTest, RunWithNullQueueLogsLoopEnd) {
 
 TEST(ProcessReceiverTest, StopWithoutRunLogsStoppedTwice) {
     NiceMock<MockLogger> logger;
+    EXPECT_CALL(logger, info("ProcessReceiver created")).Times(1);
     EXPECT_CALL(logger, info("ProcessReceiver stopped")).Times(2);
 
     {

--- a/tests/infra/thread_operation/test_thread_dispatcher.cpp
+++ b/tests/infra/thread_operation/test_thread_dispatcher.cpp
@@ -63,6 +63,7 @@ TEST(ThreadDispatcherTest, DispatchLogsErrorOnNullMessage) {
 
 TEST(ThreadDispatcherTest, DispatchLogsInfoOnUnhandledMessage) {
     NiceMock<MockLogger> logger;
+    EXPECT_CALL(logger, info("ThreadDispatcher created")).Times(1);
     EXPECT_CALL(logger, info("Unhandled thread message")).Times(1);
 
     ThreadDispatcher::HandlerMap map{};


### PR DESCRIPTION
## Summary
- add expected logger calls for receiver and dispatcher tests
- adjust GPIOSetter tests to expect destructor logs
- revise ProcessBase test expectations
- fix HumanProcess run logic and update related tests
- adjust logger injector binding
- use unique_ptr in AppBuilder

## Testing
- `cmake --build . --target test_app test_gpio_reader test_infra_extra`
- `ctest --output-on-failure` *(fails: AllTests)*

------
https://chatgpt.com/codex/tasks/task_e_688c28798c608328abcdc327449c344e