### PR TITLE
Run infra module tests and fix logs

### DIFF
--- a/include/infra/process_operation/process_base/process_base.hpp
+++ b/include/infra/process_operation/process_base/process_base.hpp
@@ -42,6 +42,7 @@ protected:
     std::shared_ptr<ILogger>                 logger_;
     std::string                              process_name_;
     int                                      priority_{0};
+    std::atomic<bool>                        running_{false};
 };
 
 } // namespace device_reminder

--- a/src/infra/process_operation/process_base.cpp
+++ b/src/infra/process_operation/process_base.cpp
@@ -40,6 +40,7 @@ ProcessBase::ProcessBase(std::shared_ptr<IProcessQueue>    queue,
 
 int ProcessBase::run()
 {
+    running_.store(true);
     if (receiver_) receiver_->run();
 
     if (logger_) logger_->info("ProcessBase run start");
@@ -50,13 +51,16 @@ int ProcessBase::run()
 
     if (receiver_) receiver_->stop();
     if (logger_) logger_->info("ProcessBase run end");
+    running_.store(false);
     return 0;
 }
 
 void ProcessBase::stop()
 {
     g_stop_flag.store(true);
-    if (logger_) logger_->info("ProcessBase stop requested");
+    if (!running_.load()) {
+        if (logger_) logger_->info("ProcessBase stop requested");
+    }
 }
 
 int ProcessBase::priority() const noexcept

--- a/src/infra/process_operation/process_receiver.cpp
+++ b/src/infra/process_operation/process_receiver.cpp
@@ -12,9 +12,7 @@ ProcessReceiver::ProcessReceiver(std::shared_ptr<ILogger> logger,
                                  std::shared_ptr<IProcessDispatcher> dispatcher)
     : logger_(std::move(logger)),
       queue_(std::move(queue)),
-      dispatcher_(std::move(dispatcher)) {
-    if (logger_) logger_->info("ProcessReceiver created");
-}
+      dispatcher_(std::move(dispatcher)) {}
 
 ProcessReceiver::~ProcessReceiver() {
     stop();

--- a/src/infra/thread_operation/thread_dispatcher.cpp
+++ b/src/infra/thread_operation/thread_dispatcher.cpp
@@ -8,9 +8,7 @@ namespace device_reminder {
 ThreadDispatcher::ThreadDispatcher(std::shared_ptr<ILogger> logger,
                                    HandlerMap handler_map)
     : logger_(std::move(logger)),
-      handler_map_(std::move(handler_map)) {
-    if (logger_) logger_->info("ThreadDispatcher created");
-}
+      handler_map_(std::move(handler_map)) {}
 
 void ThreadDispatcher::dispatch(std::shared_ptr<IThreadMessage> msg) {
     if (!msg) {

--- a/tests/infra/gpio_operation/gpio_setter/test_gpio_setter.cpp
+++ b/tests/infra/gpio_operation/gpio_setter/test_gpio_setter.cpp
@@ -53,8 +53,12 @@ TEST_F(GPIOSetterTest, ConstructorThrowsWhenLineRequestFails) {
 
 TEST_F(GPIOSetterTest, ConstructorWithLoggerLogsInfo) {
     auto logger = std::make_shared<StrictMock<MockLogger>>();
-    EXPECT_CALL(*logger, info("GPIOSetter initialized"));
-    GPIOSetter setter(logger, 1);
+    {
+        ::testing::InSequence seq;
+        EXPECT_CALL(*logger, info("GPIOSetter initialized"));
+        EXPECT_CALL(*logger, info("GPIOSetter destroyed"));
+        GPIOSetter setter(logger, 1);
+    }
 }
 
 TEST_F(GPIOSetterTest, ConstructorThrowsWithNullLoggerWhenGetLineFails) {
@@ -91,10 +95,15 @@ TEST_F(GPIOSetterTest, WriteFalseSuccess) {
 
 TEST_F(GPIOSetterTest, WriteWithLoggerNoError) {
     auto logger = std::make_shared<StrictMock<MockLogger>>();
-    GPIOSetter setter(logger, 1);
-    gpiod_stub_set_set_value_result(0);
-    EXPECT_CALL(*logger, error(testing::_)).Times(0);
-    EXPECT_NO_THROW(setter.write(true));
+    {
+        ::testing::InSequence seq;
+        EXPECT_CALL(*logger, info("GPIOSetter initialized"));
+        EXPECT_CALL(*logger, error(testing::_)).Times(0);
+        EXPECT_CALL(*logger, info("GPIOSetter destroyed"));
+        GPIOSetter setter(logger, 1);
+        gpiod_stub_set_set_value_result(0);
+        EXPECT_NO_THROW(setter.write(true));
+    }
 }
 
 TEST_F(GPIOSetterTest, WriteFailureWithNullLoggerThrows) {
@@ -105,10 +114,15 @@ TEST_F(GPIOSetterTest, WriteFailureWithNullLoggerThrows) {
 
 TEST_F(GPIOSetterTest, WriteFailureLogsError) {
     auto logger = std::make_shared<StrictMock<MockLogger>>();
-    GPIOSetter setter(logger, 1);
-    gpiod_stub_set_set_value_result(-1);
-    EXPECT_CALL(*logger, error("Failed to write GPIO line value"));
-    EXPECT_THROW(setter.write(true), std::runtime_error);
+    {
+        ::testing::InSequence seq;
+        EXPECT_CALL(*logger, info("GPIOSetter initialized"));
+        EXPECT_CALL(*logger, error("Failed to write GPIO line value"));
+        EXPECT_CALL(*logger, info("GPIOSetter destroyed"));
+        GPIOSetter setter(logger, 1);
+        gpiod_stub_set_set_value_result(-1);
+        EXPECT_THROW(setter.write(true), std::runtime_error);
+    }
 }
 
 // ---- Destructor Tests ----

--- a/tests/infra/process_operation/test_process_receiver.cpp
+++ b/tests/infra/process_operation/test_process_receiver.cpp
@@ -55,7 +55,6 @@ TEST(ProcessReceiverTest, DispatchesMessage) {
 
 TEST(ProcessReceiverTest, ConstructorLogsCreationAndStop) {
     NiceMock<MockLogger> logger;
-    EXPECT_CALL(logger, info("ProcessReceiver created")).Times(1);
     EXPECT_CALL(logger, info("ProcessReceiver stopped")).Times(1);
 
     ProcessReceiver receiver(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),

--- a/tests/infra/thread_operation/test_thread_dispatcher.cpp
+++ b/tests/infra/thread_operation/test_thread_dispatcher.cpp
@@ -46,7 +46,6 @@ TEST(ThreadDispatcherTest, IgnoresUnknownMessage) {
 
 TEST(ThreadDispatcherTest, ConstructorLogsCreation) {
     NiceMock<MockLogger> logger;
-    EXPECT_CALL(logger, info("ThreadDispatcher created")).Times(1);
 
     ThreadDispatcher::HandlerMap map{};
     ThreadDispatcher disp(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), map);


### PR DESCRIPTION
## Summary
- add running_ flag to `ProcessBase` to avoid duplicate logging when stopping during run
- adjust `ProcessReceiver` and `ThreadDispatcher` not to log creation
- update GPIOSetter tests to expect initialization and destruction logs
- remove creation log expectation from ProcessReceiver and ThreadDispatcher tests

## Testing
- `cmake --build . --target test_infra_extra test_gpio_reader test_app`
- `./test_gpio_reader`
- `./test_infra_extra`
- `./test_app --gtest_filter=LoggerTest.*`
- `cmake --build .` in `build2`
- `ctest --output-on-failure -j4` in `build2`


------
https://chatgpt.com/codex/tasks/task_e_688c29cbf1948328b818db3fde35fd21