### PR TITLE
Fix AppBuilder integration test logger binding

### DIFF
--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -31,14 +31,17 @@ file(GLOB_RECURSE DEVICE_SOURCES CONFIGURE_DEPENDS ${PROJECT_ROOT}/src/*.cpp)
 list(REMOVE_ITEM DEVICE_SOURCES ${PROJECT_ROOT}/src/main.cpp)
 list(REMOVE_ITEM DEVICE_SOURCES ${PROJECT_ROOT}/src/core/app_builder/app_builder.cpp)
 
-# テストソース
-file(GLOB_RECURSE TEST_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
-list(FILTER TEST_SOURCES EXCLUDE REGEX "/build/")
+# テストソース (core 配下のみ)
+file(GLOB_RECURSE TEST_SOURCES CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/*.cpp
+)
 
 # スタブソース（gpiod は各テストでモック化）
 set(STUB_SOURCES
     ${PROJECT_ROOT}/tests/stubs/posix_mq_stub.cpp
     ${PROJECT_ROOT}/tests/stubs/popen_stub.cpp
+    ${PROJECT_ROOT}/tests/stubs/gpiod_stub.cpp
 )
 
 add_executable(test_integration


### PR DESCRIPTION
## Summary
- use simple CountingLogger in AppBuilder integration test instead of DI bound ILogger
- limit integration test build to core tests and link gpiod stub for GPIO-dependent sources

## Testing
- `cmake -S tests/integration -B build`
- `cmake --build build`
- `./build/test_integration --gtest_filter=AppTest.*:AppBuilderIntegrationTest.*:BuzzerHandlerIntegrationTest.*:BuzzerTaskIntegrationTest.*:BuzzerProcessIntegrationTest.*:BluetoothHandlerIntegrationTest.*:BluetoothProcessIntegrationTest.*:BluetoothTaskIntegration.*:HumanProcessIntegrationTest.*:MainHandlerIntegration.*:HumanTaskIntegrationTest.*:HumanHandlerIntegrationTest.*:MainTaskIntegrationTest.*:統合テスト_main_process.*` *(fails: BluetoothProcessIntegrationTest.異常系_BluetoothDriver例外, HumanProcessIntegrationTest.RunWithStartHumanDetection, HumanProcessIntegrationTest.RunWithDecodeFailure, HumanTaskIntegrationTest.NormalDetectionCallsSendOnce, HumanTaskIntegrationTest.AbnormalDetectionLogsErrorAndNoSend)*

------
https://chatgpt.com/codex/tasks/task_e_688d8f886a108328a9a838407484f351