### PR TITLE
Refactor BluetoothDriver module per spec

### DIFF
--- a/include/infra/bluetooth_driver/bluetooth_driver.hpp
+++ b/include/infra/bluetooth_driver/bluetooth_driver.hpp
@@ -1,42 +1,32 @@
 #pragma once
 
-#include "i_bluetooth_driver.hpp"
-#include "i_bluetooth_scanner.hpp"
-#include "i_bluetooth_pairer.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
-#include "infra/thread_operation/thread_sender/i_thread_sender.hpp"
-#include "infra/logger/i_logger.hpp"
-
-#include <vector>
-#include <string>
 #include <memory>
 
 namespace device_reminder {
 
+class IBluetoothScanner;
+class ILogger;
+
+class IBluetoothDriver {
+public:
+    virtual ~IBluetoothDriver() = default;
+    virtual void run() = 0;
+    virtual void stop() = 0;
+};
+
 class BluetoothDriver : public IBluetoothDriver {
 public:
-    BluetoothDriver(std::shared_ptr<IFileLoader> device_loader,
-                    std::shared_ptr<IFileLoader> distance_threshold_loader,
-                    std::shared_ptr<IBluetoothScanner> scanner,
-                    std::shared_ptr<IBluetoothPairer> pairer,
-                    std::shared_ptr<IThreadSender> sender,
+    BluetoothDriver(std::shared_ptr<IBluetoothScanner> scanner,
                     std::shared_ptr<ILogger> logger);
 
     void run() override;
     void stop() override;
-    std::vector<std::string> scan() override;
-
-    const std::vector<std::string>& paired_devices() const { return paired_devices_; }
 
 private:
-    std::shared_ptr<IFileLoader> device_loader_;
-    std::shared_ptr<IFileLoader> distance_threshold_loader_;
-    std::shared_ptr<IBluetoothScanner> scanner_;
-    std::shared_ptr<IBluetoothPairer> pairer_;
-    std::shared_ptr<IThreadSender> sender_;
-    std::shared_ptr<ILogger> logger_;
-    std::vector<std::string> paired_devices_;
+    std::shared_ptr<IBluetoothScanner> scanner_{};
+    std::shared_ptr<ILogger> logger_{};
     bool running_{false};
 };
 
 } // namespace device_reminder
+

--- a/src/infra/bluetooth_driver/bluetooth_driver.cpp
+++ b/src/infra/bluetooth_driver/bluetooth_driver.cpp
@@ -1,73 +1,79 @@
 #include "bluetooth_driver/bluetooth_driver.hpp"
 
-#include <algorithm>
+#include "bluetooth_driver/bluetooth_scanner.hpp"
+#include "infra/logger/i_logger.hpp"
+
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace device_reminder {
 
-BluetoothDriver::BluetoothDriver(std::shared_ptr<IFileLoader> device_loader,
-                                 std::shared_ptr<IFileLoader> distance_threshold_loader,
-                                 std::shared_ptr<IBluetoothScanner> scanner,
-                                 std::shared_ptr<IBluetoothPairer> pairer,
-                                 std::shared_ptr<IThreadSender> sender,
+BluetoothDriver::BluetoothDriver(std::shared_ptr<IBluetoothScanner> scanner,
                                  std::shared_ptr<ILogger> logger)
-    : device_loader_(std::move(device_loader))
-    , distance_threshold_loader_(std::move(distance_threshold_loader))
-    , scanner_(std::move(scanner))
-    , pairer_(std::move(pairer))
-    , sender_(std::move(sender))
+    : scanner_(std::move(scanner))
     , logger_(std::move(logger)) {}
 
 void BluetoothDriver::run() {
-    running_ = true;
-    paired_devices_.clear();
-
-    if (!device_loader_ || !distance_threshold_loader_ || !scanner_ || !pairer_) {
-        if (logger_) logger_->warn("BluetoothDriver dependencies not set");
-        running_ = false;
-        return;
+    if (logger_) {
+        logger_->info("BluetoothDriver run start");
     }
-
-    auto registered = device_loader_->load_string_list("device_list");
-    int threshold = distance_threshold_loader_->load_int("distance_threshold");
-
-    auto scanned = scanner_->scan();
-    std::vector<std::string> targets;
-    for (const auto& dev : scanned) {
-        if (std::find(registered.begin(), registered.end(), dev.mac) != registered.end() &&
-            dev.rssi >= threshold) {
-            targets.push_back(dev.mac);
-        }
-    }
-
-    for (const auto& mac : targets) {
-        try {
-            if (pairer_->pair(mac)) {
-                paired_devices_.push_back(mac);
+    try {
+        running_ = true;
+        while (running_) {
+            auto devices = scanner_ ? scanner_->scan() : std::vector<BluetoothDevice>{};
+            bool paired = false;
+            for (const auto& dev : devices) {
+                if (dev.rssi >= -50) {
+                    paired = true;
+                    running_ = false;
+                    break;
+                }
             }
-        } catch (const std::exception& e) {
-            if (logger_) logger_->error(e.what());
+            if (paired) {
+                break;
+            }
         }
+        if (logger_) {
+            logger_->info("BluetoothDriver run succeeded");
+        }
+    } catch (...) {
+        if (logger_) {
+            try {
+                throw;
+            } catch (const std::exception& e) {
+                logger_->error(std::string("BluetoothDriver run failed: ") + e.what());
+            } catch (...) {
+                logger_->error("BluetoothDriver run failed: unknown error");
+            }
+        }
+        running_ = false;
+        throw;
     }
-
-    if (!paired_devices_.empty() && sender_) {
-        sender_->send();
-    }
-
-    running_ = false;
 }
 
 void BluetoothDriver::stop() {
-    running_ = false;
-}
-
-std::vector<std::string> BluetoothDriver::scan() {
-    if (!scanner_) return {};
-    auto scanned = scanner_->scan();
-    std::vector<std::string> names;
-    for (const auto& dev : scanned) {
-        names.push_back(dev.mac);
+    if (logger_) {
+        logger_->info("BluetoothDriver stop start");
     }
-    return names;
+    try {
+        running_ = false;
+        if (logger_) {
+            logger_->info("BluetoothDriver stop succeeded");
+        }
+    } catch (...) {
+        if (logger_) {
+            try {
+                throw;
+            } catch (const std::exception& e) {
+                logger_->error(std::string("BluetoothDriver stop failed: ") + e.what());
+            } catch (...) {
+                logger_->error("BluetoothDriver stop failed: unknown error");
+            }
+        }
+        throw;
+    }
 }
 
 } // namespace device_reminder
+


### PR DESCRIPTION
## Summary
- Refactor BluetoothDriver interface and implementation
- Simplify constructor dependencies and add logging per spec

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: main_task/i_main_process.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899990ef9a88328840869d1ee99c0f2