### PR TITLE
統合テスト【thread_message】

### DIFF
--- a/tests/integration/infra/thread_operation/thread_message/test_thread_message.cpp
+++ b/tests/integration/infra/thread_operation/thread_message/test_thread_message.cpp
@@ -1,0 +1,31 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "infra/thread_operation/thread_message/thread_message.hpp"
+
+using namespace device_reminder;
+
+TEST(ThreadMessageIntegrationTest, HandlesValidInput) {
+    ThreadMessage msg(ThreadMessageType::StartBuzzing, {"1"});
+
+    EXPECT_EQ(msg.type(), ThreadMessageType::StartBuzzing);
+    std::vector<std::string> expected{"1"};
+    EXPECT_EQ(msg.payload(), expected);
+
+    auto copy = msg.clone();
+    ASSERT_NE(copy, nullptr);
+    EXPECT_EQ(copy->type(), msg.type());
+    EXPECT_EQ(copy->payload(), msg.payload());
+
+    EXPECT_EQ(msg.to_string(), std::string("ThreadMessage{7,[1]}"));
+}
+
+TEST(ThreadMessageIntegrationTest, HandlesInvalidEnum) {
+    ThreadMessage msg(static_cast<ThreadMessageType>(999), {"x"});
+
+    EXPECT_EQ(static_cast<int>(msg.type()), 999);
+    std::vector<std::string> expected{"x"};
+    EXPECT_EQ(msg.payload(), expected);
+    EXPECT_EQ(msg.to_string(), std::string("ThreadMessage{999,[x]}"));
+}
+


### PR DESCRIPTION
## Summary
- ThreadMessage の統合テストを追加し、正常系と異常系の挙動を検証

## Testing
- `cmake -S tests/integration -B build`
- `cmake --build build`
- `ctest --test-dir build` (No tests were found)
- `./build/test_integration`


------
https://chatgpt.com/codex/tasks/task_e_688d7a816b548328b93aec8554328865