### PR TITLE
Refactor GPIOSetter to use file loader

### DIFF
--- a/include/infra/gpio_operation/gpio_setter/gpio_setter.hpp
+++ b/include/infra/gpio_operation/gpio_setter/gpio_setter.hpp
@@ -2,12 +2,9 @@
 
 #include "infra/gpio_operation/gpio_setter/i_gpio_setter.hpp"
 #include "infra/logger/i_logger.hpp"
+#include "infra/file_loader/i_file_loader.hpp"
 
 #include <memory>
-#include <string>
-
-struct gpiod_chip;
-struct gpiod_line;
 
 namespace device_reminder {
 
@@ -15,15 +12,14 @@ class GPIOSetter : public IGPIOSetter {
 public:
     GPIOSetter(std::shared_ptr<ILogger> logger,
                int pin_no,
-               std::string chip_name = "/dev/gpiochip0");
-    ~GPIOSetter() override;
+               std::shared_ptr<IFileLoader> loader);
 
-    void write(bool value) override;
+    void write(bool is_high) override;
 
 private:
     std::shared_ptr<ILogger> logger_;
-    gpiod_chip* chip_;
-    gpiod_line* line_;
+    int pin_no_;
+    std::shared_ptr<IFileLoader> loader_;
 };
 
 } // namespace device_reminder


### PR DESCRIPTION
## Summary
- Use `IFileLoader` in `GPIOSetter` to obtain chip name dynamically
- Rework write to open/close GPIO chip per call with improved logging

## Testing
- `cmake -S . -B build` (succeeded)
- `cmake --build build` (failed: missing header in unrelated module)
- `ctest --test-dir build` (failed: no test executables)


------
https://chatgpt.com/codex/tasks/task_e_68956d1a76808328ae11a9545d955efd