### PR TITLE
MessageReceiver を仕様に合わせて修正

### DIFF
--- a/include/infra/message/message_receiver.hpp
+++ b/include/infra/message/message_receiver.hpp
@@ -1,28 +1,37 @@
 #pragma once
-#include "infra/thread_operation/thread_receiver/i_thread_receiver.hpp"
-#include "infra/thread_operation/thread_queue/i_thread_queue.hpp"
-#include "infra/thread_operation/thread_message/i_thread_message.hpp"
-#include "infra/thread_operation/thread_dispatcher/i_thread_dispatcher.hpp"
+
 #include "infra/logger/i_logger.hpp"
-#include <memory>
+#include "infra/message/message_dispatcher.hpp"
+#include "infra/message/message_queue.hpp"
+
 #include <atomic>
+#include <memory>
+#include <thread>
 
 namespace device_reminder {
 
-class ThreadReceiver : public IThreadReceiver {
+class IMessageReceiver {
 public:
-    ThreadReceiver(std::shared_ptr<IThreadQueue> queue,
-                   std::shared_ptr<IThreadDispatcher> dispatcher,
-                   std::shared_ptr<ILogger> logger = nullptr);
+    virtual ~IMessageReceiver() = default;
+    virtual void run() = 0;
+    virtual void stop() = 0;
+};
+
+class MessageReceiver : public IMessageReceiver {
+public:
+    MessageReceiver(std::shared_ptr<ILogger> logger,
+                    std::shared_ptr<IMessageQueue> queue,
+                    std::shared_ptr<IMessageDispatcher> dispatcher);
 
     void run() override;
     void stop() override;
 
 private:
-    std::shared_ptr<IThreadQueue> queue_;
-    std::shared_ptr<IThreadDispatcher> dispatcher_;
-    std::atomic<bool> running_{true};
     std::shared_ptr<ILogger> logger_;
+    std::shared_ptr<IMessageQueue> queue_;
+    std::shared_ptr<IMessageDispatcher> dispatcher_;
+    std::atomic<bool> running_{false};
+    std::thread thread_;
 };
 
 } // namespace device_reminder

--- a/src/infra/message/message_receiver.cpp
+++ b/src/infra/message/message_receiver.cpp
@@ -1,33 +1,61 @@
-#include "infra/thread_operation/thread_receiver/thread_receiver.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/message/message_receiver.hpp"
+#include "infra/message/message.hpp"
+
+#include <stdexcept>
 #include <utility>
-#include <memory>
+#include <vector>
 
 namespace device_reminder {
 
-ThreadReceiver::ThreadReceiver(std::shared_ptr<IThreadQueue> queue,
-                               std::shared_ptr<IThreadDispatcher> dispatcher,
-                               std::shared_ptr<ILogger> logger)
-    : queue_(std::move(queue)),
-      dispatcher_(std::move(dispatcher)),
-      logger_(std::move(logger)) {
-    if (logger_) logger_->info("ThreadReceiver created");
-}
+MessageReceiver::MessageReceiver(std::shared_ptr<ILogger> logger,
+                                 std::shared_ptr<IMessageQueue> queue,
+                                 std::shared_ptr<IMessageDispatcher> dispatcher)
+    : logger_(std::move(logger)),
+      queue_(std::move(queue)),
+      dispatcher_(std::move(dispatcher)) {}
 
-void ThreadReceiver::stop() {
-    running_ = false;
-    if (logger_) logger_->info("ThreadReceiver stop requested");
-}
-
-void ThreadReceiver::run() {
-    while (running_) {
-        if (!queue_) break;
-        auto msg = queue_->pop();
-        if (!msg) break;
-        if (!running_) break;
-        if (dispatcher_) dispatcher_->dispatch(msg);
+void MessageReceiver::run() {
+    if (logger_) logger_->info("MessageReceiver run start");
+    if (!queue_ || !dispatcher_) {
+        if (logger_) logger_->error("MessageReceiver run failed: dependency null");
+        throw std::runtime_error("dependency null");
     }
-    if (logger_) logger_->info("ThreadReceiver loop end");
+
+    running_ = true;
+    thread_ = std::thread([this] {
+        try {
+            while (running_) {
+                auto msg = queue_->pop();
+                if (!running_) break;
+                if (logger_) logger_->info("MessageReceiver received: " + msg->to_string());
+                dispatcher_->dispatch(msg);
+                if (logger_) logger_->info("MessageReceiver dispatch success");
+            }
+        } catch (const std::exception &e) {
+            if (logger_) logger_->error(std::string("MessageReceiver thread error: ") + e.what());
+        }
+        if (logger_) logger_->info("MessageReceiver thread end");
+    });
+    if (logger_) logger_->info("MessageReceiver run success");
+}
+
+void MessageReceiver::stop() {
+    if (logger_) logger_->info("MessageReceiver stop start");
+    running_ = false;
+    try {
+        if (queue_) {
+            queue_->push(
+                std::make_shared<Message>(MessageType::None, std::vector<std::string>{}));
+        }
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+        if (logger_) logger_->info("MessageReceiver stop success");
+    } catch (const std::exception& e) {
+        if (logger_)
+            logger_->error(std::string("MessageReceiver stop error: ") + e.what());
+        throw;
+    }
 }
 
 } // namespace device_reminder


### PR DESCRIPTION
## Summary
- MessageReceiver インタフェースと実装を仕様通りに再設計
- メッセージ受信スレッドの起動・停止処理とログ出力を追加

## Testing
- `cmake -S . -B build` (成功)
- `cmake --build build` (main_task/i_main_process.hpp が無いため失敗)


------
https://chatgpt.com/codex/tasks/task_e_6898c0df0db88328a47aeafe8f69fd2c