### PR TITLE
Refactor GPIOReader for edge polling

### DIFF
--- a/include/infra/gpio_operation/gpio_reader.hpp
+++ b/include/infra/gpio_operation/gpio_reader.hpp
@@ -1,31 +1,40 @@
 #pragma once
 
-#include "i_gpio_reader.hpp"
 #include "infra/logger/i_logger.hpp"
+#include "infra/file_loader/i_file_loader.hpp"
 
 #include <memory>
-#include <string>
 
 struct gpiod_chip;
 struct gpiod_line;
 
 namespace device_reminder {
 
+class IGPIOReader {
+public:
+    virtual ~IGPIOReader() = default;
+
+    virtual bool read() = 0;
+    virtual void poll_edge(bool detect_rising) = 0;
+};
+
 class GPIOReader : public IGPIOReader {
 public:
     GPIOReader(std::shared_ptr<ILogger> logger,
                int pin_no,
-               std::string chip_name = "/dev/gpiochip0");
+               std::shared_ptr<IFileLoader> loader);
     ~GPIOReader() override;
 
     bool read() override;
+    void poll_edge(bool detect_rising) override;
 
 private:
-    std::shared_ptr<ILogger> logger_;
-    int pin_no_;
-    std::string chip_name_;
-    gpiod_chip* chip_;
-    gpiod_line* line_;
+    std::shared_ptr<ILogger>     logger_{};
+    int                          pin_no_{};
+    std::shared_ptr<IFileLoader> loader_{};
+    gpiod_chip*                  chip_{};
+    gpiod_line*                  line_{};
 };
 
 } // namespace device_reminder
+

--- a/src/infra/gpio_operation/gpio_reader.cpp
+++ b/src/infra/gpio_operation/gpio_reader.cpp
@@ -1,24 +1,25 @@
-#include "infra/gpio_operation/gpio_reader/gpio_reader.hpp"
+#include "infra/gpio_operation/gpio_reader.hpp"
 
 #include <gpiod.h>
 #include <stdexcept>
+#include <string>
 
 namespace device_reminder {
 
 GPIOReader::GPIOReader(std::shared_ptr<ILogger> logger,
                        int pin_no,
-                       std::string chip_name)
+                       std::shared_ptr<IFileLoader> loader)
     : logger_(std::move(logger)),
       pin_no_(pin_no),
-      chip_name_(std::move(chip_name)),
+      loader_(std::move(loader)),
       chip_(nullptr),
       line_(nullptr) {
-    chip_ = gpiod_chip_open(chip_name_.c_str());
+    chip_ = gpiod_chip_open("/dev/gpiochip0");
     if (!chip_) {
-        if (logger_) logger_->error("Failed to open GPIO chip: " + chip_name_);
-        throw std::runtime_error("Failed to open GPIO chip: " + chip_name_);
+        if (logger_) logger_->error("Failed to open GPIO chip: /dev/gpiochip0");
+        throw std::runtime_error("Failed to open GPIO chip: /dev/gpiochip0");
     }
-    line_ = gpiod_chip_get_line(chip_, pin_no_);
+    line_ = gpiod_chip_get_line(chip_, static_cast<unsigned int>(pin_no_));
     if (!line_) {
         if (logger_) logger_->error("Failed to get GPIO line: " + std::to_string(pin_no_));
         gpiod_chip_close(chip_);
@@ -45,12 +46,52 @@ GPIOReader::~GPIOReader() {
 }
 
 bool GPIOReader::read() {
-    int value = gpiod_line_get_value(line_);
-    if (value < 0) {
-        if (logger_) logger_->error("Failed to read GPIO value");
-        throw std::runtime_error("Failed to read GPIO value");
+    if (logger_) logger_->info("GPIOReader::read start: pin=" + std::to_string(pin_no_));
+    try {
+        int value = gpiod_line_get_value(line_);
+        if (value < 0) {
+            throw std::runtime_error("Failed to read GPIO value");
+        }
+        if (value != 0 && value != 1) {
+            throw std::runtime_error("Invalid GPIO value: " + std::to_string(value));
+        }
+        bool result = (value == 1);
+        if (logger_) logger_->info(std::string("GPIOReader::read success: value=") + (result ? "true" : "false"));
+        return result;
+    } catch (const std::exception& e) {
+        if (logger_) logger_->error(std::string("GPIOReader::read failed: ") + e.what());
+        throw;
     }
-    return value != 0;
+}
+
+void GPIOReader::poll_edge(bool detect_rising) {
+    if (logger_)
+        logger_->info(std::string("GPIOReader::poll_edge start: detect_rising=") + (detect_rising ? "true" : "false"));
+    try {
+        gpiod_line_release(line_);
+
+        int ret = detect_rising ? gpiod_line_request_rising_edge_events(line_, "device_reminder")
+                                : gpiod_line_request_falling_edge_events(line_, "device_reminder");
+        if (ret < 0) {
+            throw std::runtime_error("Failed to request edge events");
+        }
+
+        ret = gpiod_line_event_wait(line_, nullptr);
+        if (ret < 0) {
+            throw std::runtime_error("Waiting for edge event failed");
+        }
+
+        if (logger_) logger_->info(std::string("GPIOReader::poll_edge success: detected ") + (detect_rising ? "rising" : "falling") + " edge");
+
+        gpiod_line_release(line_);
+        if (gpiod_line_request_input(line_, "device_reminder") < 0) {
+            throw std::runtime_error("Failed to re-request GPIO input line");
+        }
+    } catch (const std::exception& e) {
+        if (logger_) logger_->error(std::string("GPIOReader::poll_edge failed: ") + e.what());
+        throw;
+    }
 }
 
 } // namespace device_reminder
+


### PR DESCRIPTION
## Summary
- unify GPIOReader interface and implementation and add edge polling support
- add detailed start/success/failure logging for GPIO reading and edge polling

## Testing
- `cmake -S . -B build` (pass)
- `cmake --build build` (fail: main_task/i_main_process.hpp missing)


------
https://chatgpt.com/codex/tasks/task_e_68998811bc208328bb0f02e02152aecc