### PR TITLE
PIRセンサドライバを仕様に合わせて修正

### DIFF
--- a/include/infra/pir_driver/pir_driver.hpp
+++ b/include/infra/pir_driver/pir_driver.hpp
@@ -1,26 +1,27 @@
 #pragma once
 
-#include "pir_driver/i_pir_driver.hpp"
 #include "infra/file_loader/i_file_loader.hpp"
-#include "infra/gpio_operation/gpio_reader/i_gpio_reader.hpp"
+#include "infra/gpio_operation/gpio_reader.hpp"
 #include "infra/logger/i_logger.hpp"
-#include "infra/thread_operation/thread_sender/i_thread_sender.hpp"
-#include <thread>
-#include <atomic>
 
+#include <atomic>
 #include <memory>
-#include <string>
 
 namespace device_reminder {
+
+class IPIRDriver {
+public:
+    virtual ~IPIRDriver() = default;
+
+    virtual void run() = 0;
+    virtual void stop() = 0;
+};
 
 class PIRDriver : public IPIRDriver {
 public:
     PIRDriver(std::shared_ptr<IFileLoader> loader,
               std::shared_ptr<ILogger> logger,
-              std::shared_ptr<IThreadSender> sender,
               std::shared_ptr<IGPIOReader> gpio);
-
-    ~PIRDriver() override;
 
     void run() override;
     void stop() override;
@@ -28,11 +29,9 @@ public:
 private:
     std::shared_ptr<IFileLoader> loader_;
     std::shared_ptr<ILogger> logger_;
-    std::shared_ptr<IThreadSender> sender_;
     std::shared_ptr<IGPIOReader> gpio_;
-    std::thread thread_;
-    std::atomic<bool> running_{false};
-    bool last_state_{false};
+    std::atomic<bool> monitoring_{false};
+    std::atomic<bool> interrupt_{false};
 };
 
 } // namespace device_reminder

--- a/src/infra/pir_driver/pir_driver.cpp
+++ b/src/infra/pir_driver/pir_driver.cpp
@@ -1,65 +1,86 @@
 #include "pir_driver/pir_driver.hpp"
-#include <chrono>
-#include <thread>
+
+#include <stdexcept>
+#include <string>
+#include <utility>
 
 namespace device_reminder {
 
 PIRDriver::PIRDriver(std::shared_ptr<IFileLoader> loader,
                      std::shared_ptr<ILogger> logger,
-                     std::shared_ptr<IThreadSender> sender,
                      std::shared_ptr<IGPIOReader> gpio)
     : loader_(std::move(loader)),
       logger_(std::move(logger)),
-      sender_(std::move(sender)),
-      gpio_(std::move(gpio))
-{
-    if (logger_) {
-        logger_->info("PIRDriver initialized");
-    }
-    if (gpio_) {
-        try {
-            last_state_ = gpio_->read();
-        } catch (...) {
-            last_state_ = false;
-        }
-    }
-}
-
-PIRDriver::~PIRDriver() {
-    stop();
-    if (logger_) {
-        logger_->info("PIRDriver shutting down");
-    }
-}
+      gpio_(std::move(gpio)) {}
 
 void PIRDriver::run() {
-    if (running_ || !gpio_) return;
-    running_ = true;
-    thread_ = std::thread([this]() {
-        bool prev = last_state_;
-        while (running_) {
-            bool val = false;
-            try {
-                val = gpio_->read();
-            } catch (...) {
-                if (logger_) logger_->error("PIRDriver read error");
-            }
-            if (val != prev) {
-                prev = val;
-                last_state_ = val;
-                if (sender_) sender_->send();
-            }
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    if (logger_) logger_->info("PIRDriver::run start");
+
+    if (monitoring_) {
+        if (logger_) logger_->error("PIRDriver::run already running");
+        throw std::runtime_error("PIRDriver already running");
+    }
+
+    monitoring_ = true;
+    interrupt_ = false;
+
+    try {
+        bool initial = gpio_->read();
+        if (initial) {
+            monitoring_ = false;
+            if (logger_) logger_->info("PIRDriver::run success: already detected");
+            return;
         }
-    });
-    if (logger_) logger_->info("PIRDriver started");
+    } catch (const std::exception& e) {
+        monitoring_ = false;
+        if (logger_) logger_->error(std::string("PIRDriver::run failed: ") + e.what());
+        throw;
+    }
+
+    try {
+        while (!interrupt_) {
+            try {
+                gpio_->poll_edge(true);
+                if (interrupt_) break;
+                monitoring_ = false;
+                if (logger_) logger_->info("PIRDriver::run success: detected rising edge");
+                return;
+            } catch (const std::exception& e) {
+                monitoring_ = false;
+                if (logger_) logger_->error(std::string("PIRDriver::run failed: ") + e.what());
+                throw;
+            }
+        }
+    } catch (...) {
+        monitoring_ = false;
+        throw;
+    }
+
+    monitoring_ = false;
+    if (logger_) logger_->info("PIRDriver::run success");
 }
 
 void PIRDriver::stop() {
-    running_ = false;
-    if (thread_.joinable()) thread_.join();
-    if (logger_) logger_->info("PIRDriver stopped");
+    if (logger_) logger_->info("PIRDriver::stop start");
+
+    if (!monitoring_) {
+        if (logger_) logger_->info("PIRDriver::stop already stopped");
+        return;
+    }
+
+    interrupt_ = true;
+
+    try {
+        // リソース解放処理が必要な場合はここで行う
+    } catch (const std::exception& e) {
+        monitoring_ = false;
+        if (logger_) logger_->error(std::string("PIRDriver::stop failed: ") + e.what());
+        throw;
+    }
+
+    monitoring_ = false;
+    if (logger_) logger_->info("PIRDriver::stop success");
 }
 
-
 } // namespace device_reminder
+


### PR DESCRIPTION
## 概要
- PIRセンサドライバを仕様書に基づいて再設計
- 監視状態と中断フラグを導入し、run/stop処理を明確化

## テスト
- `cmake -S . -B build`
- `cmake --build build` : `main_task/i_main_process.hpp` が見つからず失敗

------
https://chatgpt.com/codex/tasks/task_e_689995e7cab48328988c0d321197e3b2