### PR TITLE
refactor: update TimerService to spec

### DIFF
--- a/include/infra/timer_service/timer_service.hpp
+++ b/include/infra/timer_service/timer_service.hpp
@@ -1,33 +1,39 @@
 #pragma once
 
-#include "infra/timer_service/i_timer_service.hpp"
 #include "infra/logger/i_logger.hpp"
 #include "infra/thread_operation/thread_sender/i_thread_sender.hpp"
 
-#include <thread>
 #include <atomic>
+#include <exception>
 #include <memory>
+#include <thread>
 
 namespace device_reminder {
 
+class ITimerService {
+public:
+    virtual ~ITimerService() = default;
+    virtual void start(int duration_ms, std::shared_ptr<IThreadSender> sender) = 0;
+    virtual void stop() = 0;
+};
+
 class TimerService : public ITimerService {
 public:
-    explicit TimerService(std::shared_ptr<ILogger> logger,
-                          int duration_ms,
-                          std::shared_ptr<IThreadSender> sender);
+    explicit TimerService(std::shared_ptr<ILogger> logger);
     ~TimerService() override;
 
-    void start() override;
+    void start(int duration_ms, std::shared_ptr<IThreadSender> sender) override;
     void stop() override;
 
 private:
-    void worker();
+    void worker(int duration_ms);
 
-    std::shared_ptr<ILogger> logger_;
-    int duration_ms_{0};
-    std::shared_ptr<IThreadSender> sender_;
-    std::thread thread_;
+    std::shared_ptr<ILogger> logger_{};
+    std::shared_ptr<IThreadSender> sender_{};
+    std::thread thread_{};
+    std::atomic<bool> cancel_{false};
     std::atomic<bool> running_{false};
+    std::exception_ptr worker_exception_{};
 };
 
 } // namespace device_reminder

--- a/src/infra/timer_service/timer_service.cpp
+++ b/src/infra/timer_service/timer_service.cpp
@@ -1,45 +1,104 @@
-#include "timer_service/timer_service.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/timer_service/timer_service.hpp"
 
 #include <chrono>
-#include <thread>
+#include <stdexcept>
 
 namespace device_reminder {
 
-TimerService::TimerService(std::shared_ptr<ILogger> logger,
-                           int duration_ms,
-                           std::shared_ptr<IThreadSender> sender)
-    : logger_(std::move(logger)),
-      duration_ms_(duration_ms),
-      sender_(std::move(sender)) {
-    if (logger_) logger_->info("TimerService created");
-}
+TimerService::TimerService(std::shared_ptr<ILogger> logger)
+    : logger_(std::move(logger)) {}
 
 TimerService::~TimerService() {
-    stop();
-    if (logger_) logger_->info("TimerService destroyed");
+    try {
+        stop();
+    } catch (...) {
+        // 破棄時の例外は無視する
+    }
 }
 
-void TimerService::start() {
-    stop();
-    running_ = true;
-    thread_ = std::thread(&TimerService::worker, this);
-    if (logger_) logger_->info("TimerService started");
+void TimerService::start(int duration_ms, std::shared_ptr<IThreadSender> sender) {
+    if (logger_) {
+        logger_->info("TimerService start: duration_ms=" + std::to_string(duration_ms) +
+                      ", sender=" + (sender ? std::string("valid") : std::string("null")));
+    }
+
+    if (running_) {
+        cancel_.store(true);
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+        running_.store(false);
+        if (logger_) logger_->warn("TimerService start: existing timer stopped");
+    }
+
+    if (!sender) {
+        if (logger_) logger_->error("TimerService start: sender is null");
+        throw std::invalid_argument("sender is null");
+    }
+
+    sender_ = std::move(sender);
+    cancel_.store(false);
+    running_.store(true);
+    worker_exception_ = nullptr;
+
+    try {
+        thread_ = std::thread(&TimerService::worker, this, duration_ms);
+        if (logger_) logger_->info("TimerService start success");
+    } catch (...) {
+        running_.store(false);
+        if (logger_) logger_->error("TimerService start failed");
+        throw;
+    }
 }
 
 void TimerService::stop() {
-    running_ = false;
-    if (thread_.joinable()) thread_.join();
-    if (logger_) logger_->info("TimerService stopped");
+    if (logger_) logger_->info("TimerService stop start");
+
+    if (!running_) {
+        if (logger_) logger_->info("TimerService stop: no timer running");
+        return;
+    }
+
+    cancel_.store(true);
+    try {
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+        running_.store(false);
+
+        if (worker_exception_) {
+            if (logger_) logger_->error("TimerService stop: worker exception");
+            auto ex = worker_exception_;
+            worker_exception_ = nullptr;
+            throw;
+        }
+
+        sender_.reset();
+        thread_ = std::thread();
+        if (logger_) logger_->info("TimerService stop success");
+    } catch (...) {
+        if (logger_) logger_->error("TimerService stop failed");
+        running_.store(false);
+        sender_.reset();
+        thread_ = std::thread();
+        throw;
+    }
 }
 
-void TimerService::worker() {
-    std::this_thread::sleep_for(std::chrono::milliseconds(duration_ms_));
-    if (running_ && sender_) {
-        sender_->send();
-        if (logger_) logger_->info("TimerService timeout");
+void TimerService::worker(int duration_ms) {
+    try {
+        std::this_thread::sleep_for(std::chrono::milliseconds(duration_ms));
+        if (cancel_.load()) {
+            if (logger_) logger_->info("TimerService worker: canceled");
+        } else {
+            sender_->send();
+            if (logger_) logger_->info("TimerService worker: send success");
+        }
+    } catch (...) {
+        worker_exception_ = std::current_exception();
+        if (logger_) logger_->error("TimerService worker: exception");
     }
-    running_ = false;
+    running_.store(false);
 }
 
 } // namespace device_reminder


### PR DESCRIPTION
## Summary
- define `ITimerService` and redesign `TimerService` per specification
- add cancel-aware start/stop routines with logging and exception handling
- implement worker thread to send message or handle cancellation

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: main_task/i_main_process.hpp: No such file or directory)*
- `ctest --test-dir build` *(fails: executables not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898c0ba9668832895d302539f473f25