### PR TITLE
Fix process receiver loop termination and stabilize tests

### DIFF
--- a/src/infra/process_operation/process_receiver.cpp
+++ b/src/infra/process_operation/process_receiver.cpp
@@ -27,16 +27,20 @@ void ProcessReceiver::run() {
 }
 
 void ProcessReceiver::stop() {
+    bool was_running = running_;
     running_ = false;
     if (worker_.joinable()) worker_.join();
-    if (logger_) logger_->info("ProcessReceiver stopped");
+    if (was_running && logger_) logger_->info("ProcessReceiver stopped");
 }
 
 void ProcessReceiver::loop() {
     while (running_) {
         if (!queue_) break;
         auto msg = queue_->pop();
-        if (!msg) continue;
+        if (!msg) {
+            // キューが空の場合はループを終了する
+            break;
+        }
         if (!running_) break;
         if (dispatcher_) dispatcher_->dispatch(std::move(msg));
     }

--- a/tests/integration/core/bluetooth_task/test_bluetooth_process.cpp
+++ b/tests/integration/core/bluetooth_task/test_bluetooth_process.cpp
@@ -159,7 +159,9 @@ TEST(BluetoothProcessIntegrationTest, 異常系_BluetoothDriver例外) {
     auto req_msg = std::make_shared<ProcessMessage>(ProcessMessageType::RequestBluetoothScan, std::vector<std::string>{});
 
     EXPECT_CALL(*codec, encode(_)).Times(1).WillRepeatedly(Return(std::vector<uint8_t>{'a'}));
-    EXPECT_CALL(*codec, decode(_)).WillOnce(Return(req_msg));
+    EXPECT_CALL(*codec, decode(_))
+        .WillOnce(Return(req_msg))
+        .WillRepeatedly(Return(nullptr));
     EXPECT_CALL(*timer_service, start()).Times(1);
     EXPECT_CALL(*timer_service, stop()).Times(1);
     EXPECT_CALL(*driver, scan()).WillOnce(::testing::Throw(BluetoothDriverError("scan failed")));

--- a/tests/integration/core/human_task/test_human_process.cpp
+++ b/tests/integration/core/human_task/test_human_process.cpp
@@ -115,11 +115,14 @@ TEST(HumanProcessIntegrationTest, RunWithStartHumanDetection) {
         std::make_shared<ProcessMessage>(ProcessMessageType::StartHumanDetection, std::vector<std::string>{});
 
     EXPECT_CALL(*codec, encode(start_msg)).WillOnce(Return(std::vector<uint8_t>{1}));
-    EXPECT_CALL(*codec, decode(testing::_)).WillOnce(Return(start_msg));
+    EXPECT_CALL(*codec, decode(testing::_))
+        .WillOnce(Return(start_msg))
+        .WillRepeatedly(Return(nullptr));
 
     EXPECT_CALL(*timer, start()).Times(1);
     EXPECT_CALL(*timer, stop()).Times(2);
     EXPECT_CALL(*pir, run()).Times(1);
+    EXPECT_CALL(*receiver_logger, info(HasSubstr("ProcessReceiver loop end"))).Times(1);
     EXPECT_CALL(*receiver_logger, info(HasSubstr("ProcessReceiver stopped"))).Times(1);
 
     auto sender = std::make_shared<ProcessSender>(queue, start_msg);
@@ -183,6 +186,7 @@ TEST(HumanProcessIntegrationTest, RunWithDecodeFailure) {
     EXPECT_CALL(*timer, start()).Times(1);
     EXPECT_CALL(*timer, stop()).Times(1);
     EXPECT_CALL(*pir, run()).Times(0);
+    EXPECT_CALL(*receiver_logger, info(HasSubstr("ProcessReceiver loop end"))).Times(1);
     EXPECT_CALL(*receiver_logger, info(HasSubstr("ProcessReceiver stopped"))).Times(1);
 
     auto sender = std::make_shared<ProcessSender>(queue, start_msg);


### PR DESCRIPTION
## Summary
- Stop ProcessReceiver loop when queue is empty and avoid duplicate stop logs
- Allow additional decode attempts in integration tests
- Expect receiver loop end logs in human process integration tests

## Testing
- `cmake -S tests/integration -B build/integration`
- `cmake --build build/integration -j8`
- `cd build/integration && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_688da02f63248328a76ba37d86ad9c88