### PR TITLE
feat: implement message module

### DIFF
--- a/include/infra/message/message.hpp
+++ b/include/infra/message/message.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "infra/message/message_type.hpp"
+#include "infra/logger/i_logger.hpp"
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace device_reminder {
+
+class IMessage {
+public:
+    virtual ~IMessage() = default;
+    virtual MessageType type() const = 0;
+    virtual std::vector<std::string> payload() const = 0;
+    virtual std::string to_string() const = 0;
+};
+
+class Message : public IMessage {
+public:
+    Message(MessageType type, std::vector<std::string> payload);
+
+    MessageType type() const override;
+    std::vector<std::string> payload() const override;
+    std::string to_string() const override;
+
+private:
+    MessageType type_;
+    std::vector<std::string> payload_;
+    std::shared_ptr<ILogger> logger_{};
+};
+
+} // namespace device_reminder
+

--- a/src/infra/message/message.cpp
+++ b/src/infra/message/message.cpp
@@ -1,0 +1,51 @@
+#include "infra/message/message.hpp"
+
+#include <utility>
+#include <sstream>
+
+namespace device_reminder {
+
+Message::Message(MessageType type, std::vector<std::string> payload)
+    : type_{type}, payload_{std::move(payload)} {}
+
+MessageType Message::type() const {
+    if (logger_) logger_->info("type start");
+    try {
+        if (logger_) logger_->info("type success: " + std::to_string(static_cast<int>(type_)));
+        return type_;
+    } catch (const std::exception& e) {
+        if (logger_) logger_->error(e.what());
+        throw;
+    }
+}
+
+std::vector<std::string> Message::payload() const {
+    if (logger_) logger_->info("payload start");
+    try {
+        if (logger_) logger_->info("payload success: size=" + std::to_string(payload_.size()));
+        return payload_;
+    } catch (const std::exception& e) {
+        if (logger_) logger_->error(e.what());
+        throw;
+    }
+}
+
+std::string Message::to_string() const {
+    if (logger_) logger_->info("to_string start");
+    try {
+        std::ostringstream oss;
+        oss << static_cast<int>(type_);
+        for (const auto& s : payload_) {
+            oss << "," << s;
+        }
+        auto result = oss.str();
+        if (logger_) logger_->info("to_string success: " + result);
+        return result;
+    } catch (const std::exception& e) {
+        if (logger_) logger_->error(e.what());
+        throw;
+    }
+}
+
+} // namespace device_reminder
+


### PR DESCRIPTION
## Summary
- define IMessage interface and Message class
- implement message methods with basic logging and string conversion

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: main_task/i_main_process.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6898b0af786883289d983e1360765758