### PR TITLE
Improve process receiver message handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ add_executable(test_infra_extra
     src/infra/buzzer_driver/buzzer_driver.cpp
     src/infra/process_operation/process_dispatcher/process_dispatcher.cpp
     src/infra/process_operation/process_base.cpp
-    src/infra/process_operation/process_receiver.cpp
+    src/infra/process_operation/process_receiver/process_receiver.cpp
     src/infra/bluetooth_driver/bluetooth_driver.cpp
     src/infra/file_loader/file_loader.cpp
     tests/stubs/gpiod_stub.cpp

--- a/include/infra/process_operation/process_receiver/process_receiver.hpp
+++ b/include/infra/process_operation/process_receiver/process_receiver.hpp
@@ -21,8 +21,8 @@ public:
                     std::shared_ptr<IProcessDispatcher> dispatcher);
     ~ProcessReceiver();
 
-    void run() override;  ///< 受信スレッド開始
-    void stop() override; ///< スレッド停止要求
+    void run() override;  ///< 受信スレッドを開始
+    void stop() override; ///< 受信スレッドを停止
 
 private:
     void loop();

--- a/src/infra/process_operation/process_receiver/process_receiver.cpp
+++ b/src/infra/process_operation/process_receiver/process_receiver.cpp
@@ -12,9 +12,7 @@ ProcessReceiver::ProcessReceiver(std::shared_ptr<ILogger> logger,
                                  std::shared_ptr<IProcessDispatcher> dispatcher)
     : logger_(std::move(logger)),
       queue_(std::move(queue)),
