### PR TITLE
Refactor ProcessQueue to use IMessage

### DIFF
--- a/include/infra/process_operation/process_queue/i_process_queue.hpp
+++ b/include/infra/process_operation/process_queue/i_process_queue.hpp
@@ -1,14 +1,14 @@
 #pragma once
 #include <memory>
-#include "infra/process_operation/process_message/i_process_message.hpp"
+#include "infra/message/i_message.hpp"
 
 namespace device_reminder {
 
 class IProcessQueue {
 public:
     virtual ~IProcessQueue() = default;
-    virtual void push(std::shared_ptr<IProcessMessage> msg) = 0;
-    virtual std::shared_ptr<IProcessMessage> pop() = 0;
+    virtual void push(std::shared_ptr<IMessage> msg) = 0;
+    virtual std::shared_ptr<IMessage> pop() = 0;
 };
 
 } // namespace device_reminder

--- a/include/infra/process_operation/process_queue/process_queue.hpp
+++ b/include/infra/process_operation/process_queue/process_queue.hpp
@@ -5,7 +5,8 @@
 #include <memory>
 
 #include "infra/logger/i_logger.hpp"
-#include "infra/process_operation/message_codec/i_message_codec.hpp"
+#include "infra/message/message_codec/i_message_codec.hpp"
+#include "infra/message/i_message.hpp"
 #include "infra/process_operation/process_queue/i_process_queue.hpp"
 
 namespace device_reminder {
@@ -15,8 +16,8 @@ public:
     ProcessQueue(std::shared_ptr<ILogger> logger,
                  std::shared_ptr<IMessageCodec> codec);
 
-    void push(std::shared_ptr<IProcessMessage> msg) override;
-    std::shared_ptr<IProcessMessage> pop() override;
+    void push(std::shared_ptr<IMessage> msg) override;
+    std::shared_ptr<IMessage> pop() override;
 
 private:
     std::queue<std::vector<uint8_t>> buffer_;

--- a/src/infra/process_operation/process_queue/process_queue.cpp
+++ b/src/infra/process_operation/process_queue/process_queue.cpp
@@ -10,7 +10,7 @@ ProcessQueue::ProcessQueue(std::shared_ptr<ILogger> logger,
                            std::shared_ptr<IMessageCodec> codec)
     : codec_{std::move(codec)}, logger_{std::move(logger)} {}
 
-void ProcessQueue::push(std::shared_ptr<IProcessMessage> msg) {
+void ProcessQueue::push(std::shared_ptr<IMessage> msg) {
     if (!msg) {
         if (logger_) logger_->warn("push called with nullptr message");
         return;
@@ -28,7 +28,7 @@ void ProcessQueue::push(std::shared_ptr<IProcessMessage> msg) {
     }
 }
 
-std::shared_ptr<IProcessMessage> ProcessQueue::pop() {
+std::shared_ptr<IMessage> ProcessQueue::pop() {
     std::vector<uint8_t> data;
     {
         std::lock_guard<std::mutex> lock{mtx_};


### PR DESCRIPTION
## Summary
- 修正: ProcessQueueをIMessageに対応させ、IMessageCodecを使用するように依存関係とインタフェースを更新
- 更新: push/popでIMessageを処理し、メッセージバッファに対するログ出力とエラーハンドリングを整備

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(ヘッダ欠如により失敗)*


------
https://chatgpt.com/codex/tasks/task_e_6894ac1d1ce08328b2c0bfd3ee63600a