### PR TITLE
refactor: implement main dispatcher module

### DIFF
--- a/src/core/main_task/main_dispatcher.cpp
+++ b/src/core/main_task/main_dispatcher.cpp
@@ -1,43 +1,96 @@
-#include "main_task/main_handler.hpp"
-#include "infra/process_operation/process_message/process_message_type.hpp"
-#include "infra/process_operation/process_message/i_process_message.hpp"
+#include "main_task/main_dispatcher.hpp"
 
 namespace device_reminder {
 
-MainHandler::MainHandler(std::shared_ptr<ILogger> logger,
-                         std::shared_ptr<IMainTask> task,
-                         std::shared_ptr<ITimerService> timer_service,
-                         std::shared_ptr<IFileLoader> file_loader)
-    : logger_(std::move(logger))
-    , task_(std::move(task))
-    , timer_service_(std::move(timer_service))
-    , file_loader_(std::move(file_loader)) {
-    if (logger_) logger_->info("MainHandler created");
+namespace {
+std::string state_to_string(State state) {
+    switch (state) {
+    case State::WaitingHumanDetection:
+        return "WaitingHumanDetection";
+    case State::WaitingDevicePresenceResponse:
+        return "WaitingDevicePresenceResponse";
+    case State::WaitingDevicePresenceRetryResponse:
+        return "WaitingDevicePresenceRetryResponse";
+    case State::BluetoothScanRequestCooldown:
+        return "BluetoothScanRequestCooldown";
+    }
+    return "Unknown";
 }
+} // namespace
 
-void MainHandler::handle(std::shared_ptr<IProcessMessage> msg) {
-    if (!msg || !task_) return;
+MainDispatcher::MainDispatcher(std::shared_ptr<ILogger> logger,
+                               std::shared_ptr<IMainHandler> handler,
+                               IMessageType initial_state)
+    : logger_(std::move(logger))
+    , handler_(std::move(handler))
+    , state_(initial_state) {}
 
-    switch (msg->type()) {
-    case ProcessMessageType::HumanDetected:
-        task_->on_waiting_for_human(msg->payload());
-        break;
-    case ProcessMessageType::ResponseDevicePresence:
-        if (!msg->payload().empty() && msg->payload()[0] == "found") {
-            task_->on_response_to_human_task(msg->payload());
-        } else {
-            task_->on_response_to_buzzer_task(msg->payload());
+void MainDispatcher::dispatch(std::shared_ptr<IMessage> msg) {
+    if (logger_) logger_->info("[MainDispatcher::dispatch] start");
+    try {
+        if (!msg) {
+            if (logger_) logger_->error("[MainDispatcher::dispatch] failed: null message");
+            return;
         }
-        break;
-    case ProcessMessageType::CooldownTimeout:
-        task_->on_cooldown(msg->payload());
-        break;
-    case ProcessMessageType::ScanTimeout:
-        task_->on_waiting_for_second_response(msg->payload());
-        break;
-    default:
-        break;
+
+        auto event = msg->type();
+
+        switch (event) {
+        case MessageType::HumanDetected:
+            if (state_ == State::WaitingHumanDetection) {
+                if (handler_) handler_->start_device_detect();
+                state_ = State::WaitingDevicePresenceResponse;
+            }
+            break;
+        case MessageType::RespondDeviceFound:
+            if (state_ == State::WaitingDevicePresenceResponse) {
+                if (handler_) handler_->end_device_first_detect();
+                state_ = State::WaitingHumanDetection;
+            } else if (state_ == State::WaitingDevicePresenceRetryResponse) {
+                if (handler_) handler_->end_device_retry_detect();
+                state_ = State::WaitingHumanDetection;
+            }
+            break;
+        case MessageType::RespondDeviceNotFound:
+            if (state_ == State::WaitingDevicePresenceResponse) {
+                if (handler_) handler_->retry_device_detect();
+                state_ = State::BluetoothScanRequestCooldown;
+            } else if (state_ == State::WaitingDevicePresenceRetryResponse) {
+                if (handler_) handler_->send_bt_request();
+                state_ = State::BluetoothScanRequestCooldown;
+            }
+            break;
+        case MessageType::CooldownTimeout:
+            if (state_ == State::BluetoothScanRequestCooldown) {
+                if (handler_) handler_->send_bt_request();
+                state_ = State::WaitingDevicePresenceRetryResponse;
+            }
+            break;
+        case MessageType::ProcessingTimeout:
+            if (state_ == State::WaitingDevicePresenceResponse) {
+                if (handler_) handler_->end_device_first_detect();
+                state_ = State::WaitingHumanDetection;
+            } else if (state_ == State::BluetoothScanRequestCooldown) {
+                if (handler_) handler_->end_device_retry_detect();
+                state_ = State::WaitingHumanDetection;
+            } else if (state_ == State::WaitingDevicePresenceRetryResponse) {
+                if (handler_) handler_->end_device_retry_detect();
+                state_ = State::WaitingHumanDetection;
+            }
+            break;
+        default:
+            break;
+        }
+
+        if (logger_) {
+            logger_->info(std::string("[MainDispatcher::dispatch] success: state=") +
+                          state_to_string(state_));
+        }
+    } catch (const std::exception& e) {
+        if (logger_) logger_->error(std::string("[MainDispatcher::dispatch] failed: ") + e.what());
+        throw;
     }
 }
 
 } // namespace device_reminder
+


### PR DESCRIPTION
## Summary
- replace misplaced MainHandler code with MainDispatcher implementation
- manage main task state transitions and delegate to MainHandler

## Testing
- `cmake -S . -B build`
- `cmake --build build --target test_unit` *(fails: main_task/i_main_process.hpp missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c306d697883289b6780ad00c843ef