### PR TITLE
BuzzerDriver を仕様に合わせて修正

### DIFF
--- a/include/infra/buzzer_driver/buzzer_driver.hpp
+++ b/include/infra/buzzer_driver/buzzer_driver.hpp
@@ -1,12 +1,21 @@
 #pragma once
-#include "i_buzzer_driver.hpp"
-#include "infra/logger/i_logger.hpp"
-#include "infra/gpio_operation/gpio_setter/i_gpio_setter.hpp"
+
 #include "infra/file_loader/i_file_loader.hpp"
+#include "infra/gpio_operation/gpio_setter/i_gpio_setter.hpp"
+#include "infra/logger/i_logger.hpp"
+
 #include <memory>
 #include <string>
 
 namespace device_reminder {
+
+class IBuzzerDriver {
+public:
+    virtual ~IBuzzerDriver() = default;
+
+    virtual void on()  = 0;
+    virtual void off() = 0;
+};
 
 class BuzzerDriver : public IBuzzerDriver {
 public:
@@ -22,6 +31,6 @@ private:
     std::shared_ptr<IFileLoader> loader_;
     std::shared_ptr<ILogger>     logger_;
     std::shared_ptr<IGPIOSetter> gpio_;
-}; 
+};
 
 } // namespace device_reminder


### PR DESCRIPTION
## Summary
- ヘッダに IBuzzerDriver を定義し、BuzzerDriver と一体化
- on/off で周波数取得と GPIO 制御を行い、開始・成功・失敗をログ出力

## Testing
- `cmake -S . -B build`
- `cmake --build build` (main_task/i_main_process.hpp が無いため失敗)
- `ctest --test-dir build` (ビルド失敗により実行ファイル未生成)


------
https://chatgpt.com/codex/tasks/task_e_68999b778dec83288af309682e7a7459