### PR TITLE
Implement ProcessSender module per spec

### DIFF
--- a/include/infra/process_operation/i_process_sender.hpp
+++ b/include/infra/process_operation/i_process_sender.hpp
@@ -5,7 +5,8 @@
 namespace device_reminder {
 
 class IProcessQueue;
-class IProcessMessage;
+class IMessage;
+class ILogger;
 
 class IProcessSender {
 public:

--- a/include/infra/process_operation/process_queue/i_process_queue.hpp
+++ b/include/infra/process_operation/process_queue/i_process_queue.hpp
@@ -1,14 +1,14 @@
 #pragma once
 #include <memory>
-#include "infra/process_operation/process_message/i_process_message.hpp"
+#include "infra/message/i_message.hpp"
 
 namespace device_reminder {
 
 class IProcessQueue {
 public:
     virtual ~IProcessQueue() = default;
-    virtual void push(std::shared_ptr<IProcessMessage> msg) = 0;
-    virtual std::shared_ptr<IProcessMessage> pop() = 0;
+    virtual void enqueue(std::shared_ptr<IMessage> msg) = 0;
+    virtual std::shared_ptr<IMessage> pop() = 0;
 };
 
 } // namespace device_reminder

--- a/include/infra/process_operation/process_sender.hpp
+++ b/include/infra/process_operation/process_sender.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "infra/process_operation/process_message/i_process_message.hpp"
+#include "infra/process_operation/i_process_sender.hpp"
 #include "infra/process_operation/process_queue/i_process_queue.hpp"
-#include "infra/process_operation/process_sender/i_process_sender.hpp"
+#include "infra/message/i_message.hpp"
+#include "infra/logger/i_logger.hpp"
 #include <memory>
 
 namespace device_reminder {
@@ -10,13 +11,15 @@ namespace device_reminder {
 class ProcessSender : public IProcessSender {
 public:
   ProcessSender(std::shared_ptr<IProcessQueue> queue,
-                std::shared_ptr<IProcessMessage> msg);
+                std::shared_ptr<IMessage> msg,
+                std::shared_ptr<ILogger> logger);
 
   void send() override;
 
 private:
   std::shared_ptr<IProcessQueue> queue_;
-  std::shared_ptr<IProcessMessage> msg_;
+  std::shared_ptr<IMessage> msg_;
+  std::shared_ptr<ILogger> logger_;
 };
 
 } // namespace device_reminder

--- a/src/infra/process_operation/process_sender.cpp
+++ b/src/infra/process_operation/process_sender.cpp
@@ -1,20 +1,42 @@
-#include "infra/process_operation/process_sender/process_sender.hpp"
+#include "infra/process_operation/process_sender.hpp"
 
-#include "infra/process_operation/process_message/i_process_message.hpp"
+#include "infra/message/i_message.hpp"
 #include "infra/process_operation/process_queue/i_process_queue.hpp"
+#include "infra/logger/i_logger.hpp"
 
+#include <stdexcept>
 #include <utility>
 
 namespace device_reminder {
 
 ProcessSender::ProcessSender(std::shared_ptr<IProcessQueue> queue,
-                             std::shared_ptr<IProcessMessage> msg)
-    : queue_{std::move(queue)}, msg_{std::move(msg)} {}
+                             std::shared_ptr<IMessage> msg,
+                             std::shared_ptr<ILogger> logger)
+    : queue_{std::move(queue)},
+      msg_{std::move(msg)},
+      logger_{std::move(logger)} {}
 
 void ProcessSender::send() {
-  if (queue_) {
-    queue_->push(msg_);
+  try {
+    if (!logger_) {
+      throw std::runtime_error("logger is null");
+    }
+
+    logger_->info("メッセージ送信処理開始");
+
+    if (!queue_) {
+      throw std::runtime_error("queue is null");
+    }
+
+    queue_->enqueue(msg_);
+    logger_->info("メッセージ送信成功");
+  } catch (...) {
+    if (logger_) {
+      logger_->error("メッセージ送信失敗");
+    }
+    throw;
   }
 }
 
 } // namespace device_reminder
+


### PR DESCRIPTION
## Summary
- implement ProcessSender to send `IMessage` to `IProcessQueue` with logging
- update `IProcessQueue` interface for `enqueue`

## Testing
- `cmake -S . -B build`
- `cmake --build build` (fails: fatal error: infra/thread_operation/thread_message/i_thread_message.hpp: No such file or directory)
- `ctest --test-dir build` (fails: Unable to find executable: /workspace/device_reminder/build/test_app)

------
https://chatgpt.com/codex/tasks/task_e_6894a35a0ce08328829be65fdced7b97