### PR TITLE
MessageDispatcherの仕様準拠修正

### DIFF
--- a/include/infra/message/message_dispatcher.hpp
+++ b/include/infra/message/message_dispatcher.hpp
@@ -18,17 +18,17 @@ public:
 
 class MessageDispatcher : public IMessageDispatcher {
 public:
-    using Handler = std::function<void(std::vector<std::string>)>;
-    using HandlerMap = std::unordered_map<MessageType, Handler>;
-
-    MessageDispatcher(std::shared_ptr<ILogger> logger,
-                      HandlerMap handler_map);
+    MessageDispatcher(
+        std::shared_ptr<ILogger> logger,
+        std::unordered_map<MessageType, std::function<void(std::vector<std::string>)>>
+            handler_map);
 
     void dispatch(std::shared_ptr<IMessage> msg) override;
 
 private:
     std::shared_ptr<ILogger> logger_;
-    HandlerMap handler_map_;
+    std::unordered_map<MessageType, std::function<void(std::vector<std::string>)>>
+        handler_map_;
 };
 
 } // namespace device_reminder

--- a/src/infra/message/message_dispatcher.cpp
+++ b/src/infra/message/message_dispatcher.cpp
@@ -1,13 +1,16 @@
 #include "infra/message/message_dispatcher.hpp"
 #include "infra/logger/i_logger.hpp"
 
+#include <spdlog/fmt/fmt.h>
 #include <stdexcept>
 #include <utility>
 
 namespace device_reminder {
 
-MessageDispatcher::MessageDispatcher(std::shared_ptr<ILogger> logger,
-                                     HandlerMap handler_map)
+MessageDispatcher::MessageDispatcher(
+    std::shared_ptr<ILogger> logger,
+    std::unordered_map<MessageType, std::function<void(std::vector<std::string>)>>
+        handler_map)
     : logger_(std::move(logger)),
       handler_map_(std::move(handler_map)) {}
 
@@ -19,24 +22,23 @@ void MessageDispatcher::dispatch(std::shared_ptr<IMessage> msg) {
 
     auto type = msg->type();
     auto payload = msg->payload();
+    auto payload_size = payload.size();
 
     if (logger_) {
-        if (!payload.empty()) {
-            logger_->info("dispatch: type=" +
-                         std::to_string(static_cast<int>(type)) +
-                         ", payload_size=" +
-                         std::to_string(payload.size()));
+        if (payload_size) {
+            logger_->info(fmt::format("dispatch: type={}, payload_size={}",
+                                      static_cast<int>(type), payload_size));
         } else {
-            logger_->info("dispatch: type=" +
-                         std::to_string(static_cast<int>(type)));
+            logger_->info(
+                fmt::format("dispatch: type={}", static_cast<int>(type)));
         }
     }
 
     auto it = handler_map_.find(type);
     if (it == handler_map_.end()) {
         if (logger_) {
-            logger_->error("dispatch: no handler for type=" +
-                           std::to_string(static_cast<int>(type)));
+            logger_->error(fmt::format("dispatch: no handler for type={}",
+                                       static_cast<int>(type)));
         }
         throw std::runtime_error("no handler");
     }
@@ -47,29 +49,27 @@ void MessageDispatcher::dispatch(std::shared_ptr<IMessage> msg) {
         handler(payload);
     } catch (const std::exception &e) {
         if (logger_) {
-            logger_->error("dispatch failed: type=" +
-                           std::to_string(static_cast<int>(type)) +
-                           ", what=" + e.what());
+            logger_->error(fmt::format("dispatch failed: type={}, what={}",
+                                       static_cast<int>(type), e.what()));
         }
         throw;
     } catch (...) {
         if (logger_) {
-            logger_->error("dispatch failed: type=" +
-                           std::to_string(static_cast<int>(type)) +
-                           ", unknown exception");
+            logger_->error(fmt::format(
+                "dispatch failed: type={}, unknown exception",
+                static_cast<int>(type)));
         }
         throw;
     }
 
     if (logger_) {
-        if (!payload.empty()) {
-            logger_->info("dispatch: succeeded, type=" +
-                         std::to_string(static_cast<int>(type)) +
-                         ", payload_size=" +
-                         std::to_string(payload.size()));
+        if (payload_size) {
+            logger_->info(fmt::format(
+                "dispatch: succeeded, type={}, payload_size={}",
+                static_cast<int>(type), payload_size));
         } else {
-            logger_->info("dispatch: succeeded, type=" +
-                         std::to_string(static_cast<int>(type)));
+            logger_->info(fmt::format("dispatch: succeeded, type={}",
+                                      static_cast<int>(type)));
         }
     }
 }


### PR DESCRIPTION
## 概要
- MessageDispatcherをIF仕様書に合わせて修正
- ログメッセージを種別とペイロード件数の出力に対応

## テスト
- `cmake --build . --target test_unit` (main_task/i_main_process.hpp が無くビルド失敗)


------
https://chatgpt.com/codex/tasks/task_e_6898be563aec8328a97e7f9e548f1332