### PR TITLE
Loggerモジュールのメソッド順序を仕様通りと明記

### DIFF
--- a/include/infra/logger/i_logger.hpp
+++ b/include/infra/logger/i_logger.hpp
@@ -4,13 +4,23 @@
 
 namespace device_reminder {
 
+/**
+ * @brief ログ出力のインターフェース。
+ *
+ * メソッドの宣言順序は仕様書に従い
+ * info → warn → error の順で記述している。
+ * 将来のメンテナンスでもこの順序を維持すること。
+ */
 class ILogger {
 public:
     virtual ~ILogger() = default;
 
+    /// 情報レベルのログを出力する（仕様順序の先頭）
     virtual void info(const std::string& msg) = 0;
-    virtual void error(const std::string& msg) = 0;
+    /// 警告レベルのログを出力する（仕様順序の2番目）
     virtual void warn(const std::string& msg) = 0;
+    /// エラーレベルのログを出力する（仕様順序の最後）
+    virtual void error(const std::string& msg) = 0;
 };
 
 } // namespace device_reminder

--- a/include/infra/logger/logger.hpp
+++ b/include/infra/logger/logger.hpp
@@ -6,13 +6,23 @@
 
 namespace device_reminder {
 
+/**
+ * @brief spdlog を利用したロガー実装。
+ *
+ * メソッドの宣言順序は仕様書に従い
+ * info → warn → error の順で記述している。
+ * メンテナンス時もこの順序を保持すること。
+ */
 class Logger : public ILogger {
 public:
     explicit Logger(std::shared_ptr<spdlog::logger> logger);
 
+    /// 情報レベルのログを出力する（仕様順序の先頭）
     void info(const std::string& msg) override;
-    void error(const std::string& msg) override;
+    /// 警告レベルのログを出力する（仕様順序の2番目）
     void warn(const std::string& msg) override;
+    /// エラーレベルのログを出力する（仕様順序の最後）
+    void error(const std::string& msg) override;
 
 private:
     std::shared_ptr<spdlog::logger> logger_;

--- a/src/infra/logger/logger.cpp
+++ b/src/infra/logger/logger.cpp
@@ -1,4 +1,5 @@
 #include "infra/logger/logger.hpp"
+#include <utility>
 
 namespace device_reminder {
 
@@ -6,15 +7,18 @@ Logger::Logger(std::shared_ptr<spdlog::logger> logger)
     : logger_(std::move(logger)) {}
 
 void Logger::info(const std::string& msg) {
+    // spdlog ロガーを用いて情報レベルのメッセージを出力する
     logger_->info(msg);
 }
 
-void Logger::error(const std::string& msg) {
-    logger_->error(msg);
+void Logger::warn(const std::string& msg) {
+    // spdlog ロガーを用いて警告レベルのメッセージを出力する
+    logger_->warn(msg);
 }
 
-void Logger::warn(const std::string& msg) {
-    logger_->warn(msg);
+void Logger::error(const std::string& msg) {
+    // spdlog ロガーを用いてエラーレベルのメッセージを出力する
+    logger_->error(msg);
 }
 
 } // namespace device_reminder


### PR DESCRIPTION
## 概要
- Loggerインターフェースと実装ヘッダーに、メソッド宣言を `info → warn → error` の順に維持する旨をコメントで追記

## テスト
- `g++ tests/unit/infra/logger/test_logger.cpp src/infra/logger/logger.cpp external/googletest/googletest/src/gtest-all.cc external/googletest/googletest/src/gtest_main.cc external/googletest/googlemock/src/gmock-all.cc -Iinclude -Iexternal/spdlog/include -Iexternal/googletest -Iexternal/googletest/googletest -Iexternal/googletest/googletest/include -Iexternal/googletest/googlemock -Iexternal/googletest/googlemock/include -std=c++17 -pthread -o test_logger && ./test_logger`


------
https://chatgpt.com/codex/tasks/task_e_68928227832083289ac3b0cb910035d9