### PR TITLE
refactor: adjust FileLoader interface

### DIFF
--- a/include/infra/file_loader/file_loader.hpp
+++ b/include/infra/file_loader/file_loader.hpp
@@ -3,25 +3,54 @@
 #include "infra/file_loader/i_file_loader.hpp"
 #include "infra/logger/i_logger.hpp"
 
-#include <string>
 #include <memory>
+#include <string>
 
 namespace device_reminder {
 
+/**
+ * @brief ファイルから設定値を読み出す `IFileLoader` の実装。
+ *
+ * 各読み出しメソッドは呼び出しごとにファイルへアクセスし、コンストラクタで
+ * 指定されたキーに対応する値を取得する。エラー発生時には `ILogger` を通して
+ * 記録し、`std::runtime_error` を送出する。
+ *
+ * スレッドセーフ性は保証されないため、同一インスタンスを複数スレッドから
+ * 利用する場合は外部で同期すること。
+ */
 class FileLoader : public IFileLoader {
 public:
-    FileLoader(std::shared_ptr<ILogger> logger,
-               const std::string& file_path);
+  /**
+   * @brief ファイルパスとキーを指定してローダを構築する。
+   *
+   * @param logger ログ出力に使用する `ILogger`。`nullptr`
+   * の場合はログ出力しない。
+   * @param file_path 読み込む設定ファイルのパス。
+   * @param key 取得対象となるキー。コンストラクタで保持される。
+   */
+  FileLoader(std::shared_ptr<ILogger> logger, const std::string &file_path,
+             const std::string &key);
 
-    int load_int(const std::string& key) const override;
-    std::string load_string(const std::string& key) const override;
-    std::vector<std::string> load_string_list(const std::string& key) const override;
+  /// @copydoc IFileLoader::load_int
+  int load_int() const override;
+
+  /// @copydoc IFileLoader::load_string
+  std::string load_string() const override;
+
+  /// @copydoc IFileLoader::load_string_list
+  std::vector<std::string> load_string_list() const override;
 
 private:
-    std::string load_value(const std::string& key) const;
+  /**
+   * @brief `key_` に対応する文字列値をファイルから取得する。
+   * @return 取得した文字列。
+   * @throws std::runtime_error ファイルオープン失敗やキー未存在の場合。
+   */
+  std::string load_value() const;
 
-    std::shared_ptr<ILogger> logger_;
-    std::string              file_path_;
+  std::shared_ptr<ILogger> logger_; ///< ログ出力に使用するロガー。
+  std::string file_path_;           ///< 対象となる設定ファイルのパス。
+  std::string key_;                 ///< 取得対象のキー。
 };
 
 } // namespace device_reminder

--- a/include/infra/file_loader/i_file_loader.hpp
+++ b/include/infra/file_loader/i_file_loader.hpp
@@ -5,13 +5,45 @@
 
 namespace device_reminder {
 
+/**
+ * @brief 設定ファイルから値を取得するためのインタフェース。
+ *
+ * 事前に指定されたキーに対応する値を読み出す API を提供する。
+ * 各呼び出しでは設定ファイルへアクセスを行うため、高頻度で呼び出す
+ * 場合はパフォーマンスに注意すること。
+ *
+ * エラー発生時には実装側で例外を送出する。スレッドセーフ性は保証されず、
+ * 複数スレッドから同時に利用する場合は呼び出し側で同期を行うこと。
+ */
 class IFileLoader {
 public:
-    virtual ~IFileLoader() = default;
+  virtual ~IFileLoader() = default;
 
-    virtual int load_int(const std::string& key) const = 0;
-    virtual std::string load_string(const std::string& key) const = 0;
-    virtual std::vector<std::string> load_string_list(const std::string& key) const = 0;
+  /**
+   * @brief 値を整数として取得する。
+   * @return 読み込まれた整数値。
+   * @throws std::runtime_error
+   * ファイルアクセスやキー未存在などの致命的な問題が発生した場合。
+   * @throws std::invalid_argument, std::out_of_range
+   * 整数への変換に失敗した場合。
+   */
+  virtual int load_int() const = 0;
+
+  /**
+   * @brief 値を文字列として取得する。
+   * @return 読み込まれた文字列。
+   * @throws std::runtime_error
+   * ファイルアクセスやキー未存在などの致命的な問題が発生した場合。
+   */
+  virtual std::string load_string() const = 0;
+
+  /**
+   * @brief 値をカンマ区切りの文字列リストとして取得する。
+   * @return 取り出した文字列のリスト。
+   * @throws std::runtime_error
+   * ファイルアクセスやキー未存在などの致命的な問題が発生した場合。
+   */
+  virtual std::vector<std::string> load_string_list() const = 0;
 };
 
 } // namespace device_reminder

--- a/src/infra/file_loader/file_loader.cpp
+++ b/src/infra/file_loader/file_loader.cpp
@@ -8,30 +8,32 @@
 namespace device_reminder {
 
 FileLoader::FileLoader(std::shared_ptr<ILogger> logger,
-                       const std::string& file_path)
+                       const std::string& file_path,
+                       const std::string& key)
     : logger_(std::move(logger))
     , file_path_(file_path)
