### PR TITLE
feat: add send result logging to timer service

### DIFF
--- a/include/infra/timer_service/timer_service.hpp
+++ b/include/infra/timer_service/timer_service.hpp
@@ -27,7 +27,7 @@ private:
     int duration_ms_{0};
     std::shared_ptr<IThreadSender> sender_;
     std::thread thread_;
-    std::atomic<bool> running_{false};
+    std::atomic<bool> cancel_flag_{false};
 };
 
 } // namespace device_reminder

--- a/tests/integration/infra/timer_service/test_timer_service.cpp
+++ b/tests/integration/infra/timer_service/test_timer_service.cpp
@@ -70,7 +70,7 @@ TEST(統合テストTimerService, 正常系_タイムアウトで送信) {
         EXPECT_CALL(*sink, log(InfoMsgEq("TimerService stopped")));
         EXPECT_CALL(*sink, log(InfoMsgEq("TimerService started")));
         EXPECT_CALL(*queue, push(msg_base));
-        EXPECT_CALL(*sink, log(InfoMsgEq("TimerService timeout")));
+        EXPECT_CALL(*sink, log(InfoMsgEq("TimerService send succeeded")));
         EXPECT_CALL(*sink, log(InfoMsgEq("TimerService stopped")));
         EXPECT_CALL(*sink, log(InfoMsgEq("TimerService destroyed")));
     }
@@ -99,7 +99,7 @@ TEST(統合テストTimerService, 異常系_メッセージ未設定) {
         EXPECT_CALL(*sink, log(InfoMsgEq("TimerService stopped")));
         EXPECT_CALL(*sink, log(InfoMsgEq("TimerService started")));
         EXPECT_CALL(*sink, log(ErrorMsgEq("ThreadSender send failed: null queue or message")));
-        EXPECT_CALL(*sink, log(InfoMsgEq("TimerService timeout")));
+        EXPECT_CALL(*sink, log(ErrorMsgEq("TimerService send failed")));
         EXPECT_CALL(*sink, log(InfoMsgEq("TimerService stopped")));
         EXPECT_CALL(*sink, log(InfoMsgEq("TimerService destroyed")));
     }

--- a/tests/unit/infra/timer_service/test_timer_service.cpp
+++ b/tests/unit/infra/timer_service/test_timer_service.cpp
@@ -50,7 +50,7 @@ TEST(TimerServiceTest, StartTriggersSendAndTimeoutLog) {
         EXPECT_CALL(logger, info("TimerService stopped"));
         EXPECT_CALL(logger, info("TimerService started"));
         EXPECT_CALL(sender, send()).Times(1);
-        EXPECT_CALL(logger, info("TimerService timeout"));
+        EXPECT_CALL(logger, info("TimerService send succeeded"));
         EXPECT_CALL(logger, info("TimerService stopped"));
         EXPECT_CALL(logger, info("TimerService destroyed"));
     }
@@ -70,7 +70,8 @@ TEST(TimerServiceTest, StartWithNullSenderDoesNotSend) {
         EXPECT_CALL(logger, info("TimerService created"));
         EXPECT_CALL(logger, info("TimerService stopped"));
         EXPECT_CALL(logger, info("TimerService started"));
-        EXPECT_CALL(logger, info("TimerService timeout")).Times(0);
+        EXPECT_CALL(logger, info("TimerService send succeeded")).Times(0);
+        EXPECT_CALL(logger, error("TimerService send failed"));
         EXPECT_CALL(logger, info("TimerService stopped"));
         EXPECT_CALL(logger, info("TimerService destroyed"));
     }
@@ -103,6 +104,8 @@ TEST(TimerServiceTest, StopBeforeTimeoutPreventsSend) {
         EXPECT_CALL(logger, info("TimerService stopped"));
         EXPECT_CALL(logger, info("TimerService started"));
         EXPECT_CALL(sender, send()).Times(0);
+        EXPECT_CALL(logger, info("TimerService send succeeded")).Times(0);
+        EXPECT_CALL(logger, error("TimerService send failed")).Times(0);
         EXPECT_CALL(logger, info("TimerService stopped"));
         EXPECT_CALL(logger, info("TimerService stopped"));
         EXPECT_CALL(logger, info("TimerService destroyed"));
@@ -127,7 +130,7 @@ TEST(TimerServiceTest, ZeroDurationTimeoutTriggersImmediately) {
         EXPECT_CALL(logger, info("TimerService stopped"));
         EXPECT_CALL(logger, info("TimerService started"));
         EXPECT_CALL(sender, send()).Times(1);
-        EXPECT_CALL(logger, info("TimerService timeout"));
+        EXPECT_CALL(logger, info("TimerService send succeeded"));
         EXPECT_CALL(logger, info("TimerService stopped"));
         EXPECT_CALL(logger, info("TimerService destroyed"));
     }


### PR DESCRIPTION
## Summary
- log timer send success or failure
- use cancel flag to control TimerService thread
- adjust unit and integration tests for TimerService

## Testing
- `cmake --build . --target test_infra_extra` *(fails: infra/thread_operation/thread_message/thread_message.hpp: No such file or directory)*
- `g++ -std=c++17 -I../include -I../external/googletest/googletest/include -I../external/googletest/googlemock/include -pthread ../tests/unit/infra/timer_service/test_timer_service.cpp ../src/infra/timer_service/timer_service.cpp -Llib -lgtest -lgmock -lgtest_main -o timer_service_test_manual && ./timer_service_test_manual`


------
https://chatgpt.com/codex/tasks/task_e_68933980dc50832888ca3f02a3c2a7be