### PR TITLE
Refactor WatchDog to follow specification

### DIFF
--- a/include/infra/watch_dog/watch_dog.hpp
+++ b/include/infra/watch_dog/watch_dog.hpp
@@ -1,22 +1,41 @@
+// Copyright 2024 device_reminder
+// WatchDog interface and implementation
+
 #pragma once
 
-#include "infra/watch_dog/i_watch_dog.hpp"
-#include "infra/timer_service/i_timer_service.hpp"
 #include <memory>
 
 namespace device_reminder {
 
+class ITimerService;
+class IMessageQueue;
+class IMessage;
+class ILogger;
+
+class IWatchDog {
+public:
+    virtual ~IWatchDog() = default;
+    virtual void start() = 0;
+    virtual void stop() = 0;
+    virtual void kick() = 0;
+};
+
 class WatchDog : public IWatchDog {
 public:
-    explicit WatchDog(std::shared_ptr<ITimerService> timer_service);
+    WatchDog(std::shared_ptr<ITimerService> timer_service,
+             std::shared_ptr<IMessageQueue> message_queue,
+             std::shared_ptr<IMessage> message,
+             std::shared_ptr<ILogger> logger);
 
     void start() override;
     void stop() override;
     void kick() override;
 
 private:
-    std::shared_ptr<ITimerService> timer_service_;
-    bool running_{false};
+    std::shared_ptr<ITimerService> timer_service_{};
+    std::shared_ptr<IMessageQueue> message_queue_{};
+    std::shared_ptr<IMessage> message_{};
+    std::shared_ptr<ILogger> logger_{};
 };
 
 } // namespace device_reminder

--- a/src/infra/watch_dog/watch_dog.cpp
+++ b/src/infra/watch_dog/watch_dog.cpp
@@ -1,28 +1,87 @@
 #include "watch_dog/watch_dog.hpp"
-#include "infra/timer_service/i_timer_service.hpp"
+
+#include <string>
+#include <utility>
 
 namespace device_reminder {
 
-WatchDog::WatchDog(std::shared_ptr<ITimerService> timer_service)
-    : timer_service_(std::move(timer_service)) {}
+WatchDog::WatchDog(std::shared_ptr<ITimerService> timer_service,
+                   std::shared_ptr<IMessageQueue> message_queue,
+                   std::shared_ptr<IMessage> message,
+                   std::shared_ptr<ILogger> logger)
+    : timer_service_(std::move(timer_service))
+    , message_queue_(std::move(message_queue))
+    , message_(std::move(message))
+    , logger_(std::move(logger)) {}
 
 void WatchDog::start() {
-    if (!timer_service_ || running_) return;
-    timer_service_->start();
-    running_ = true;
+    if (logger_) {
+        logger_->info("WatchDog start called");
+    }
+    try {
+        timer_service_->start(message_queue_, message_);
+        if (logger_) {
+            logger_->info("WatchDog start succeeded");
+        }
+    } catch (...) {
+        if (logger_) {
+            try {
+                throw;
+            } catch (const std::exception& e) {
+                logger_->error(std::string("WatchDog start failed: ") + e.what());
+            } catch (...) {
+                logger_->error("WatchDog start failed: unknown error");
+            }
+        }
+        throw;
+    }
 }
 
 void WatchDog::stop() {
-    if (!timer_service_ || !running_) return;
-    timer_service_->stop();
-    running_ = false;
+    if (logger_) {
+        logger_->info("WatchDog stop called");
+    }
+    try {
+        timer_service_->stop();
+        if (logger_) {
+            logger_->info("WatchDog stop succeeded");
+        }
+    } catch (...) {
+        if (logger_) {
+            try {
+                throw;
+            } catch (const std::exception& e) {
+                logger_->error(std::string("WatchDog stop failed: ") + e.what());
+            } catch (...) {
+                logger_->error("WatchDog stop failed: unknown error");
+            }
+        }
+        throw;
+    }
 }
 
 void WatchDog::kick() {
-    if (!timer_service_) return;
-    timer_service_->stop();
-    timer_service_->start();
-    running_ = true;
+    if (logger_) {
+        logger_->info("WatchDog kick called");
+    }
+    try {
+        timer_service_->stop();
+        timer_service_->start(message_queue_, message_);
+        if (logger_) {
+            logger_->info("WatchDog kick succeeded");
+        }
+    } catch (...) {
+        if (logger_) {
+            try {
+                throw;
+            } catch (const std::exception& e) {
+                logger_->error(std::string("WatchDog kick failed: ") + e.what());
+            } catch (...) {
+                logger_->error("WatchDog kick failed: unknown error");
+            }
+        }
+        throw;
+    }
 }
 
 } // namespace device_reminder


### PR DESCRIPTION
## Summary
- define IWatchDog and WatchDog in single header
- add dependencies (timer service, message queue, message, logger) to WatchDog
- implement start/stop/kick with logging and timer service delegation

## Testing
- `cmake --build .` *(fails: main_task/i_main_process.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899803413d48328897aa3054f1123fe