### PR TITLE
Add integration tests for MainProcess

### DIFF
--- a/tests/integration/core/main_task/test_main_process.cpp
+++ b/tests/integration/core/main_task/test_main_process.cpp
@@ -1,0 +1,143 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <fstream>
+#include <thread>
+#include <chrono>
+#include <memory>
+#include <vector>
+
+#include "core/main_task/main_process.hpp"
+#include "infra/process_operation/process_sender/process_sender.hpp"
+#include "infra/process_operation/process_receiver/process_receiver.hpp"
+#include "infra/process_operation/process_queue/process_queue.hpp"
+#include "infra/process_operation/process_message/process_message.hpp"
+#include "infra/process_operation/process_dispatcher/i_process_dispatcher.hpp"
+#include "infra/process_operation/message_codec/i_message_codec.hpp"
+#include "infra/watch_dog/watch_dog.hpp"
+#include "infra/timer_service/i_timer_service.hpp"
+#include "infra/file_loader/file_loader.hpp"
+#include "infra/logger/logger.hpp"
+
+extern "C" {
+#include "posix_mq_stub.h"
+}
+
+#include <spdlog/sinks/null_sink.h>
+
+using ::testing::_;
+using ::testing::StrictMock;
+using ::testing::Return;
+using ::testing::Property;
+
+using namespace device_reminder;
+
+class MockTimerService : public ITimerService {
+public:
+    MOCK_METHOD(void, start, (), (override));
+    MOCK_METHOD(void, stop, (), (override));
+};
+
+class MockProcessDispatcher : public IProcessDispatcher {
+public:
+    MOCK_METHOD(void, dispatch, (std::shared_ptr<IProcessMessage> msg), (override));
+};
+
+class MockMessageCodec : public IMessageCodec {
+public:
+    MOCK_METHOD(std::vector<uint8_t>, encode, (std::shared_ptr<IProcessMessage> msg), (override));
+    MOCK_METHOD(std::shared_ptr<IProcessMessage>, decode, (const std::vector<uint8_t>& data), (override));
+};
+
+class TestMainProcess : public MainProcess {
+public:
+    using ProcessBase::g_stop_flag;
+    using MainProcess::MainProcess;
+};
+
+static std::shared_ptr<Logger> make_logger() {
+    auto sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+    auto spd = std::make_shared<spdlog::logger>("null", sink);
+    return std::make_shared<Logger>(spd);
+}
+
+TEST(統合テスト_main_process, 正常系メッセージを処理できること) {
+    mq_stub_reset();
+    TestMainProcess::g_stop_flag.store(false);
+
+    auto logger = make_logger();
+
+    auto timer_service = std::make_shared<StrictMock<MockTimerService>>();
+    auto watchdog = std::make_shared<WatchDog>(timer_service);
+
+    auto dispatcher = std::make_shared<StrictMock<MockProcessDispatcher>>();
+    auto codec = std::make_shared<StrictMock<MockMessageCodec>>();
+    auto queue = std::make_shared<ProcessQueue>(logger, codec, "/main_proc_queue1");
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    auto sender = std::make_shared<ProcessSender>(queue, msg);
+    auto receiver = std::make_shared<ProcessReceiver>(logger, queue, dispatcher);
+
+    std::string cfg = "/tmp/main_process.cfg";
+    { std::ofstream ofs(cfg); ofs << "priority=1\n"; }
+    auto loader = std::make_shared<FileLoader>(logger, cfg);
+
+    TestMainProcess proc(receiver, sender, queue, loader, logger, watchdog);
+
+    EXPECT_CALL(*codec, encode(_)).WillOnce(Return(std::vector<uint8_t>{1}));
+    EXPECT_CALL(*codec, decode(_))
+        .WillOnce(Return(msg))
+        .WillRepeatedly(Return(nullptr));
+    EXPECT_CALL(*dispatcher,
+                dispatch(testing::Truly([](const std::shared_ptr<IProcessMessage>& m) {
+                    return m && m->type() == ProcessMessageType::StartBuzzing;
+                })))
+        .Times(1);
+    EXPECT_CALL(*timer_service, start()).Times(1);
+    EXPECT_CALL(*timer_service, stop()).Times(1);
+
+    sender->send();
+
+    std::thread th([&]{ proc.run(); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    proc.stop();
+    th.join();
+}
+
+TEST(統合テスト_main_process, 未定義メッセージを投入した場合にディスパッチされないこと) {
+    mq_stub_reset();
+    TestMainProcess::g_stop_flag.store(false);
+
+    auto logger = make_logger();
+
+    auto timer_service = std::make_shared<StrictMock<MockTimerService>>();
+    auto watchdog = std::make_shared<WatchDog>(timer_service);
+
+    auto dispatcher = std::make_shared<StrictMock<MockProcessDispatcher>>();
+    auto codec = std::make_shared<StrictMock<MockMessageCodec>>();
+    auto queue = std::make_shared<ProcessQueue>(logger, codec, "/main_proc_queue2");
+
+    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::BuzzTimeout, std::vector<std::string>{});
+    auto sender = std::make_shared<ProcessSender>(queue, msg);
+    auto receiver = std::make_shared<ProcessReceiver>(logger, queue, dispatcher);
+
+    std::string cfg = "/tmp/main_process.cfg";
+    { std::ofstream ofs(cfg); ofs << "priority=1\n"; }
+    auto loader = std::make_shared<FileLoader>(logger, cfg);
+
+    TestMainProcess proc(receiver, sender, queue, loader, logger, watchdog);
+
+    EXPECT_CALL(*codec, encode(_)).WillOnce(Return(std::vector<uint8_t>{2}));
+    EXPECT_CALL(*codec, decode(_)).WillRepeatedly(Return(nullptr));
+    EXPECT_CALL(*dispatcher, dispatch(_)).Times(0);
+    EXPECT_CALL(*timer_service, start()).Times(1);
+    EXPECT_CALL(*timer_service, stop()).Times(1);
+
+    sender->send();
+
+    std::thread th([&]{ proc.run(); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    proc.stop();
+    th.join();
+}
+

--- a/tests/stubs/posix_mq_stub.cpp
+++ b/tests/stubs/posix_mq_stub.cpp
@@ -34,7 +34,10 @@ int mq_send(mqd_t, const char* msg_ptr, size_t msg_len, unsigned int) {
     return 0;
 }
 ssize_t mq_receive(mqd_t, char* msg_ptr, size_t msg_len, unsigned int*) {
-    if(fail_receive || g_mq.q.empty()) { errno = EAGAIN; return -1; }
+    if (fail_receive) { errno = EAGAIN; return -1; }
+    if (g_mq.q.empty()) {
+        return 0; // no data available
+    }
     auto& s = g_mq.q.front();
     size_t n = std::min(msg_len, s.size());
     std::memcpy(msg_ptr, s.data(), n);


### PR DESCRIPTION
## Summary
- add integration tests for MainProcess covering normal and abnormal message cases
- adjust POSIX MQ stub to return empty data when no message is available

## Testing
- `cmake --build .`
- `./test_integration`

------
https://chatgpt.com/codex/tasks/task_e_688d7818925c832899ff9013c4b56d94