### PR TITLE
feat: implement message codec

### DIFF
--- a/include/infra/message/message_codec.hpp
+++ b/include/infra/message/message_codec.hpp
@@ -1,19 +1,32 @@
 #pragma once
-#include "infra/process_operation/message_codec/i_message_codec.hpp"
-#include "infra/logger/i_logger.hpp"
+// MessageCodec は IMessage をバイト列へエンコード／デコードする責務を持つ
+
+#include <cstdint>
 #include <memory>
+#include <vector>
+
+#include "infra/logger/i_logger.hpp"
+#include "infra/message/message.hpp"
 
 namespace device_reminder {
+
+class IMessageCodec {
+public:
+    virtual ~IMessageCodec() = default;
+    virtual std::vector<uint8_t> encode(std::shared_ptr<IMessage> msg) = 0;
+    virtual std::shared_ptr<IMessage> decode(const std::vector<uint8_t>& data) = 0;
+};
 
 class MessageCodec : public IMessageCodec {
 public:
     explicit MessageCodec(std::shared_ptr<ILogger> logger);
 
-    std::vector<uint8_t> encode(std::shared_ptr<IProcessMessage> msg) override;
-    std::shared_ptr<IProcessMessage> decode(const std::vector<uint8_t>& data) override;
+    std::vector<uint8_t> encode(std::shared_ptr<IMessage> msg) override;
+    std::shared_ptr<IMessage> decode(const std::vector<uint8_t>& data) override;
 
 private:
     std::shared_ptr<ILogger> logger_;
 };
 
 } // namespace device_reminder
+

