### PR TITLE
PIRDriverの仕様改修

### DIFF
--- a/include/infra/pir_driver/pir_driver.hpp
+++ b/include/infra/pir_driver/pir_driver.hpp
@@ -2,23 +2,23 @@
 
 #include "pir_driver/i_pir_driver.hpp"
 #include "infra/file_loader/i_file_loader.hpp"
-#include "infra/gpio_operation/gpio_reader/i_gpio_reader.hpp"
+#include "infra/gpio_operation/i_gpio_reader.hpp"
 #include "infra/logger/i_logger.hpp"
 #include "infra/thread_operation/thread_sender/i_thread_sender.hpp"
-#include <thread>
 #include <atomic>
-
 #include <memory>
 #include <string>
+#include <thread>
 
 namespace device_reminder {
 
 class PIRDriver : public IPIRDriver {
 public:
-    PIRDriver(std::shared_ptr<IFileLoader> loader,
+    PIRDriver(std::shared_ptr<IFileLoader> gpiochip_loader,
               std::shared_ptr<ILogger> logger,
               std::shared_ptr<IThreadSender> sender,
-              std::shared_ptr<IGPIOReader> gpio);
+              std::shared_ptr<IGPIOReader> reader,
+              IFileLoader& pin_loader);
 
     ~PIRDriver() override;
 
@@ -26,13 +26,14 @@ public:
     void stop() override;
 
 private:
-    std::shared_ptr<IFileLoader> loader_;
+    std::shared_ptr<IFileLoader> gpiochip_loader_;
     std::shared_ptr<ILogger> logger_;
     std::shared_ptr<IThreadSender> sender_;
-    std::shared_ptr<IGPIOReader> gpio_;
+    std::shared_ptr<IGPIOReader> reader_;
+    IFileLoader& pin_loader_;
     std::thread thread_;
     std::atomic<bool> running_{false};
-    bool last_state_{false};
+    std::exception_ptr thread_exception_{};
 };
 
 } // namespace device_reminder


### PR DESCRIPTION
## 概要
- PIRドライバをGPIOエッジ検出ベースの実装へ更新
- ローダの構成変更に伴うコンストラクタとテストの修正

## テスト
- `cmake -S . -B build` : OK
- `cmake --build build` : `infra/thread_operation/thread_message/i_thread_message.hpp` が存在せずビルド失敗
- `g++ -std=c++17 -Iinclude -Iinclude/infra -c src/infra/pir_driver/pir_driver.cpp` : OK


------
https://chatgpt.com/codex/tasks/task_e_689570e0f9148328b1f5a75829067c2b