### PR TITLE
Fix integration CMake and isolate gpiod mock

### DIFF
--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -31,11 +31,17 @@ file(GLOB_RECURSE DEVICE_SOURCES CONFIGURE_DEPENDS ${PROJECT_ROOT}/src/*.cpp)
 list(REMOVE_ITEM DEVICE_SOURCES ${PROJECT_ROOT}/src/main.cpp)
 list(REMOVE_ITEM DEVICE_SOURCES ${PROJECT_ROOT}/src/core/app_builder/app_builder.cpp)
 
-# テストソース (core 配下のみ)
+# テストソース
 file(GLOB_RECURSE TEST_SOURCES CONFIGURE_DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/test_main.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/infra/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/full_di/*.cpp
 )
+
+# gpiod を独自にモック化するテストは別ターゲットでビルド
+list(FILTER TEST_SOURCES EXCLUDE REGEX "infra/gpio_operation/gpio_reader/test_gpio_reader.cpp")
+list(FILTER TEST_SOURCES EXCLUDE REGEX "full_di/test_app_run.cpp")
 
 # スタブソース（gpiod は各テストでモック化）
 set(STUB_SOURCES
@@ -59,3 +65,42 @@ target_link_libraries(test_integration
 )
 
 add_test(NAME test_integration COMMAND test_integration)
+
+# -----------------------------------------------------------------------------
+# gpiod モックを独自に定義する GPIOReader のテスト
+# -----------------------------------------------------------------------------
+add_executable(test_integration_gpio_reader
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/infra/gpio_operation/gpio_reader/test_gpio_reader.cpp
+    ${DEVICE_SOURCES}
+    ${PROJECT_ROOT}/tests/stubs/posix_mq_stub.cpp
+    ${PROJECT_ROOT}/tests/stubs/popen_stub.cpp
+)
+
+target_link_libraries(test_integration_gpio_reader
+    gtest
+    gmock
+    gtest_main
+    pthread
+    rt
+)
+
+add_test(NAME test_integration_gpio_reader COMMAND test_integration_gpio_reader)
+
+# -----------------------------------------------------------------------------
+# full_di の統合テスト（専用の main を含む）
+# -----------------------------------------------------------------------------
+add_executable(test_integration_full_di
+    ${CMAKE_CURRENT_SOURCE_DIR}/full_di/test_app_run.cpp
+    ${DEVICE_SOURCES}
+    ${STUB_SOURCES}
+)
+
+target_link_libraries(test_integration_full_di
+    gtest
+    gmock
+    pthread
+    rt
+)
+
+add_test(NAME test_integration_full_di COMMAND test_integration_full_di)


### PR DESCRIPTION
## Summary
- include infra and full_di sources in integration tests
- build GPIOReader and full DI tests as separate targets

## Testing
- `cmake -S tests/integration -B build_integration`
- `cmake --build build_integration`
- `ctest --test-dir build_integration` *(fails: test_integration)*

------
https://chatgpt.com/codex/tasks/task_e_688da01797d083289896ba6821d5a041