--- a/src/infra/message/message_codec.cpp
+++ b/src/infra/message/message_codec.cpp
@@ -1,60 +1,157 @@
-#include "infra/process_operation/message_codec/message_codec.hpp"
-#include "infra/process_operation/process_message/process_message.hpp"
+#include "infra/message/message_codec.hpp"
+#include "infra/message/message.hpp"
 
 #include <cstring>
 #include <stdexcept>
 
 namespace device_reminder {
 
-MessageCodec::MessageCodec(std::shared_ptr<ILogger> logger)
-    : logger_(std::move(logger)) {}
-
 namespace {
 
-static void append_uint32(std::vector<uint8_t>& buf, uint32_t v) {
-    for (int i = 0; i < 4; ++i) buf.push_back(static_cast<uint8_t>((v >> (i*8)) & 0xFF));
-}
+constexpr uint8_t  kMagic[2]   = {0x4D, 0x43};
+constexpr uint8_t  kVersion    = 0x01;
+constexpr uint8_t  kFlags      = 0x00;
+constexpr size_t   kHeaderSize = 2 + 1 + 1 + 2 + 4; // fixed header length
+constexpr size_t   kFooterSize = 4;                 // CRC32 length
+constexpr size_t   kMinFrame   = kHeaderSize + kFooterSize;
+constexpr size_t   kMaxPayload = 1024 * 1024; // 任意の上限(1MB)
 
-static uint32_t read_uint32(const std::vector<uint8_t>& buf, size_t& pos) {
-    if (pos + 4 > buf.size()) throw std::runtime_error("decode overflow");
-    uint32_t v = 0;
-    for (int i = 0; i < 4; ++i) v |= static_cast<uint32_t>(buf[pos++]) << (i*8);
+uint16_t read_u16(const std::vector<uint8_t>& buf, size_t& pos) {
+    if (pos + 2 > buf.size()) throw std::runtime_error("decode overflow");
+    uint16_t v = (static_cast<uint16_t>(buf[pos]) << 8) |
+                 static_cast<uint16_t>(buf[pos + 1]);
+    pos += 2;
     return v;
 }
 
+uint32_t read_u32(const std::vector<uint8_t>& buf, size_t& pos) {
+    if (pos + 4 > buf.size()) throw std::runtime_error("decode overflow");
+    uint32_t v = (static_cast<uint32_t>(buf[pos]) << 24) |
+                 (static_cast<uint32_t>(buf[pos + 1]) << 16) |
+                 (static_cast<uint32_t>(buf[pos + 2]) << 8) |
+                 static_cast<uint32_t>(buf[pos + 3]);
+    pos += 4;
+    return v;
 }
 
-std::vector<uint8_t> MessageCodec::encode(std::shared_ptr<IProcessMessage> msg) {
-    std::vector<uint8_t> out;
-    if (!msg) return out;
-    out.push_back(static_cast<uint8_t>(msg->type()));
-    const auto payload = msg->payload();
-    append_uint32(out, static_cast<uint32_t>(payload.size()));
-    for (const auto& s : payload) {
-        append_uint32(out, static_cast<uint32_t>(s.size()));
-        out.insert(out.end(), s.begin(), s.end());
-    }
-    return out;
+void append_u16(std::vector<uint8_t>& buf, uint16_t v) {
+    buf.push_back(static_cast<uint8_t>((v >> 8) & 0xFF));
+    buf.push_back(static_cast<uint8_t>(v & 0xFF));
 }
 
-std::shared_ptr<IProcessMessage> MessageCodec::decode(const std::vector<uint8_t>& data) {
-    try {
-        size_t pos = 0;
-        if (data.size() < 1) throw std::runtime_error("data too short");
-        auto type = static_cast<ProcessMessageType>(data[pos++]);
-        uint32_t count = read_uint32(data, pos);
-        std::vector<std::string> payload;
-        payload.reserve(count);
-        for (uint32_t i = 0; i < count; ++i) {
-            uint32_t len = read_uint32(data, pos);
-            if (pos + len > data.size()) throw std::runtime_error("data too short");
-            payload.emplace_back(reinterpret_cast<const char*>(&data[pos]), len);
-            pos += len;
+void append_u32(std::vector<uint8_t>& buf, uint32_t v) {
+    buf.push_back(static_cast<uint8_t>((v >> 24) & 0xFF));
+    buf.push_back(static_cast<uint8_t>((v >> 16) & 0xFF));
+    buf.push_back(static_cast<uint8_t>((v >> 8) & 0xFF));
+    buf.push_back(static_cast<uint8_t>(v & 0xFF));
+}
+
+uint32_t crc32(const uint8_t* data, size_t len) {
+    uint32_t crc = 0xFFFFFFFFu;
+    for (size_t i = 0; i < len; ++i) {
+        crc ^= data[i];
+        for (int j = 0; j < 8; ++j) {
+            crc = (crc & 1) ? (crc >> 1) ^ 0xEDB88320u : (crc >> 1);
         }
-        return std::make_shared<ProcessMessage>(type, payload);
+    }
+    return ~crc;
+}
+
+} // namespace
+
+MessageCodec::MessageCodec(std::shared_ptr<ILogger> logger)
+    : logger_(std::move(logger)) {}
+
+std::vector<uint8_t> MessageCodec::encode(std::shared_ptr<IMessage> msg) {
+    try {
+        if (!msg) {
+            throw std::invalid_argument("msg is null");
+        }
+
+        const auto payload = msg->payload();
+        if (payload.size() > kMaxPayload) {
+            throw std::range_error("payload too large");
+        }
+
+        if (logger_) {
+            logger_->info("encode start");
+        }
+
+        std::vector<uint8_t> out;
+        out.reserve(kHeaderSize + payload.size() + kFooterSize);
+
+        out.push_back(kMagic[0]);
+        out.push_back(kMagic[1]);
+        out.push_back(kVersion);
+        out.push_back(kFlags);
+        append_u16(out, static_cast<uint16_t>(msg->type()));
+        append_u32(out, static_cast<uint32_t>(payload.size()));
+        out.insert(out.end(), payload.begin(), payload.end());
+
+        uint32_t crc = crc32(out.data(), out.size());
+        append_u32(out, crc);
+
+        if (logger_) {
+            logger_->info("encode success");
+        }
+        return out;
     } catch (const std::exception& e) {
-        if (logger_) logger_->error(e.what());
-        return nullptr;
+        if (logger_) {
+            logger_->error(e.what());
+        }
+        throw;
+    }
+}
+
+std::shared_ptr<IMessage> MessageCodec::decode(const std::vector<uint8_t>& data) {
+    try {
+        if (data.size() < kMinFrame) {
+            throw std::invalid_argument("frame too short");
+        }
+
+        if (logger_) {
+            logger_->info("decode start");
+        }
+
+        size_t pos = 0;
+        if (data[pos++] != kMagic[0] || data[pos++] != kMagic[1]) {
+            throw std::invalid_argument("invalid magic");
+        }
+
+        uint8_t version = data[pos++];
+        if (version != kVersion) {
+            throw std::runtime_error("unsupported version");
+        }
+
+        pos++; // flags
+
+        auto type = static_cast<MessageType>(read_u16(data, pos));
+        uint32_t length = read_u32(data, pos);
+
+        if (data.size() < pos + length + kFooterSize) {
+            throw std::invalid_argument("invalid length");
+        }
+
+        size_t body_pos = pos;
+        pos += length;
+        uint32_t recv_crc = read_u32(data, pos);
+        uint32_t calc_crc = crc32(data.data(), body_pos + length);
+        if (recv_crc != calc_crc) {
+            throw std::runtime_error("crc mismatch");
+        }
+
+        std::vector<uint8_t> payload(data.begin() + body_pos, data.begin() + body_pos + length);
+        auto msg = std::make_shared<Message>(type, std::move(payload));
+
+        if (logger_) {
+            logger_->info("decode success");
+        }
+        return msg;
+    } catch (const std::exception& e) {
+        if (logger_) {
+            logger_->error(e.what());
+        }
+        throw;
     }
 }
 


### PR DESCRIPTION
## Summary
- implement MessageCodec encode/decode following framing, CRC32, version and logging rules
- provide unified abstract and concrete codec interface in single header

## Testing
- `cmake --build build` *(fails: main_task/i_main_process.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6898b9f9e0c8832883f0959e5b8e2dfb