### PR TITLE
refactor: revise file loader interface

### DIFF
--- a/include/infra/file_loader.hpp
+++ b/include/infra/file_loader.hpp
@@ -1,27 +1,34 @@
 #pragma once
 
-#include "infra/file_loader/i_file_loader.hpp"
 #include "infra/logger/i_logger.hpp"
 
-#include <string>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace device_reminder {
 
+class IFileLoader {
+public:
+    virtual ~IFileLoader() = default;
+
+    virtual int load_int(const std::string& file_path, const std::string& key) const = 0;
+    virtual std::string load_string(const std::string& file_path, const std::string& key) const = 0;
+    virtual std::vector<std::string> load_string_list(const std::string& file_path, const std::string& key) const = 0;
+};
+
 class FileLoader : public IFileLoader {
 public:
-    FileLoader(std::shared_ptr<ILogger> logger,
-               const std::string& file_path);
+    explicit FileLoader(std::shared_ptr<ILogger> logger);
 
-    int load_int(const std::string& key) const override;
-    std::string load_string(const std::string& key) const override;
-    std::vector<std::string> load_string_list(const std::string& key) const override;
+    int load_int(const std::string& file_path, const std::string& key) const override;
+    std::string load_string(const std::string& file_path, const std::string& key) const override;
+    std::vector<std::string> load_string_list(const std::string& file_path, const std::string& key) const override;
 
 private:
-    std::string load_value(const std::string& key) const;
+    std::string load_value(const std::string& file_path, const std::string& key) const;
 
     std::shared_ptr<ILogger> logger_;
-    std::string              file_path_;
 };
 
 } // namespace device_reminder


### PR DESCRIPTION
## Summary
- consolidate FileLoader and IFileLoader into single header
- adapt methods to accept file path and key while constructor only takes logger
- add detailed logging and input validation for file loading operations

## Testing
- `cmake -S . -B build`
- `cmake --build build` (failed: main_task/i_main_process.hpp missing)
- `ctest` (executables not found)


------
https://chatgpt.com/codex/tasks/task_e_6898823d3ad08328a059fa748e4c5f63