### PR TITLE
feat: 実装見直し human dispatcher

### DIFF
--- a/src/core/human_task/human_dispatcher.cpp
+++ b/src/core/human_task/human_dispatcher.cpp
@@ -1,49 +1,103 @@
-#include "human_task/human_handler.hpp"
-#include "infra/process_operation/process_message/process_message_type.hpp"
+#include "human_task/human_dispatcher.hpp"
+
+#include <stdexcept>
+#include <string>
 
 namespace device_reminder {
 
-HumanHandler::HumanHandler(std::shared_ptr<ILogger> logger,
-                           std::shared_ptr<IHumanTask> task,
-                           std::shared_ptr<ITimerService> timer)
-    : logger_(std::move(logger)), task_(std::move(task)), timer_(std::move(timer)) {
-    if (logger_) logger_->info("HumanHandler created");
+IHumanDispatcher::IHumanDispatcher(std::shared_ptr<ILogger> logger,
+                                   std::shared_ptr<IHumanHandler> handler,
+                                   MessageType message_type)
+    : logger_(std::move(logger)),
+      handler_(std::move(handler)),
+      message_type_(message_type) {}
+
+HumanDispatcher::HumanDispatcher(std::shared_ptr<ILogger> logger,
+                                 std::shared_ptr<IHumanHandler> handler,
+                                 MessageType message_type)
+    : IHumanDispatcher(std::move(logger), std::move(handler), message_type) {}
+
+const char* HumanDispatcher::state_to_string(State state) const {
+    switch (state) {
+    case State::Detecting:
+        return "人検知中";
+    case State::Stopped:
+        return "人検知停止中";
+    }
+    return "";
 }
 
-void HumanHandler::handle(std::shared_ptr<IProcessMessage> msg) {
-    if (!msg || !task_) return;
+void HumanDispatcher::dispatch(std::shared_ptr<IMessage> msg) {
+    try {
+        if (!msg) {
+            if (logger_) logger_->error("dispatch start: msg is null");
+            throw std::invalid_argument("msg is null");
+        }
 
-    switch (msg->type()) {
-    case ProcessMessageType::StartHumanDetection:
-        state_ = State::Detecting;
-        if (timer_) timer_->stop();
-        if (logger_) logger_->info("StartHumanDetection");
-        break;
-    case ProcessMessageType::StopHumanDetection:
-        state_ = State::Stopping;
-        if (timer_) timer_->start();
-        if (logger_) logger_->info("StopHumanDetection");
-        break;
-    case ProcessMessageType::CooldownTimeout:
-        state_ = State::Cooldown;
-        if (timer_) timer_->stop();
-        if (logger_) logger_->info("CooldownTimeout");
-        break;
-    default:
-        break;
-    }
+        State       prev_state = state_;
+        MessageType type       = msg->type();
+        if (logger_) {
+            logger_->info(std::string("dispatch start: state=") +
+                          state_to_string(state_) +
+                          ", msg.type=" +
+                          std::to_string(static_cast<int>(type)));
+        }
 
-    switch (state_) {
-    case State::Detecting:
-        task_->on_detecting(msg->payload());
-        break;
-    case State::Stopping:
-        task_->on_stopping(msg->payload());
-        break;
-    case State::Cooldown:
-        task_->on_cooldown(msg->payload());
-        break;
+        std::string action;
+
+        switch (type) {
+        case MessageType::HumanDetected:
+            if (handler_) handler_->get_detect();
+            action = "get_detect";
+            if (state_ == State::Detecting) {
+                state_ = State::Stopped;
+            } else if (logger_) {
+                logger_->info("state mismatch, transition skipped");
+            }
+            break;
+        case MessageType::CooldownTimeout:
+            if (handler_) handler_->start_detect();
+            action = "start_detect";
+            if (state_ == State::Stopped) {
+                state_ = State::Detecting;
+            } else if (logger_) {
+                logger_->info("state mismatch, transition skipped");
+            }
+            break;
+        case MessageType::StopHumanDetection:
+            if (state_ == State::Detecting) {
+                state_ = State::Stopped;
+            } else if (logger_) {
+                logger_->info("state mismatch, transition skipped");
+            }
+            action = "none";
+            break;
+        case MessageType::StartHumanDetection:
+            if (handler_) handler_->start_detect();
+            action = "start_detect";
+            if (state_ == State::Stopped) {
+                state_ = State::Detecting;
+            } else if (logger_) {
+                logger_->info("state mismatch, transition skipped");
+            }
+            break;
+        default:
+            if (logger_) logger_->warn("undefined message type");
+            action = "none";
+            break;
+        }
+
+        if (logger_) {
+            logger_->info(std::string("dispatch success: ") +
+                          state_to_string(prev_state) + " -> " +
+                          state_to_string(state_) +
+                          ", action=" + action);
+        }
+    } catch (...) {
+        if (logger_) logger_->error("dispatch failed");
+        throw;
     }
 }
 
 } // namespace device_reminder
+


### PR DESCRIPTION
## 概要
- 人検知タスクのディスパッチャをIF仕様に沿って再実装
- メッセージ種別に応じた状態遷移とハンドラ呼び出しを追加

## テスト
- `cmake -S . -B build` (成功)
- `cmake --build build` (main_task/i_main_process.hpp がなく失敗)

------
https://chatgpt.com/codex/tasks/task_e_689bcad377d883288d33eb4be1634167