+    , key_(key)
 {}
 
-int FileLoader::load_int(const std::string& key) const
+int FileLoader::load_int() const
 {
-    std::string value = load_value(key);
+    std::string value = load_value();
     try {
         return std::stoi(value);
     } catch (const std::exception&) {
-        if (logger_) logger_->error(std::string("invalid int value for ") + key);
+        if (logger_) logger_->error(std::string("invalid int value for ") + key_);
         throw;
     }
 }
 
-std::string FileLoader::load_string(const std::string& key) const
+std::string FileLoader::load_string() const
 {
-    return load_value(key);
+    return load_value();
 }
 
-std::vector<std::string> FileLoader::load_string_list(const std::string& key) const
+std::vector<std::string> FileLoader::load_string_list() const
 {
-    std::string value = load_value(key);
+    std::string value = load_value();
     std::vector<std::string> result;
     std::istringstream iss(value);
     std::string item;
@@ -44,7 +46,7 @@ std::vector<std::string> FileLoader::load_string_list(const std::string& key) co
     return result;
 }
 
-std::string FileLoader::load_value(const std::string& key) const
+std::string FileLoader::load_value() const
 {
     std::ifstream ifs(file_path_);
     if (!ifs) {
@@ -76,12 +78,12 @@ std::string FileLoader::load_value(const std::string& key) const
         auto value_start = value.find_first_not_of(" \t");
         if (value_start != std::string::npos) value = value.substr(value_start);
 
-        if (k == key) {
+        if (k == key_) {
             return value;
         }
     }
-    if (logger_) logger_->error("key not found: " + key);
-    throw std::runtime_error("key not found: " + key);
+    if (logger_) logger_->error("key not found: " + key_);
+    throw std::runtime_error("key not found: " + key_);
 }
 
 } // namespace device_reminder

--- a/tests/integration/infra/file_loader/test_file_loader.cpp
+++ b/tests/integration/infra/file_loader/test_file_loader.cpp
@@ -56,8 +56,8 @@ TEST(FileLoaderIntegrationTest, LoadIntReturnsValueWithoutErrorLog)
         ofs << "buzz_duration_ms=5000\n";
     }
 
-    device_reminder::FileLoader loader(logger, path.string());
-    int value = loader.load_int("buzz_duration_ms");
+    device_reminder::FileLoader loader(logger, path.string(), "buzz_duration_ms");
+    int value = loader.load_int();
     EXPECT_EQ(value, 5000);
 
     fs::remove(path);
@@ -84,8 +84,8 @@ TEST(FileLoaderIntegrationTest, LoadIntInvalidValueThrows)
         ofs << "buzz_duration_ms=abc\n";
     }
 
-    device_reminder::FileLoader loader(logger, path.string());
-    EXPECT_THROW(loader.load_int("buzz_duration_ms"), std::invalid_argument);
+    device_reminder::FileLoader loader(logger, path.string(), "buzz_duration_ms");
+    EXPECT_THROW(loader.load_int(), std::invalid_argument);
 
     fs::remove(path);
 }
@@ -111,8 +111,8 @@ TEST(FileLoaderIntegrationTest, LoadIntKeyNotFoundThrows)
         ofs << "other_key=1\n";
     }
 
-    device_reminder::FileLoader loader(logger, path.string());
-    EXPECT_THROW(loader.load_int("buzz_duration_ms"), std::runtime_error);
+    device_reminder::FileLoader loader(logger, path.string(), "buzz_duration_ms");
+    EXPECT_THROW(loader.load_int(), std::runtime_error);
 
     fs::remove(path);
 }
@@ -134,7 +134,7 @@ TEST(FileLoaderIntegrationTest, LoadIntFileNotFoundThrows)
 
     fs::path path = fs::temp_directory_path() / "file_loader_notfound.cfg";
 
-    device_reminder::FileLoader loader(logger, path.string());
-    EXPECT_THROW(loader.load_int("buzz_duration_ms"), std::runtime_error);
+    device_reminder::FileLoader loader(logger, path.string(), "buzz_duration_ms");
+    EXPECT_THROW(loader.load_int(), std::runtime_error);
 }
 

--- a/tests/unit/infra/file_loader/test_file_loader.cpp
+++ b/tests/unit/infra/file_loader/test_file_loader.cpp
@@ -26,9 +26,11 @@ TEST(FileLoaderTest, LoadIntSuccess) {
     ofs.close();
 
     NiceMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt");
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                      "/tmp/test_settings.txt",
+                      "buzz_duration_ms");
 