-      dispatcher_(std::move(dispatcher)) {
-    if (logger_) logger_->info("ProcessReceiver created");
-}
+      dispatcher_(std::move(dispatcher)) {}
 
 ProcessReceiver::~ProcessReceiver() {
     stop();
@@ -23,14 +21,15 @@ ProcessReceiver::~ProcessReceiver() {
 void ProcessReceiver::run() {
     if (running_) return;
     running_ = true;
+    if (logger_) logger_->info("受信スレッド開始");
     worker_ = std::thread(&ProcessReceiver::loop, this);
 }
 
 void ProcessReceiver::stop() {
-    bool was_running = running_;
+    if (!running_) return;
     running_ = false;
     if (worker_.joinable()) worker_.join();
-    if (was_running && logger_) logger_->info("ProcessReceiver stopped");
+    if (logger_) logger_->info("受信スレッド停止完了");
 }
 
 void ProcessReceiver::loop() {
@@ -38,13 +37,16 @@ void ProcessReceiver::loop() {
         if (!queue_) break;
         auto msg = queue_->pop();
         if (!msg) {
-            // キューが空の場合はループを終了する
-            break;
+            if (logger_) logger_->warn("受信メッセージがnullptrのため無視");
+            continue;
         }
-        if (!running_) break;
-        if (dispatcher_) dispatcher_->dispatch(std::move(msg));
+        if (dispatcher_) {
+            dispatcher_->dispatch(std::move(msg));
+            if (logger_) logger_->info("メッセージをディスパッチしました");
+        }
     }
-    if (logger_) logger_->info("ProcessReceiver loop end");
+    if (logger_) logger_->info("受信スレッド停止");
 }
 
 } // namespace device_reminder
+

--- a/tests/unit/infra/process_operation/test_process_receiver.cpp
+++ b/tests/unit/infra/process_operation/test_process_receiver.cpp
@@ -1,51 +1,67 @@
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
-#include "infra/process_operation/process_receiver/process_receiver.hpp"
-#include "infra/process_operation/process_message/process_message.hpp"
-#include "infra/process_operation/process_queue/i_process_queue.hpp"
-#include "infra/process_operation/process_dispatcher/i_process_dispatcher.hpp"
 #include "infra/logger/i_logger.hpp"
+#include "infra/message/i_message.hpp"
+#include "infra/process_operation/process_dispatcher/i_process_dispatcher.hpp"
+#include "infra/process_operation/process_queue/i_process_queue.hpp"
+#include "infra/process_operation/process_receiver/process_receiver.hpp"
+
 #include <thread>
 
 using namespace device_reminder;
+using ::testing::AtLeast;
 using ::testing::NiceMock;
-using ::testing::StrictMock;
+using ::testing::Return;
 
 namespace {
+
 class MockLogger : public ILogger {
 public:
     MOCK_METHOD(void, info, (const std::string&), (override));
-    MOCK_METHOD(void, error, (const std::string&), (override));
     MOCK_METHOD(void, warn, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
 };
 
 class MockQueue : public IProcessQueue {
 public:
-    MOCK_METHOD(void, push, (std::shared_ptr<IProcessMessage>), (override));
-    MOCK_METHOD(std::shared_ptr<IProcessMessage>, pop, (), (override));
-    MOCK_METHOD(std::size_t, size, (), (const, override));
+    MOCK_METHOD(void, push, (std::shared_ptr<IMessage>), (override));
+    MOCK_METHOD(std::shared_ptr<IMessage>, pop, (), (override));
 };
 
 class MockDispatcher : public IProcessDispatcher {
 public:
-    MOCK_METHOD(void, dispatch, (std::shared_ptr<IProcessMessage>), (override));
+    MOCK_METHOD(void, dispatch, (std::shared_ptr<IMessage>), (override));
 };
+
+class DummyMessage : public IMessage {
+public:
+    MessageType type() const noexcept override { return MessageType::None; }
+    std::vector<std::string> payload() const noexcept override { return {}; }
+    std::string to_string() const override { return {}; }
+};
+
 } // namespace
 
 TEST(ProcessReceiverTest, DispatchesMessage) {
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    auto msg = std::make_shared<DummyMessage>();
 
+    NiceMock<MockLogger> logger;
     MockQueue queue;
     MockDispatcher dispatcher;
 
+    EXPECT_CALL(logger, info("受信スレッド開始")).Times(1);
+    EXPECT_CALL(logger, info("メッセージをディスパッチしました")).Times(1);
+    EXPECT_CALL(logger, info("受信スレッド停止")).Times(1);
+    EXPECT_CALL(logger, info("受信スレッド停止完了")).Times(1);
+
     EXPECT_CALL(queue, pop())
-        .WillOnce(testing::Return(msg))
-        .WillRepeatedly(testing::Return(nullptr));
-    auto msg_base = std::static_pointer_cast<IProcessMessage>(msg);
+        .WillOnce(Return(msg))
+        .WillRepeatedly(Return(nullptr));
+    auto msg_base = std::static_pointer_cast<IMessage>(msg);
     EXPECT_CALL(dispatcher, dispatch(msg_base)).Times(1);
 
-    ProcessReceiver receiver(nullptr,
+    ProcessReceiver receiver(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
                             std::shared_ptr<IProcessQueue>(&queue, [](IProcessQueue*){}),
                             std::shared_ptr<IProcessDispatcher>(&dispatcher, [](IProcessDispatcher*){}));
     receiver.run();
@@ -53,46 +69,24 @@ TEST(ProcessReceiverTest, DispatchesMessage) {
     receiver.stop();
 }
 
-TEST(ProcessReceiverTest, ConstructorLogsCreationAndStop) {
+TEST(ProcessReceiverTest, NullMessageLogsWarning) {
     NiceMock<MockLogger> logger;
-    EXPECT_CALL(logger, info("ProcessReceiver created")).Times(1);
-    EXPECT_CALL(logger, info("ProcessReceiver stopped")).Times(1);
+    MockQueue queue;
+    MockDispatcher dispatcher;
+
+    EXPECT_CALL(logger, info("受信スレッド開始")).Times(1);
+    EXPECT_CALL(logger, warn("受信メッセージがnullptrのため無視")).Times(AtLeast(1));
+    EXPECT_CALL(logger, info("受信スレッド停止")).Times(1);
+    EXPECT_CALL(logger, info("受信スレッド停止完了")).Times(1);
+
+    EXPECT_CALL(queue, pop()).WillRepeatedly(Return(nullptr));
+    EXPECT_CALL(dispatcher, dispatch(::testing::_)).Times(0);
 
     ProcessReceiver receiver(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
-                            nullptr,
-                            nullptr);
+                            std::shared_ptr<IProcessQueue>(&queue, [](IProcessQueue*){}),
+                            std::shared_ptr<IProcessDispatcher>(&dispatcher, [](IProcessDispatcher*){}));
+    receiver.run();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    receiver.stop();
 }
 
-TEST(ProcessReceiverTest, ConstructorWithoutLogger) {
-    ProcessReceiver receiver(nullptr, nullptr, nullptr);
-}
-
-TEST(ProcessReceiverTest, RunWithNullQueueLogsLoopEnd) {
-    NiceMock<MockLogger> logger;
-    EXPECT_CALL(logger, info("ProcessReceiver created")).Times(1);
-    EXPECT_CALL(logger, info("ProcessReceiver loop end")).Times(1);
-    EXPECT_CALL(logger, info("ProcessReceiver stopped")).Times(1);
-
-    {
-        ProcessReceiver receiver(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
-                                nullptr,
-                                nullptr);
-        receiver.run();
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        // destructor will call stop()
-    }
-}
-
-TEST(ProcessReceiverTest, StopWithoutRunLogsStoppedTwice) {
-    NiceMock<MockLogger> logger;
-    EXPECT_CALL(logger, info("ProcessReceiver created")).Times(1);
-    EXPECT_CALL(logger, info("ProcessReceiver stopped")).Times(2);
-
-    {
-        ProcessReceiver receiver(std::shared_ptr<ILogger>(&logger, [](ILogger*){}),
-                                nullptr,
-                                nullptr);
-        receiver.stop();
-        // destructor will call stop() again
-    }
-}


### PR DESCRIPTION
## Summary
- Move process receiver implementation to dedicated directory
- Handle message reception in a thread with start/stop logs and warnings for null messages
- Add unit tests for process receiver dispatching and null message handling

## Testing
- `cmake -S . -B build` *(pass)*
- `cmake --build build` *(fails: infra/thread_operation/thread_message/i_thread_message.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689568d319e0832896a1118db2c171b8