### PR TITLE
Add integration test for main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,17 @@ if(UNIX)
     target_link_libraries(device_reminder pthread)
 endif()
 
+# Integration test sources (exclude src/main.cpp to avoid duplicate main)
+set(DEVICE_SOURCES_NO_MAIN ${DEVICE_SOURCES})
+list(REMOVE_ITEM DEVICE_SOURCES_NO_MAIN ${CMAKE_SOURCE_DIR}/src/main.cpp)
+add_executable(test_integration
+    tests/integration/test_main.cpp
+    ${DEVICE_SOURCES_NO_MAIN}
+    tests/stubs/gpiod_stub.cpp
+)
+target_include_directories(test_integration BEFORE PRIVATE tests/integration)
+target_link_libraries(test_integration gtest gmock pthread)
+
 # GoogleTestライブラリをリンク
 target_link_libraries(test_app
     gtest
@@ -159,6 +170,7 @@ enable_testing()
 add_test(NAME AllTests COMMAND test_app)
 add_test(NAME GPIOReaderTests COMMAND test_gpio_reader)
 add_test(NAME InfraExtraTests COMMAND test_infra_extra)
+add_test(NAME IntegrationMain COMMAND test_integration)
 
 
 # 動的ランタイム(MDd)に統一する

--- a/tests/integration/di/app_injector.hpp
+++ b/tests/integration/di/app_injector.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <gmock/gmock.h>
+#include <boost/di.hpp>
+
+#include "core/main_task/i_main_task.hpp"
+#include "core/human_task/i_human_task.hpp"
+#include "core/bluetooth_task/i_bluetooth_task.hpp"
+#include "core/buzzer_task/i_buzzer_task.hpp"
+#include "infra/logger/i_logger.hpp"
+
+namespace di = boost::di;
+namespace device_reminder {
+
+class MockMainTask;
+class MockHumanTask;
+class MockBluetoothTask;
+class MockBuzzerTask;
+class MockLogger;
+
+inline MockMainTask* g_mock_main_task = nullptr;
+inline MockHumanTask* g_mock_human_task = nullptr;
+inline MockBluetoothTask* g_mock_bluetooth_task = nullptr;
+inline MockBuzzerTask* g_mock_buzzer_task = nullptr;
+inline MockLogger* g_mock_logger = nullptr;
+
+class MockMainTask : public IMainTask {
+public:
+    MockMainTask() { g_mock_main_task = this; }
+    MOCK_METHOD(void, run, (const IThreadMessage& msg), (override));
+    MOCK_METHOD(void, on_waiting_for_human, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_response_to_buzzer_task, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_response_to_human_task, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_cooldown, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_waiting_for_second_response, (const std::vector<std::string>&), (override));
+};
+
+class MockHumanTask : public IHumanTask {
+public:
+    MockHumanTask() { g_mock_human_task = this; }
+    MOCK_METHOD(void, on_detecting, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_stopping, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_cooldown, (const std::vector<std::string>&), (override));
+};
+
+class MockBluetoothTask : public IBluetoothTask {
+public:
+    MockBluetoothTask() { g_mock_bluetooth_task = this; }
+    MOCK_METHOD(void, on_waiting, (const std::vector<std::string>&), (override));
+};
+
+class MockBuzzerTask : public IBuzzerTask {
+public:
+    MockBuzzerTask() { g_mock_buzzer_task = this; }
+    MOCK_METHOD(void, run, (), (override));
+    MOCK_METHOD(bool, send_message, (const IThreadMessage&), (override));
+    MOCK_METHOD(void, on_waiting, (const std::vector<std::string>&), (override));
+    MOCK_METHOD(void, on_buzzing, (const std::vector<std::string>&), (override));
+};
+
+class MockLogger : public ILogger {
+public:
+    MockLogger() { g_mock_logger = this; }
+    MOCK_METHOD(void, info, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
+    MOCK_METHOD(void, warn, (const std::string&), (override));
+};
+
+
+inline auto make_app_injector() {
+    return di::make_injector(
+        di::bind<IMainTask>.to([] {
+            return std::unique_ptr<IMainTask>(g_mock_main_task = new testing::StrictMock<MockMainTask>());
+        }),
+        di::bind<IHumanTask>.to([] {
+            return std::unique_ptr<IHumanTask>(g_mock_human_task = new testing::StrictMock<MockHumanTask>());
+        }),
+        di::bind<IBluetoothTask>.to([] {
+            return std::unique_ptr<IBluetoothTask>(g_mock_bluetooth_task = new testing::StrictMock<MockBluetoothTask>());
+        }),
+        di::bind<IBuzzerTask>.to([] {
+            return std::unique_ptr<IBuzzerTask>(g_mock_buzzer_task = new testing::StrictMock<MockBuzzerTask>());
+        }),
+        di::bind<ILogger>.to([] {
+            return std::unique_ptr<ILogger>(g_mock_logger = new testing::StrictMock<MockLogger>());
+        })
+    );
+}
+
+} // namespace device_reminder

--- a/tests/integration/test_main.cpp
+++ b/tests/integration/test_main.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "di/app_injector.hpp" // our mock injector
+
+// Rename main from src for testing
+#define main app_entry_point
+#include "src/main.cpp"
+#undef main
+
+using namespace testing;
+using namespace device_reminder;
+
+TEST(IntegrationMain, TasksAreCalledThroughApp) {
+    AppBuilder builder;
+    auto app = builder.build();
+
+    ASSERT_NE(g_mock_main_task, nullptr);
+    ASSERT_NE(g_mock_human_task, nullptr);
+    ASSERT_NE(g_mock_bluetooth_task, nullptr);
+    ASSERT_NE(g_mock_buzzer_task, nullptr);
+    ASSERT_NE(g_mock_logger, nullptr);
+
+    EXPECT_CALL(*g_mock_main_task, run(_)).Times(1);
+    EXPECT_CALL(*g_mock_human_task, on_detecting(_)).Times(1);
+    EXPECT_CALL(*g_mock_bluetooth_task, on_waiting(_)).Times(1);
+    EXPECT_CALL(*g_mock_buzzer_task, run()).Times(1);
+    EXPECT_CALL(*g_mock_logger, info(_)).Times(AtLeast(1));
+
+    app->run();
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- introduce integration test to verify task creation via AppBuilder
- provide custom DI injector with mocks
- compile new test in CMake

## Testing
- `cmake --build build --target test_integration`
- `ctest -R IntegrationMain -V`

------
https://chatgpt.com/codex/tasks/task_e_688c3fdcaf9483289dc988ba7df36efb