-    EXPECT_EQ(loader.load_int("buzz_duration_ms"), 5000);
+    EXPECT_EQ(loader.load_int(), 5000);
 }
 
 TEST(FileLoaderTest, LoadIntThrowsIfMissing) {
@@ -37,9 +39,11 @@ TEST(FileLoaderTest, LoadIntThrowsIfMissing) {
     ofs.close();
 
     StrictMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt");
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                      "/tmp/test_settings.txt",
+                      "b");
     EXPECT_CALL(logger, error(testing::HasSubstr("key not found"))).Times(1);
-    EXPECT_THROW(loader.load_int("b"), std::runtime_error);
+    EXPECT_THROW(loader.load_int(), std::runtime_error);
 }
 
 TEST(FileLoaderTest, LoadIntThrowsIfInvalid) {
@@ -48,16 +52,20 @@ TEST(FileLoaderTest, LoadIntThrowsIfInvalid) {
     ofs.close();
 
     StrictMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt");
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                      "/tmp/test_settings.txt",
+                      "buzz_duration_ms");
     EXPECT_CALL(logger, error(testing::HasSubstr("invalid int value"))).Times(1);
-    EXPECT_THROW(loader.load_int("buzz_duration_ms"), std::invalid_argument);
+    EXPECT_THROW(loader.load_int(), std::invalid_argument);
 }
 
 TEST(FileLoaderTest, LoadIntThrowsIfFileMissing) {
     StrictMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/does_not_exist.txt");
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                      "/tmp/does_not_exist.txt",
+                      "buzz_duration_ms");
     EXPECT_CALL(logger, error(testing::HasSubstr("failed to open file"))).Times(1);
-    EXPECT_THROW(loader.load_int("buzz_duration_ms"), std::runtime_error);
+    EXPECT_THROW(loader.load_int(), std::runtime_error);
 }
 
 TEST(FileLoaderTest, LoadIntInvalidWithoutLogger) {
@@ -65,8 +73,8 @@ TEST(FileLoaderTest, LoadIntInvalidWithoutLogger) {
     ofs << "buzz_duration_ms=bad\n";
     ofs.close();
 
-    FileLoader loader(nullptr, "/tmp/test_settings.txt");
-    EXPECT_THROW(loader.load_int("buzz_duration_ms"), std::invalid_argument);
+    FileLoader loader(nullptr, "/tmp/test_settings.txt", "buzz_duration_ms");
+    EXPECT_THROW(loader.load_int(), std::invalid_argument);
 }
 
 TEST(FileLoaderTest, LoadStringSuccess) {
@@ -75,15 +83,19 @@ TEST(FileLoaderTest, LoadStringSuccess) {
     ofs.close();
 
     NiceMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt");
-    EXPECT_EQ(loader.load_string("device_name"), "reminder");
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                      "/tmp/test_settings.txt",
+                      "device_name");
+    EXPECT_EQ(loader.load_string(), "reminder");
 }
 
 TEST(FileLoaderTest, LoadStringFileMissing) {
     StrictMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/missing.txt");
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                      "/tmp/missing.txt",
+                      "device_name");
     EXPECT_CALL(logger, error(testing::HasSubstr("failed to open file"))).Times(1);
-    EXPECT_THROW(loader.load_string("device_name"), std::runtime_error);
+    EXPECT_THROW(loader.load_string(), std::runtime_error);
 }
 
 TEST(FileLoaderTest, LoadStringKeyMissing) {
@@ -92,9 +104,11 @@ TEST(FileLoaderTest, LoadStringKeyMissing) {
     ofs.close();
 
     StrictMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt");
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                      "/tmp/test_settings.txt",
+                      "device_name");
     EXPECT_CALL(logger, error(testing::HasSubstr("key not found"))).Times(1);
-    EXPECT_THROW(loader.load_string("device_name"), std::runtime_error);
+    EXPECT_THROW(loader.load_string(), std::runtime_error);
 }
 
 TEST(FileLoaderTest, LoadStringListSuccess) {
@@ -103,8 +117,10 @@ TEST(FileLoaderTest, LoadStringListSuccess) {
     ofs.close();
 
     NiceMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt");
-    auto list = loader.load_string_list("device_list");
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                      "/tmp/test_settings.txt",
+                      "device_list");
+    auto list = loader.load_string_list();
     ASSERT_EQ(list.size(), 3);
     EXPECT_EQ(list[0], "phone");
     EXPECT_EQ(list[1], "watch");
@@ -117,7 +133,9 @@ TEST(FileLoaderTest, LoadStringListKeyMissing) {
     ofs.close();
 
     StrictMock<MockLogger> logger;
-    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), "/tmp/test_settings.txt");
+    FileLoader loader(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
+                      "/tmp/test_settings.txt",
+                      "device_list");
     EXPECT_CALL(logger, error(testing::HasSubstr("key not found"))).Times(1);
-    EXPECT_THROW(loader.load_string_list("device_list"), std::runtime_error);
+    EXPECT_THROW(loader.load_string_list(), std::runtime_error);
 }


### PR DESCRIPTION
## Summary
- update IFileLoader to read configured key without parameters
- revise FileLoader to take key in constructor and load values without arguments
- add API documentation comments for FileLoader and interface
- adapt unit and integration tests for FileLoader

## Testing
- `cmake -S . -B build` *(fails: Cannot find source file tests/core/app/test_app.cpp)*


------
https://chatgpt.com/codex/tasks/task_e_68928a611d4083288c1cc70b5b019f48