### PR TITLE
feat: redesign buzzer driver

### DIFF
--- a/include/infra/buzzer_driver/buzzer_driver.hpp
+++ b/include/infra/buzzer_driver/buzzer_driver.hpp
@@ -4,6 +4,7 @@
 #include "infra/gpio_operation/gpio_setter/i_gpio_setter.hpp"
 #include "infra/file_loader/i_file_loader.hpp"
 #include <memory>
+#include <mutex>
 #include <string>
 
 namespace device_reminder {
@@ -19,9 +20,12 @@ public:
     void off() override;
 
 private:
-    std::shared_ptr<IFileLoader> loader_;
+    int pin_{};
+    bool active_high_{true};
     std::shared_ptr<ILogger>     logger_;
     std::shared_ptr<IGPIOSetter> gpio_;
-}; 
+    std::mutex mutex_;
+    bool is_on_{false};
+};
 
 } // namespace device_reminder

--- a/include/infra/buzzer_driver/i_buzzer_driver.hpp
+++ b/include/infra/buzzer_driver/i_buzzer_driver.hpp
@@ -1,4 +1,4 @@
-// buzzer_driver.hpp
+// i_buzzer_driver.hpp
 #pragma once
 
 namespace device_reminder {

--- a/src/infra/buzzer_driver/buzzer_driver.cpp
+++ b/src/infra/buzzer_driver/buzzer_driver.cpp
@@ -1,36 +1,110 @@
 #include "buzzer_driver/buzzer_driver.hpp"
 
+#include <stdexcept>
+#include <string>
+
 namespace device_reminder {
 
 BuzzerDriver::BuzzerDriver(std::shared_ptr<IFileLoader> loader,
                            std::shared_ptr<ILogger> logger,
                            std::shared_ptr<IGPIOSetter> gpio)
-    : loader_(std::move(loader)),
-      logger_(std::move(logger)),
-      gpio_(std::move(gpio))
-{
-    if (logger_) logger_->info("BuzzerDriver created");
-    if (loader_) {
-        try {
-            loader_->load_int("buzz_duration_ms"); // 設定値読み込み (エラー確認のみ)
-        } catch (...) {
-            if (logger_) logger_->error("Failed to load buzzer config");
-        }
+    : logger_(std::move(logger)), gpio_(std::move(gpio)) {
+    if (!logger_) { throw std::invalid_argument("ILogger is null"); }
+    if (!loader) {
+        logger_->error("IFileLoader is null");
+        throw std::invalid_argument("IFileLoader is null");
     }
+    if (!gpio_) {
+        logger_->error("IGPIOSetter is null");
+        throw std::invalid_argument("IGPIOSetter is null");
+    }
+
+    try {
+        pin_ = loader->load_int();
+    } catch (const std::exception& e) {
+        logger_->error(std::string("Failed to load pin: ") + e.what());
+        throw;
+    }
+    if (pin_ < 0) {
+        logger_->error("Invalid pin number: " + std::to_string(pin_));
+        throw std::runtime_error("Invalid pin number");
+    }
+
+    std::string active_level = "high";
+    try {
+        active_level = loader->load_string();
+    } catch (...) {
+        // use default
+    }
+    if (active_level == "high") {
+        active_high_ = true;
+    } else if (active_level == "low") {
+        active_high_ = false;
+    } else {
+        logger_->error("Invalid active_level: " + active_level);
+        throw std::runtime_error("Invalid active_level");
+    }
+
+    std::string initial_state = "off";
+    try {
+        initial_state = loader->load_string();
+    } catch (...) {
+        // use default
+    }
+    if (initial_state == "on") {
+        is_on_ = true;
+    } else if (initial_state == "off") {
+        is_on_ = false;
+    } else {
+        logger_->error("Invalid initial_state: " + initial_state);
+        throw std::runtime_error("Invalid initial_state");
+    }
+
+    try {
+        gpio_->write(is_on_ ? active_high_ : !active_high_);
+    } catch (const std::exception& e) {
+        logger_->error(std::string("Failed to set initial state: ") + e.what());
+        throw;
+    }
+
+    logger_->info("BuzzerDriver init: pin=" + std::to_string(pin_)
+                  + " active_level=" + (active_high_ ? "high" : "low")
+                  + " initial_state=" + (is_on_ ? "on" : "off"));
 }
 
 void BuzzerDriver::on() {
-    if (gpio_) {
-        gpio_->write(true);
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (is_on_) {
+        logger_->info("Buzzer already ON");
+        return;
     }
-    if (logger_) logger_->info("buzzer on");
+    try {
+        gpio_->write(active_high_);
+    } catch (const std::exception& e) {
+        logger_->error("Failed to turn ON buzzer pin " + std::to_string(pin_)
+                        + ": " + e.what());
+        throw;
+    }
+    is_on_ = true;
+    logger_->info("Buzzer ON pin=" + std::to_string(pin_));
 }
 
 void BuzzerDriver::off() {
-    if (gpio_) {
-        gpio_->write(false);
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!is_on_) {
+        logger_->info("Buzzer already OFF");
+        return;
     }
-    if (logger_) logger_->info("buzzer off");
+    try {
+        gpio_->write(!active_high_);
+    } catch (const std::exception& e) {
+        logger_->error("Failed to turn OFF buzzer pin " + std::to_string(pin_)
+                        + ": " + e.what());
+        throw;
+    }
+    is_on_ = false;
+    logger_->info("Buzzer OFF pin=" + std::to_string(pin_));
 }
 
 } // namespace device_reminder
+

--- a/tests/unit/infra/buzzer_driver/test_buzzer_driver.cpp
+++ b/tests/unit/infra/buzzer_driver/test_buzzer_driver.cpp
@@ -1,23 +1,21 @@
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
 
 #include "infra/buzzer_driver/buzzer_driver.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
-#include "infra/gpio_operation/gpio_setter/i_gpio_setter.hpp"
 
 using namespace device_reminder;
-using ::testing::NiceMock;
-using ::testing::StrictMock;
 using ::testing::Return;
-using ::testing::Throw;
+using ::testing::StrictMock;
 
 namespace {
 
 class MockLogger : public ILogger {
 public:
     MOCK_METHOD(void, info, (const std::string&), (override));
-    MOCK_METHOD(void, error, (const std::string&), (override));
     MOCK_METHOD(void, warn, (const std::string&), (override));
+    MOCK_METHOD(void, error, (const std::string&), (override));
 };
 
 class MockGPIO : public IGPIOSetter {
@@ -27,152 +25,73 @@ public:
 
 class MockLoader : public IFileLoader {
 public:
-    MOCK_METHOD(int, load_int, (const std::string&), (const, override));
-    MOCK_METHOD(std::string, load_string, (const std::string&), (const, override));
-    MOCK_METHOD(std::vector<std::string>, load_string_list, (const std::string&), (const, override));
+    MOCK_METHOD(int, load_int, (), (const, override));
+    MOCK_METHOD(std::string, load_string, (), (const, override));
+    MOCK_METHOD(std::vector<std::string>, load_string_list, (), (const, override));
 };
 
 } // namespace
 
-TEST(BuzzerDriverTest, ConstructorAllValid) {
+TEST(BuzzerDriverTest, ConstructorInitializesGPIO) {
     auto loader = std::make_shared<StrictMock<MockLoader>>();
     auto logger = std::make_shared<StrictMock<MockLogger>>();
     auto gpio   = std::make_shared<StrictMock<MockGPIO>>();
 
-    EXPECT_CALL(*logger, info("BuzzerDriver created")).Times(1);
-    EXPECT_CALL(*loader, load_int("buzz_duration_ms")).Times(1);
+    {
+        ::testing::InSequence seq;
+        EXPECT_CALL(*loader, load_int()).WillOnce(Return(1));
+        EXPECT_CALL(*loader, load_string()).WillOnce(Return("high"));
+        EXPECT_CALL(*loader, load_string()).WillOnce(Return("off"));
+        EXPECT_CALL(*gpio, write(false));
+        EXPECT_CALL(*logger, info("BuzzerDriver init: pin=1 active_level=high initial_state=off"));
+    }
 
     BuzzerDriver driver(loader, logger, gpio);
 }
 
-TEST(BuzzerDriverTest, ConstructorLoaderNull) {
+TEST(BuzzerDriverTest, OnOffOperations) {
+    auto loader = std::make_shared<StrictMock<MockLoader>>();
     auto logger = std::make_shared<StrictMock<MockLogger>>();
     auto gpio   = std::make_shared<StrictMock<MockGPIO>>();
 
-    EXPECT_CALL(*logger, info("BuzzerDriver created")).Times(1);
+    {
+        ::testing::InSequence seq;
+        EXPECT_CALL(*loader, load_int()).WillOnce(Return(2));
+        EXPECT_CALL(*loader, load_string()).WillOnce(Return("low"));
+        EXPECT_CALL(*loader, load_string()).WillOnce(Return("off"));
+        EXPECT_CALL(*gpio, write(true));
+        EXPECT_CALL(*logger, info("BuzzerDriver init: pin=2 active_level=low initial_state=off"));
+    }
 
-    BuzzerDriver driver(nullptr, logger, gpio);
+    BuzzerDriver driver(loader, logger, gpio);
+
+    EXPECT_CALL(*gpio, write(false));
+    EXPECT_CALL(*logger, info("Buzzer ON pin=2"));
+    driver.on();
+
+    EXPECT_CALL(*logger, info("Buzzer already ON"));
+    driver.on();
+
+    EXPECT_CALL(*gpio, write(true));
+    EXPECT_CALL(*logger, info("Buzzer OFF pin=2"));
+    driver.off();
+
+    EXPECT_CALL(*logger, info("Buzzer already OFF"));
+    driver.off();
 }
 
-TEST(BuzzerDriverTest, ConstructorLoggerNull) {
+TEST(BuzzerDriverTest, NullLoaderThrows) {
+    auto logger = std::make_shared<StrictMock<MockLogger>>();
+    auto gpio   = std::make_shared<StrictMock<MockGPIO>>();
+
+    EXPECT_CALL(*logger, error("IFileLoader is null"));
+    EXPECT_THROW(BuzzerDriver(nullptr, logger, gpio), std::invalid_argument);
+}
+
+TEST(BuzzerDriverTest, NullLoggerThrows) {
     auto loader = std::make_shared<StrictMock<MockLoader>>();
     auto gpio   = std::make_shared<StrictMock<MockGPIO>>();
 
-    EXPECT_CALL(*loader, load_int("buzz_duration_ms")).Times(1);
-
-    BuzzerDriver driver(loader, nullptr, gpio);
-}
-
-TEST(BuzzerDriverTest, ConstructorAllNull) {
-    EXPECT_NO_THROW({ BuzzerDriver driver(nullptr, nullptr, nullptr); });
-}
-
-TEST(BuzzerDriverTest, ConstructorLoadIntThrowsLogsError) {
-    auto loader = std::make_shared<StrictMock<MockLoader>>();
-    auto logger = std::make_shared<StrictMock<MockLogger>>();
-
-    EXPECT_CALL(*logger, info("BuzzerDriver created")).Times(1);
-    EXPECT_CALL(*loader, load_int("buzz_duration_ms")).WillOnce(Throw(std::runtime_error("err")));
-    EXPECT_CALL(*logger, error("Failed to load buzzer config")).Times(1);
-
-    BuzzerDriver driver(loader, logger, nullptr);
-}
-
-TEST(BuzzerDriverTest, OnCallsGPIOAndLogger) {
-    auto logger = std::make_shared<StrictMock<MockLogger>>();
-    auto gpio   = std::make_shared<StrictMock<MockGPIO>>();
-
-    EXPECT_CALL(*logger, info("BuzzerDriver created")).Times(1);
-    BuzzerDriver driver(nullptr, logger, gpio);
-
-    EXPECT_CALL(*gpio, write(true)).Times(1);
-    EXPECT_CALL(*logger, info("buzzer on")).Times(1);
-    driver.on();
-}
-
-TEST(BuzzerDriverTest, OnWithNullGPIO) {
-    auto logger = std::make_shared<StrictMock<MockLogger>>();
-
-    EXPECT_CALL(*logger, info("BuzzerDriver created")).Times(1);
-    BuzzerDriver driver(nullptr, logger, nullptr);
-
-    EXPECT_CALL(*logger, info("buzzer on")).Times(1);
-    driver.on();
-}
-
-TEST(BuzzerDriverTest, OnWithNullLogger) {
-    auto loader = std::make_shared<NiceMock<MockLoader>>();
-    auto gpio   = std::make_shared<StrictMock<MockGPIO>>();
-
-    BuzzerDriver driver(loader, nullptr, gpio);
-
-    EXPECT_CALL(*gpio, write(true)).Times(1);
-    driver.on();
-}
-
-TEST(BuzzerDriverTest, OnWithAllNull) {
-    BuzzerDriver driver(nullptr, nullptr, nullptr);
-    EXPECT_NO_THROW(driver.on());
-}
-
-TEST(BuzzerDriverTest, OnWriteThrowsPropagates) {
-    auto logger = std::make_shared<StrictMock<MockLogger>>();
-    auto gpio   = std::make_shared<StrictMock<MockGPIO>>();
-
-    EXPECT_CALL(*logger, info("BuzzerDriver created")).Times(1);
-    BuzzerDriver driver(nullptr, logger, gpio);
-
-    EXPECT_CALL(*gpio, write(true)).WillOnce(Throw(std::runtime_error("gpio")));
-    EXPECT_CALL(*logger, info("buzzer on")).Times(0);
-    EXPECT_THROW(driver.on(), std::runtime_error);
-}
-
-TEST(BuzzerDriverTest, OffCallsGPIOAndLogger) {
-    auto logger = std::make_shared<StrictMock<MockLogger>>();
-    auto gpio   = std::make_shared<StrictMock<MockGPIO>>();
-
-    EXPECT_CALL(*logger, info("BuzzerDriver created")).Times(1);
-    BuzzerDriver driver(nullptr, logger, gpio);
-
-    EXPECT_CALL(*gpio, write(false)).Times(1);
-    EXPECT_CALL(*logger, info("buzzer off")).Times(1);
-    driver.off();
-}
-
-TEST(BuzzerDriverTest, OffWithNullGPIO) {
-    auto logger = std::make_shared<StrictMock<MockLogger>>();
-
-    EXPECT_CALL(*logger, info("BuzzerDriver created")).Times(1);
-    BuzzerDriver driver(nullptr, logger, nullptr);
-
-    EXPECT_CALL(*logger, info("buzzer off")).Times(1);
-    driver.off();
-}
-
-TEST(BuzzerDriverTest, OffWithNullLogger) {
-    auto loader = std::make_shared<NiceMock<MockLoader>>();
-    auto gpio   = std::make_shared<StrictMock<MockGPIO>>();
-
-    BuzzerDriver driver(loader, nullptr, gpio);
-
-    EXPECT_CALL(*gpio, write(false)).Times(1);
-    driver.off();
-}
-
-TEST(BuzzerDriverTest, OffWithAllNull) {
-    BuzzerDriver driver(nullptr, nullptr, nullptr);
-    EXPECT_NO_THROW(driver.off());
-}
-
-TEST(BuzzerDriverTest, OffWriteThrowsPropagates) {
-    auto logger = std::make_shared<StrictMock<MockLogger>>();
-    auto gpio   = std::make_shared<StrictMock<MockGPIO>>();
-
-    EXPECT_CALL(*logger, info("BuzzerDriver created")).Times(1);
-    BuzzerDriver driver(nullptr, logger, gpio);
-
-    EXPECT_CALL(*gpio, write(false)).WillOnce(Throw(std::runtime_error("gpio")));
-    EXPECT_CALL(*logger, info("buzzer off")).Times(0);
-    EXPECT_THROW(driver.off(), std::runtime_error);
+    EXPECT_THROW(BuzzerDriver(loader, nullptr, gpio), std::invalid_argument);
 }
 


### PR DESCRIPTION
## Summary
- BuzzerDriverを設定読込・GPIO初期化・排他制御付きで再実装
- ユニットテストを更新し、初期化とON/OFF動作を検証

## Testing
- `cmake --build build` *(エラー: infra/thread_operation/thread_message/i_thread_message.hpp が見つかりません)*
- `g++ -std=c++17 tests/unit/infra/buzzer_driver/test_buzzer_driver.cpp src/infra/buzzer_driver/buzzer_driver.cpp external/googletest/googletest/src/gtest-all.cc external/googletest/googlemock/src/gmock-all.cc external/googletest/googletest/src/gtest_main.cc -Iexternal/googletest/googletest/include -Iexternal/googletest/googlemock/include -Iexternal/googletest/googletest -Iexternal/googletest/googlemock -Iinclude -Iinclude/infra -Itests -pthread -o /tmp/buzzer_test && /tmp/buzzer_test`


------
https://chatgpt.com/codex/tasks/task_e_689602bc93ec8328b7cb044606ec2d9b