### PR TITLE
統合テスト【watch_dog】

### DIFF
--- a/tests/integration/infra/watch_dog/test_watch_dog.cpp
+++ b/tests/integration/infra/watch_dog/test_watch_dog.cpp
@@ -1,0 +1,92 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "infra/watch_dog/watch_dog.hpp"
+#include "infra/timer_service/timer_service.hpp"
+#include "infra/logger/i_logger.hpp"
+#include "infra/thread_operation/thread_sender/i_thread_sender.hpp"
+
+#include <chrono>
+#include <thread>
+
+using ::testing::StrictMock;
+using ::testing::InSequence;
+
+namespace device_reminder {
+
+class MockLogger : public ILogger {
+public:
+    MOCK_METHOD(void, info, (const std::string& msg), (override));
+    MOCK_METHOD(void, error, (const std::string& msg), (override));
+    MOCK_METHOD(void, warn, (const std::string& msg), (override));
+};
+
+class MockThreadSender : public IThreadSender {
+public:
+    MOCK_METHOD(void, send, (), (override));
+};
+
+} // namespace device_reminder
+
+TEST(WatchDogIntegrationTest, StartTriggersTimeoutAndSend) {
+    using namespace device_reminder;
+
+    StrictMock<MockLogger> logger;
+    StrictMock<MockThreadSender> sender;
+
+    {
+        InSequence seq;
+        EXPECT_CALL(logger, info("TimerService created"));
+        EXPECT_CALL(logger, info("TimerService stopped"));
+        EXPECT_CALL(logger, info("TimerService started"));
+        EXPECT_CALL(logger, info("TimerService timeout"));
+        EXPECT_CALL(logger, info("TimerService stopped"));
+        EXPECT_CALL(logger, info("TimerService destroyed"));
+    }
+    EXPECT_CALL(sender, send()).Times(1);
+
+    auto logger_ptr = std::shared_ptr<ILogger>(&logger, [](ILogger*){});
+    auto sender_ptr = std::shared_ptr<IThreadSender>(&sender, [](IThreadSender*){});
+
+    auto timer = std::make_shared<TimerService>(logger_ptr, 10, sender_ptr);
+
+    {
+        WatchDog wd(timer);
+        wd.start();
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    timer.reset();
+}
+
+TEST(WatchDogIntegrationTest, StopBeforeTimeoutDoesNotSend) {
+    using namespace device_reminder;
+
+    StrictMock<MockLogger> logger;
+    StrictMock<MockThreadSender> sender;
+
+    {
+        InSequence seq;
+        EXPECT_CALL(logger, info("TimerService created"));
+        EXPECT_CALL(logger, info("TimerService stopped"));
+        EXPECT_CALL(logger, info("TimerService started"));
+        EXPECT_CALL(logger, info("TimerService stopped"));
+        EXPECT_CALL(logger, info("TimerService stopped"));
+        EXPECT_CALL(logger, info("TimerService destroyed"));
+    }
+    EXPECT_CALL(logger, info("TimerService timeout")).Times(0);
+    EXPECT_CALL(sender, send()).Times(0);
+
+    auto logger_ptr = std::shared_ptr<ILogger>(&logger, [](ILogger*){});
+    auto sender_ptr = std::shared_ptr<IThreadSender>(&sender, [](IThreadSender*){});
+
+    auto timer = std::make_shared<TimerService>(logger_ptr, 50, sender_ptr);
+
+    {
+        WatchDog wd(timer);
+        wd.start();
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        wd.stop();
+    }
+    timer.reset();
+}
+


### PR DESCRIPTION
## Summary
- add integration tests for WatchDog covering normal timeout and early stop cases

## Testing
- `cmake -S tests/integration -B build/integration`
- `cmake --build build/integration`
- `./build/integration/test_integration`


------
https://chatgpt.com/codex/tasks/task_e_688d7aa5838483288f64ccba1d9ff2f1