### PR TITLE
refactor: implement BuzzerHandler according to spec

### DIFF
--- a/src/core/buzzer_task/buzzer_handler.cpp
+++ b/src/core/buzzer_task/buzzer_handler.cpp
@@ -1,54 +1,74 @@
-#include "buzzer_task/buzzer_task.hpp"
-#include "infra/process_operation/process_message/process_message.hpp"
+#include "buzzer_task/buzzer_handler.hpp"
+#include "infra/message/thread_sender.hpp"
+
+#include <utility>
 
 namespace device_reminder {
 
-BuzzerTask::BuzzerTask(std::shared_ptr<ILogger> logger,
-                       std::shared_ptr<IProcessSender> sender,
-                       std::shared_ptr<IFileLoader> file_loader,
-                       std::shared_ptr<IBuzzerDriver> driver)
+BuzzerHandler::BuzzerHandler(std::shared_ptr<ILogger> logger,
+                             std::shared_ptr<IFileLoader> file_loader,
+                             std::shared_ptr<IBuzzerDriver> driver,
+                             std::shared_ptr<ITimerService> timer_service,
+                             std::shared_ptr<IMessageQueue> buzzer_queue,
+                             std::shared_ptr<IMessage> buzzing_end_msg)
     : logger_(std::move(logger))
-    , sender_(std::move(sender))
     , file_loader_(std::move(file_loader))
     , driver_(std::move(driver))
-{
-    if (logger_) logger_->info("BuzzerTask created");
-}
+    , timer_service_(std::move(timer_service))
+    , buzzer_queue_(std::move(buzzer_queue))
+    , buzzing_end_msg_(std::move(buzzing_end_msg)) {}
 
-bool BuzzerTask::send_message(const IThreadMessage& msg) {
-    onMessage(msg);
-    return true;
-}
+void BuzzerHandler::start_buzzing_and_start_timer() {
+    if (logger_) logger_->info("[BuzzerHandler::start_buzzing_and_start_timer] start");
+    try {
+        if (driver_) {
+            driver_->on();
+        }
 
-void BuzzerTask::onMessage(const IThreadMessage& msg) {
-    switch (msg.type()) {
-    case ThreadMessageType::StartBuzzing:
-        if (state_ == State::WaitStart) startBuzzer();
-        break;
-    case ThreadMessageType::StopBuzzing:
-        if (state_ == State::Buzzing) stopBuzzer();
-        break;
-    default:
-        break;
+        if (timer_service_ && buzzer_queue_ && buzzing_end_msg_) {
+            auto thread_sender = std::make_shared<ThreadSender>(logger_);
+            timer_service_->start(0, thread_sender);
+            thread_sender->send(buzzer_queue_, buzzing_end_msg_);
+        }
+
+        if (logger_) logger_->info("[BuzzerHandler::start_buzzing_and_start_timer] success");
+    } catch (const std::exception& e) {
+        if (logger_) logger_->error(std::string("[BuzzerHandler::start_buzzing_and_start_timer] failed: ") + e.what());
+        throw;
     }
 }
 
-void BuzzerTask::startBuzzer() {
-    if (driver_) driver_->on();
-    state_ = State::Buzzing;
+void BuzzerHandler::stop_buzzing_and_stop_timer() {
+    if (logger_) logger_->info("[BuzzerHandler::stop_buzzing_and_stop_timer] start");
+    try {
+        if (driver_) {
+            driver_->off();
+        }
+
+        if (timer_service_) {
+            timer_service_->stop();
+        }
+
+        if (logger_) logger_->info("[BuzzerHandler::stop_buzzing_and_stop_timer] success");
+    } catch (const std::exception& e) {
+        if (logger_) logger_->error(std::string("[BuzzerHandler::stop_buzzing_and_stop_timer] failed: ") + e.what());
+        throw;
+    }
 }
 
-void BuzzerTask::stopBuzzer() {
-    if (driver_) driver_->off();
-    state_ = State::WaitStart;
-}
+void BuzzerHandler::stop_buzzing() {
+    if (logger_) logger_->info("[BuzzerHandler::stop_buzzing] start");
+    try {
+        if (driver_) {
+            driver_->off();
+        }
 
-void BuzzerTask::on_waiting(const std::vector<std::string>&) {
-    startBuzzer();
-}
-
-void BuzzerTask::on_buzzing(const std::vector<std::string>&) {
-    stopBuzzer();
+        if (logger_) logger_->info("[BuzzerHandler::stop_buzzing] success");
+    } catch (const std::exception& e) {
+        if (logger_) logger_->error(std::string("[BuzzerHandler::stop_buzzing] failed: ") + e.what());
+        throw;
+    }
 }
 
 } // namespace device_reminder
+


### PR DESCRIPTION
## Summary
- rework BuzzerHandler interface and implementation per specification
- add timer and buzzer control methods with logging and error propagation

## Testing
- `cmake -B build`
- `cmake --build build` *(fails: main_task/i_main_process.hpp missing)*


------
https://chatgpt.com/codex/tasks/task_e_689c36e811bc83288272f6a9bf4a682f