### PR TITLE
統合テスト【GPIOSetter】

### DIFF
--- a/tests/integration/infra/gpio_operation/gpio_setter/test_gpio_setter.cpp
+++ b/tests/integration/infra/gpio_operation/gpio_setter/test_gpio_setter.cpp
@@ -1,0 +1,77 @@
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "infra/gpio_operation/gpio_setter/gpio_setter.hpp"
+#include "infra/logger/logger.hpp"
+#include "stubs/gpiod_stub.h"
+
+#include <spdlog/logger.h>
+#include <spdlog/sinks/null_sink.h>
+#include <spdlog/sinks/sink.h>
+#include <memory>
+#include <string>
+
+using namespace device_reminder;
+
+using ::testing::StrictMock;
+using ::testing::InSequence;
+
+class MockSink : public spdlog::sinks::sink {
+public:
+    MOCK_METHOD(void, log, (const spdlog::details::log_msg& msg), (override));
+    MOCK_METHOD(void, flush, (), (override));
+    MOCK_METHOD(void, set_pattern, (const std::string& pattern), (override));
+    void set_formatter(std::unique_ptr<spdlog::formatter>) override {}
+};
+
+class GPIOSetterIntegrationTest : public ::testing::Test {
+protected:
+    void SetUp() override { gpiod_stub_reset(); }
+};
+
+TEST_F(GPIOSetterIntegrationTest, WriteNormal) {
+    auto sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+    auto spdlogger = std::make_shared<spdlog::logger>("test", sink);
+    auto logger = std::make_shared<Logger>(spdlogger);
+
+    GPIOSetter setter(logger, 1);
+    gpiod_stub_set_set_value_result(0);
+
+    EXPECT_NO_THROW(setter.write(true));
+    EXPECT_EQ(1, gpiod_stub_get_last_set_value());
+
+    EXPECT_NO_THROW(setter.write(false));
+    EXPECT_EQ(0, gpiod_stub_get_last_set_value());
+}
+
+TEST_F(GPIOSetterIntegrationTest, WriteFailureLogsError) {
+    auto sink = std::make_shared<StrictMock<MockSink>>();
+    auto spdlogger = std::make_shared<spdlog::logger>("test", sink);
+    auto logger = std::make_shared<Logger>(spdlogger);
+
+    {
+        InSequence seq;
+        EXPECT_CALL(*sink, log(testing::Truly([](const spdlog::details::log_msg& msg) {
+                            return msg.level == spdlog::level::info &&
+                                   std::string(msg.payload.data(), msg.payload.size()) ==
+                                       "GPIOSetter initialized";
+                        })));
+        EXPECT_CALL(*sink, log(testing::Truly([](const spdlog::details::log_msg& msg) {
+                            return msg.level == spdlog::level::err &&
+                                   std::string(msg.payload.data(), msg.payload.size()) ==
+                                       "Failed to write GPIO line value";
+                        })));
+        EXPECT_CALL(*sink, log(testing::Truly([](const spdlog::details::log_msg& msg) {
+                            return msg.level == spdlog::level::info &&
+                                   std::string(msg.payload.data(), msg.payload.size()) ==
+                                       "GPIOSetter destroyed";
+                        })));
+    }
+
+    GPIOSetter setter(logger, 1);
+    gpiod_stub_set_set_value_result(-1);
+
+    EXPECT_THROW(setter.write(true), std::runtime_error);
+    EXPECT_EQ(1, gpiod_stub_get_last_set_value());
+}

--- a/tests/stubs/gpiod_stub.cpp
+++ b/tests/stubs/gpiod_stub.cpp
@@ -10,6 +10,7 @@ static int request_input_result = 0;
 static int get_value_result = 0;
 static int request_output_result = 0;
 static int set_value_result = 0;
+static int last_set_value = 0;
 static int request_rising_result = 0;
 static int request_falling_result = 0;
 static int request_both_result = 0;
@@ -24,6 +25,7 @@ void gpiod_stub_reset(void) {
     get_value_result = 0;
     request_output_result = 0;
     set_value_result = 0;
+    last_set_value = 0;
     request_rising_result = 0;
     request_falling_result = 0;
     request_both_result = 0;
@@ -36,6 +38,7 @@ void gpiod_stub_set_request_input_result(int val) { request_input_result = val; 
 void gpiod_stub_set_get_value_result(int val) { get_value_result = val; }
 void gpiod_stub_set_request_output_result(int val) { request_output_result = val; }
 void gpiod_stub_set_set_value_result(int val) { set_value_result = val; }
+int gpiod_stub_get_last_set_value(void) { return last_set_value; }
 void gpiod_stub_set_request_rising_result(int val) { request_rising_result = val; }
 void gpiod_stub_set_request_falling_result(int val) { request_falling_result = val; }
 void gpiod_stub_set_request_both_result(int val) { request_both_result = val; }
@@ -71,7 +74,8 @@ int gpiod_line_request_output(struct gpiod_line* line, const char* consumer, int
 }
 
 int gpiod_line_set_value(struct gpiod_line* line, int value) {
-    (void)line; (void)value;
+    (void)line;
+    last_set_value = value;
     return set_value_result;
 }
 

--- a/tests/stubs/gpiod_stub.h
+++ b/tests/stubs/gpiod_stub.h
@@ -14,6 +14,7 @@ void gpiod_stub_set_request_input_result(int val);
 void gpiod_stub_set_get_value_result(int val);
 void gpiod_stub_set_request_output_result(int val);
 void gpiod_stub_set_set_value_result(int val);
+int gpiod_stub_get_last_set_value(void);
 void gpiod_stub_set_request_rising_result(int val);
 void gpiod_stub_set_request_falling_result(int val);
 void gpiod_stub_set_request_both_result(int val);


### PR DESCRIPTION
## 概要
- GPIOSetterの統合テストを追加
- gpiodスタブに値記録機能を実装

## テスト
- `./build/test_integration/test_integration`


------
https://chatgpt.com/codex/tasks/task_e_688d7a2630408328931b57a3f0297bbb