### PR TITLE
Refactor ThreadSender to message spec

### DIFF
--- a/include/infra/message/thread_sender.hpp
+++ b/include/infra/message/thread_sender.hpp
@@ -1,23 +1,29 @@
 #pragma once
-#include "infra/thread_operation/thread_sender/i_thread_sender.hpp"
-#include "infra/thread_operation/thread_queue/i_thread_queue.hpp"
-#include "infra/thread_operation/thread_message/i_thread_message.hpp"
+
 #include "infra/logger/i_logger.hpp"
+#include "infra/message/message_queue.hpp"
+#include "infra/message/message.hpp"
+
 #include <memory>
 
 namespace device_reminder {
 
+class IThreadSender {
+public:
+    virtual ~IThreadSender() = default;
+    virtual void send(std::shared_ptr<IMessageQueue> queue,
+                      std::shared_ptr<IMessage> message) = 0;
+};
+
 class ThreadSender : public IThreadSender {
 public:
-    ThreadSender(std::shared_ptr<ILogger> logger,
-                 std::shared_ptr<IThreadQueue> queue,
-                 std::shared_ptr<IThreadMessage> message);
-    void send() override;
+    explicit ThreadSender(std::shared_ptr<ILogger> logger);
+    void send(std::shared_ptr<IMessageQueue> queue,
+              std::shared_ptr<IMessage> message) override;
 
 private:
-    std::shared_ptr<ILogger> logger_;
-    std::shared_ptr<IThreadQueue> queue_;
-    std::shared_ptr<IThreadMessage> message_;
+    std::shared_ptr<ILogger> logger_{};
 };
 
 } // namespace device_reminder
+

--- a/src/infra/message/thread_sender.cpp
+++ b/src/infra/message/thread_sender.cpp
@@ -1,24 +1,52 @@
-#include "infra/thread_operation/thread_sender/thread_sender.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/message/thread_sender.hpp"
+
+#include <stdexcept>
 #include <utility>
 
 namespace device_reminder {
 
-ThreadSender::ThreadSender(std::shared_ptr<ILogger> logger,
-                           std::shared_ptr<IThreadQueue> queue,
-                           std::shared_ptr<IThreadMessage> message)
-    : logger_(std::move(logger)),
-      queue_(std::move(queue)),
-      message_(std::move(message)) {
-    if (logger_) logger_->info("ThreadSender created");
+ThreadSender::ThreadSender(std::shared_ptr<ILogger> logger)
+    : logger_(std::move(logger)) {
+    if (logger_) {
+        logger_->info("ThreadSender created");
+    }
 }
 
-void ThreadSender::send() {
-    if (!queue_ || !message_) {
-        if (logger_) logger_->error("ThreadSender send failed: null queue or message");
-        return;
+void ThreadSender::send(std::shared_ptr<IMessageQueue> queue,
+                        std::shared_ptr<IMessage> message) {
+    if (logger_) {
+        logger_->info("ThreadSender send start");
     }
-    queue_->push(message_);
+    try {
+        if (!queue) {
+            if (logger_) {
+                logger_->error("ThreadSender send failed: queue is null");
+            }
+            throw std::invalid_argument("queue is null");
+        }
+        if (!message) {
+            if (logger_) {
+                logger_->error("ThreadSender send failed: message is null");
+            }
+            throw std::invalid_argument("message is null");
+        }
+
+        if (logger_) {
+            logger_->info("ThreadSender send message: " + message->to_string());
+        }
+
+        queue->push(std::move(message));
+
+        if (logger_) {
+            logger_->info("ThreadSender send success");
+        }
+    } catch (const std::exception& e) {
+        if (logger_) {
+            logger_->error(std::string("ThreadSender send exception: ") + e.what());
+        }
+        throw;
+    }
 }
 
 } // namespace device_reminder
+

--- a/tests/integration/infra/message/test_thread_sender.cpp
+++ b/tests/integration/infra/message/test_thread_sender.cpp
@@ -1,10 +1,11 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "infra/thread_operation/thread_sender/thread_sender.hpp"
-#include "infra/thread_operation/thread_queue/thread_queue.hpp"
-#include "infra/thread_operation/thread_message/thread_message.hpp"
 #include "infra/logger/i_logger.hpp"
+#include "infra/message/message.hpp"
+#include "infra/message/message_queue.hpp"
+#include "infra/message/message_type.hpp"
+#include "infra/message/thread_sender.hpp"
 
 using namespace device_reminder;
 using ::testing::NiceMock;
@@ -19,13 +20,13 @@ public:
 } // namespace
 
 TEST(ThreadSenderTest, SendPushesMessageToQueue) {
-    auto queue = std::make_shared<ThreadQueue>(nullptr);
     NiceMock<MockLogger> logger;
-    auto message = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing, std::vector<std::string>{"1"});
+    auto queue = std::make_shared<MessageQueue>(std::shared_ptr<ILogger>(&logger, [](ILogger*){}));
+    auto message = std::make_shared<Message>(MessageType::StartBuzzing, std::vector<std::string>{"1"});
 
-    ThreadSender sender(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), queue, message);
+    ThreadSender sender(std::shared_ptr<ILogger>(&logger, [](ILogger*){}));
 
-    sender.send();
+    sender.send(queue, message);
 
     auto res = queue->pop();
     ASSERT_NE(res, nullptr);

--- a/tests/unit/infra/message/test_thread_sender.cpp
+++ b/tests/unit/infra/message/test_thread_sender.cpp
@@ -1,10 +1,11 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "infra/thread_operation/thread_sender/thread_sender.hpp"
-#include "infra/thread_operation/thread_queue/thread_queue.hpp"
-#include "infra/thread_operation/thread_message/thread_message.hpp"
 #include "infra/logger/i_logger.hpp"
+#include "infra/message/message.hpp"
+#include "infra/message/message_queue.hpp"
+#include "infra/message/message_type.hpp"
+#include "infra/message/thread_sender.hpp"
 
 using namespace device_reminder;
 using ::testing::NiceMock;
@@ -19,13 +20,13 @@ public:
 } // namespace
 
 TEST(ThreadSenderTest, SendPushesMessageToQueue) {
-    auto queue = std::make_shared<ThreadQueue>(nullptr);
     NiceMock<MockLogger> logger;
-    auto message = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing, std::vector<std::string>{"1"});
+    auto queue = std::make_shared<MessageQueue>(std::shared_ptr<ILogger>(&logger, [](ILogger*){}));
+    auto message = std::make_shared<Message>(MessageType::StartBuzzing, std::vector<std::string>{"1"});
 
-    ThreadSender sender(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), queue, message);
+    ThreadSender sender(std::shared_ptr<ILogger>(&logger, [](ILogger*){}));
 
-    sender.send();
+    sender.send(queue, message);
 
     auto res = queue->pop();
     ASSERT_NE(res, nullptr);


### PR DESCRIPTION
## Summary
- adjust ThreadSender to accept ILogger and send messages via IMessageQueue
- update unit and integration tests for new ThreadSender interface

## Testing
- `cmake .. && cmake --build . && ctest --output-on-failure` *(fails: main_task/i_main_process.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6898ba8bc7588328a08f0f2534e6fcf8