### PR TITLE
refactor bluetooth driver to use distance field

### DIFF
--- a/include/infra/bluetooth_driver/i_bluetooth_scanner.hpp
+++ b/include/infra/bluetooth_driver/i_bluetooth_scanner.hpp
@@ -7,7 +7,7 @@ namespace device_reminder {
 
 struct BluetoothDevice {
     std::string mac;
-    int rssi;
+    int distance;
 };
 
 class IBluetoothScanner {

--- a/src/infra/bluetooth_driver/bluetooth_driver.cpp
+++ b/src/infra/bluetooth_driver/bluetooth_driver.cpp
@@ -34,7 +34,7 @@ void BluetoothDriver::run() {
     std::vector<std::string> targets;
     for (const auto& dev : scanned) {
         if (std::find(registered.begin(), registered.end(), dev.mac) != registered.end() &&
-            dev.rssi >= threshold) {
+            dev.distance <= threshold) {
             targets.push_back(dev.mac);
         }
     }

--- a/tests/unit/infra/bluetooth_driver/test_bluetooth_driver.cpp
+++ b/tests/unit/infra/bluetooth_driver/test_bluetooth_driver.cpp
@@ -56,10 +56,10 @@ TEST(BluetoothDriverTest, RunFiltersPairsAndNotifies) {
     EXPECT_CALL(*dev_loader, load_string_list("device_list"))
         .WillOnce(Return(std::vector<std::string>{"AA", "CC"}));
     EXPECT_CALL(*dist_loader, load_int("distance_threshold"))
-        .WillOnce(Return(-50));
+        .WillOnce(Return(50));
     EXPECT_CALL(*scanner, scan())
         .WillOnce(Return(std::vector<BluetoothDevice>{
-            {"AA", -40}, {"BB", -30}, {"CC", -60}
+            {"AA", 40}, {"BB", 30}, {"CC", 60}
         }));
     EXPECT_CALL(*pairer, pair("AA")).WillOnce(Return(true));
     EXPECT_CALL(*pairer, pair("CC")).Times(0);
@@ -84,9 +84,9 @@ TEST(BluetoothDriverTest, RunNoSuccessNoNotify) {
     EXPECT_CALL(*dev_loader, load_string_list("device_list"))
         .WillOnce(Return(std::vector<std::string>{"AA"}));
     EXPECT_CALL(*dist_loader, load_int("distance_threshold"))
-        .WillOnce(Return(-50));
+        .WillOnce(Return(50));
     EXPECT_CALL(*scanner, scan())
-        .WillOnce(Return(std::vector<BluetoothDevice>{{"AA", -80}}));
+        .WillOnce(Return(std::vector<BluetoothDevice>{{"AA", 80}}));
     EXPECT_CALL(*pairer, pair(_)).Times(0);
     EXPECT_CALL(*sender, send()).Times(0);
 


### PR DESCRIPTION
## Summary
- rename BluetoothDevice rssi to distance
- filter devices by distance threshold and update tests

## Testing
- `cmake ..` (passed)
- `cmake --build .` (failed: infra/thread_operation/thread_message/i_thread_message.hpp: No such file or directory)
- `cmake --build . --target test_infra_extra` (failed: infra/thread_operation/thread_message/thread_message.hpp: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68957217b3688328a006e0f98691fda4