### PR TITLE
Refactor MessageDispatcher to no-op base

### DIFF
--- a/include/infra/message/message_dispatcher.hpp
+++ b/include/infra/message/message_dispatcher.hpp
@@ -3,32 +3,25 @@
 #include "infra/logger/i_logger.hpp"
 #include "infra/message/message.hpp"
 
-#include <functional>
 #include <memory>
-#include <unordered_map>
-#include <vector>
 
 namespace device_reminder {
 
 class IMessageDispatcher {
 public:
+    explicit IMessageDispatcher(std::shared_ptr<ILogger> logger);
     virtual ~IMessageDispatcher() = default;
     virtual void dispatch(std::shared_ptr<IMessage> msg) = 0;
+
+protected:
+    std::shared_ptr<ILogger> logger_{};
 };
 
 class MessageDispatcher : public IMessageDispatcher {
 public:
-    MessageDispatcher(
-        std::shared_ptr<ILogger> logger,
-        std::unordered_map<MessageType, std::function<void(std::vector<std::string>)>>
-            handler_map);
+    explicit MessageDispatcher(std::shared_ptr<ILogger> logger);
 
     void dispatch(std::shared_ptr<IMessage> msg) override;
-
-private:
-    std::shared_ptr<ILogger> logger_;
-    std::unordered_map<MessageType, std::function<void(std::vector<std::string>)>>
-        handler_map_;
 };
 
 } // namespace device_reminder

--- a/src/infra/message/message_dispatcher.cpp
+++ b/src/infra/message/message_dispatcher.cpp
@@ -1,76 +1,37 @@
 #include "infra/message/message_dispatcher.hpp"
-#include "infra/logger/i_logger.hpp"
 
-#include <spdlog/fmt/fmt.h>
-#include <stdexcept>
+#include <exception>
+#include <string>
 #include <utility>
 
 namespace device_reminder {
 
-MessageDispatcher::MessageDispatcher(
-    std::shared_ptr<ILogger> logger,
-    std::unordered_map<MessageType, std::function<void(std::vector<std::string>)>>
-        handler_map)
-    : logger_(std::move(logger)),
-      handler_map_(std::move(handler_map)) {}
+IMessageDispatcher::IMessageDispatcher(std::shared_ptr<ILogger> logger)
+    : logger_(std::move(logger)) {}
+
+MessageDispatcher::MessageDispatcher(std::shared_ptr<ILogger> logger)
+    : IMessageDispatcher(std::move(logger)) {}
 
 void MessageDispatcher::dispatch(std::shared_ptr<IMessage> msg) {
-    if (!msg) {
-        if (logger_) logger_->error("dispatch: msg is null");
-        throw std::invalid_argument("msg is null");
-    }
-
-    auto type = msg->type();
-    auto payload = msg->payload();
-    auto payload_size = payload.size();
-
-    if (logger_) {
-        if (payload_size) {
-            logger_->info(fmt::format("dispatch: type={}, payload_size={}",
-                                      static_cast<int>(type), payload_size));
-        } else {
-            logger_->info(
-                fmt::format("dispatch: type={}", static_cast<int>(type)));
-        }
-    }
-
-    auto it = handler_map_.find(type);
-    if (it == handler_map_.end()) {
-        if (logger_) {
-            logger_->error(fmt::format("dispatch: no handler for type={}",
-                                       static_cast<int>(type)));
-        }
-        throw std::runtime_error("no handler");
-    }
-
-    auto &handler = it->second;
-
     try {
-        handler(payload);
-    } catch (const std::exception &e) {
         if (logger_) {
-            logger_->error(fmt::format("dispatch failed: type={}, what={}",
-                                       static_cast<int>(type), e.what()));
+            logger_->info("dispatch start: " +
+                           (msg ? msg->to_string() : std::string("null message")));
+        }
+
+        if (logger_) {
+            logger_->info("dispatch success");
+        }
+    } catch (const std::exception& e) {
+        if (logger_) {
+            logger_->error(std::string("dispatch failed: ") + e.what());
         }
         throw;
     } catch (...) {
         if (logger_) {
-            logger_->error(fmt::format(
-                "dispatch failed: type={}, unknown exception",
-                static_cast<int>(type)));
+            logger_->error("dispatch failed: unknown exception");
         }
         throw;
-    }
-
-    if (logger_) {
-        if (payload_size) {
-            logger_->info(fmt::format(
-                "dispatch: succeeded, type={}, payload_size={}",
-                static_cast<int>(type), payload_size));
-        } else {
-            logger_->info(fmt::format("dispatch: succeeded, type={}",
-                                      static_cast<int>(type)));
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- revise IMessageDispatcher and MessageDispatcher interfaces to accept ILogger and remove handler map
- implement default no-op dispatch with start/success/failure logging

## Testing
- `cmake --build build` *(fails: main_task/i_main_process.hpp: No such file or directory)*
- `ctest --test-dir build` *(fails: Unable to find executable: /workspace/device_reminder/build/test_unit, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689aa70fa648832899b6e4129707407f