### PR TITLE
Refactor GPIOSetter to match specification

### DIFF
--- a/include/infra/gpio_operation/gpio_setter.hpp
+++ b/include/infra/gpio_operation/gpio_setter.hpp
@@ -1,29 +1,44 @@
 #pragma once
 
-#include "infra/gpio_operation/gpio_setter/i_gpio_setter.hpp"
+// GPIOSetter インターフェースおよび実装
+
 #include "infra/logger/i_logger.hpp"
+#include "infra/file_loader/i_file_loader.hpp"
 
 #include <memory>
-#include <string>
 
 struct gpiod_chip;
 struct gpiod_line;
 
 namespace device_reminder {
 
+class IGPIOSetter {
+public:
+    virtual ~IGPIOSetter() = default;
+
+    virtual void write(bool is_high) = 0;
+    virtual void buzz_start(int frequency_hz) = 0;
+    virtual void buzz_stop() = 0;
+};
+
 class GPIOSetter : public IGPIOSetter {
 public:
-    GPIOSetter(std::shared_ptr<ILogger> logger,
-               int pin_no,
-               std::string chip_name = "/dev/gpiochip0");
+    GPIOSetter(std::shared_ptr<ILogger>     logger,
+               int                          pin_no,
+               std::shared_ptr<IFileLoader> loader);
     ~GPIOSetter() override;
 
-    void write(bool value) override;
+    void write(bool is_high) override;
+    void buzz_start(int frequency_hz) override;
+    void buzz_stop() override;
 
 private:
-    std::shared_ptr<ILogger> logger_;
-    gpiod_chip* chip_;
-    gpiod_line* line_;
+    std::shared_ptr<ILogger>     logger_{};
+    int                          pin_no_{};
+    std::shared_ptr<IFileLoader> loader_{};
+    gpiod_chip*                  chip_{};
+    gpiod_line*                  line_{};
 };
 
 } // namespace device_reminder
+

--- a/src/infra/gpio_operation/gpio_setter.cpp
+++ b/src/infra/gpio_operation/gpio_setter.cpp
@@ -1,22 +1,28 @@
-#include "gpio_operation/gpio_setter/gpio_setter.hpp"
+#include "infra/gpio_operation/gpio_setter.hpp"
+
 #include <gpiod.h>
 #include <stdexcept>
+#include <string>
 
 namespace device_reminder {
 
-GPIOSetter::GPIOSetter(std::shared_ptr<ILogger> logger,
-                       int pin_no,
-                       std::string chip_name)
-    : logger_(std::move(logger)), chip_(nullptr), line_(nullptr) {
-    chip_ = gpiod_chip_open(chip_name.c_str());
+GPIOSetter::GPIOSetter(std::shared_ptr<ILogger>     logger,
+                       int                          pin_no,
+                       std::shared_ptr<IFileLoader> loader)
+    : logger_(std::move(logger)),
+      pin_no_(pin_no),
+      loader_(std::move(loader)),
+      chip_(nullptr),
+      line_(nullptr) {
+    chip_ = gpiod_chip_open("/dev/gpiochip0");
     if (!chip_) {
-        if (logger_) logger_->error("Failed to open GPIO chip: " + chip_name);
-        throw std::runtime_error("Failed to open GPIO chip: " + chip_name);
+        if (logger_) logger_->error("Failed to open GPIO chip: /dev/gpiochip0");
+        throw std::runtime_error("Failed to open GPIO chip: /dev/gpiochip0");
     }
 
-    line_ = gpiod_chip_get_line(chip_, static_cast<unsigned int>(pin_no));
+    line_ = gpiod_chip_get_line(chip_, static_cast<unsigned int>(pin_no_));
     if (!line_) {
-        if (logger_) logger_->error("Failed to get GPIO line: " + std::to_string(pin_no));
+        if (logger_) logger_->error("Failed to get GPIO line: " + std::to_string(pin_no_));
         gpiod_chip_close(chip_);
         throw std::runtime_error("Failed to get GPIO line");
     }
@@ -44,15 +50,66 @@ GPIOSetter::~GPIOSetter() {
     if (logger_) logger_->info("GPIOSetter destroyed");
 }
 
-void GPIOSetter::write(bool value) {
-    if (!line_) {
-        if (logger_) logger_->error("GPIO line not initialized");
-        throw std::runtime_error("GPIO line not initialized");
+void GPIOSetter::write(bool is_high) {
+    if (logger_)
+        logger_->info("GPIOSetter::write start: pin=" + std::to_string(pin_no_) +
+                       ", value=" + (is_high ? "true" : "false"));
+    try {
+        if (!line_) {
+            throw std::runtime_error("GPIO line not initialized");
+        }
+        int normalized = is_high ? 1 : 0;
+        if (gpiod_line_set_value(line_, normalized) < 0) {
+            throw std::runtime_error("Failed to write GPIO line value");
+        }
+        if (logger_)
+            logger_->info(std::string("GPIOSetter::write success: value=") +
+                           (normalized ? "1" : "0"));
+    } catch (const std::exception& e) {
+        if (logger_) logger_->error(std::string("GPIOSetter::write failed: ") + e.what());
+        throw;
     }
-    if (gpiod_line_set_value(line_, value ? 1 : 0) < 0) {
-        if (logger_) logger_->error("Failed to write GPIO line value");
-        throw std::runtime_error("Failed to write GPIO line value");
+}
+
+void GPIOSetter::buzz_start(int frequency_hz) {
+    if (logger_)
+        logger_->info("GPIOSetter::buzz_start start: pin=" + std::to_string(pin_no_) +
+                       ", frequency=" + std::to_string(frequency_hz));
+    try {
+        if (!line_) {
+            throw std::runtime_error("GPIO line not initialized");
+        }
+        if (frequency_hz <= 0) {
+            throw std::invalid_argument("frequency must be greater than 0");
+        }
+        if (gpiod_line_set_value(line_, 1) < 0) {
+            throw std::runtime_error("Failed to start buzzer");
+        }
+        if (logger_)
+            logger_->info("GPIOSetter::buzz_start success: frequency=" +
+                           std::to_string(frequency_hz));
+    } catch (const std::exception& e) {
+        if (logger_) logger_->error(std::string("GPIOSetter::buzz_start failed: ") + e.what());
+        throw;
+    }
+}
+
+void GPIOSetter::buzz_stop() {
+    if (logger_)
+        logger_->info("GPIOSetter::buzz_stop start: pin=" + std::to_string(pin_no_));
+    try {
+        if (!line_) {
+            throw std::runtime_error("GPIO line not initialized");
+        }
+        if (gpiod_line_set_value(line_, 0) < 0) {
+            throw std::runtime_error("Failed to stop buzzer");
+        }
+        if (logger_) logger_->info("GPIOSetter::buzz_stop success");
+    } catch (const std::exception& e) {
+        if (logger_) logger_->error(std::string("GPIOSetter::buzz_stop failed: ") + e.what());
+        throw;
     }
 }
 
 } // namespace device_reminder
+


### PR DESCRIPTION
## Summary
- integrate IGPIOSetter and GPIOSetter into a single header
- add GPIO buzzing controls with logging and error handling

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: main_task/i_main_process.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899900d65488328b6dc1c1921ef3d72