### PR TITLE
Add WatchDog logging and update tests

### DIFF
--- a/include/infra/watch_dog/watch_dog.hpp
+++ b/include/infra/watch_dog/watch_dog.hpp
@@ -2,13 +2,15 @@
 
 #include "infra/watch_dog/i_watch_dog.hpp"
 #include "infra/timer_service/i_timer_service.hpp"
+#include "infra/logger/i_logger.hpp"
 #include <memory>
 
 namespace device_reminder {
 
 class WatchDog : public IWatchDog {
 public:
-    explicit WatchDog(std::shared_ptr<ITimerService> timer_service);
+    explicit WatchDog(std::shared_ptr<ITimerService> timer_service,
+                      std::shared_ptr<ILogger>     logger = nullptr);
 
     void start() override;
     void stop() override;
@@ -16,7 +18,8 @@ public:
 
 private:
     std::shared_ptr<ITimerService> timer_service_;
-    bool running_{false};
+    std::shared_ptr<ILogger>       logger_;
+    bool                           running_{false};
 };
 
 } // namespace device_reminder

--- a/src/infra/watch_dog/watch_dog.cpp
+++ b/src/infra/watch_dog/watch_dog.cpp
@@ -3,23 +3,31 @@
 
 namespace device_reminder {
 
-WatchDog::WatchDog(std::shared_ptr<ITimerService> timer_service)
-    : timer_service_(std::move(timer_service)) {}
+WatchDog::WatchDog(std::shared_ptr<ITimerService> timer_service,
+                   std::shared_ptr<ILogger>     logger)
+    : timer_service_(std::move(timer_service)),
+      logger_(std::move(logger)) {}
 
 void WatchDog::start() {
     if (!timer_service_ || running_) return;
+
+    if (logger_) logger_->info("WDT監視開始");
     timer_service_->start();
     running_ = true;
 }
 
 void WatchDog::stop() {
     if (!timer_service_ || !running_) return;
+
+    if (logger_) logger_->info("WDT監視停止");
     timer_service_->stop();
     running_ = false;
 }
 
 void WatchDog::kick() {
     if (!timer_service_) return;
+
+    if (logger_) logger_->info("WDT kick");
     timer_service_->stop();
     timer_service_->start();
     running_ = true;


### PR DESCRIPTION
## Summary
- log WatchDog start/stop/kick events
- accept optional logger in WatchDog and pass it in integration tests
- adjust integration tests to new TimerService log messages

## Testing
- `cmake -S . -B build` (pass)
- `cmake --build build` (fail: missing infra/thread_operation/thread_message/i_thread_message.hpp)
- `cmake --build build --target test_infra_extra` (fail: missing infra/process_operation/process_message/i_process_message.hpp)


------
https://chatgpt.com/codex/tasks/task_e_689353541cc08328b543a192b4961b52