### PR TITLE
Implement Bluetooth dispatcher

### DIFF
--- a/include/core/bluetooth_task/bluetooth_dispatcher.hpp
+++ b/include/core/bluetooth_task/bluetooth_dispatcher.hpp
@@ -1,24 +1,43 @@
 #pragma once
 
-#include "core/interfaces/i_handler.hpp"
-#include "core/bluetooth_task/i_bluetooth_task.hpp"
 #include "infra/logger/i_logger.hpp"
-#include "infra/process_operation/process_message/i_process_message.hpp"
+#include "infra/message/message.hpp"
 
 #include <memory>
 
 namespace device_reminder {
 
-class BluetoothHandler : public IHandler {
-public:
-    BluetoothHandler(std::shared_ptr<ILogger> logger,
-                     std::shared_ptr<IBluetoothTask> task);
+class IBluetoothHandler;
 
-    void handle(std::shared_ptr<IProcessMessage> msg) override;
+class IBluetoothDispatcher {
+public:
+    IBluetoothDispatcher(std::shared_ptr<ILogger> logger,
+                         std::shared_ptr<IBluetoothHandler> handler,
+                         MessageType message_type);
+    virtual ~IBluetoothDispatcher() = default;
+
+    virtual void dispatch(std::shared_ptr<IMessage> msg) = 0;
+
+protected:
+    std::shared_ptr<ILogger>          logger_;
+    std::shared_ptr<IBluetoothHandler> handler_;
+    MessageType                       message_type_;
+};
+
+class BluetoothDispatcher : public IBluetoothDispatcher {
+public:
+    BluetoothDispatcher(std::shared_ptr<ILogger> logger,
+                        std::shared_ptr<IBluetoothHandler> handler,
+                        MessageType message_type);
+
+    void dispatch(std::shared_ptr<IMessage> msg) override;
 
 private:
-    std::shared_ptr<ILogger>       logger_;
-    std::shared_ptr<IBluetoothTask> task_;
+    enum class State { Ready, Cooldown };
+    State state_{State::Ready};
+
+    const char* state_to_string(State state) const;
 };
 
 } // namespace device_reminder
+

--- a/src/core/bluetooth_task/bluetooth_dispatcher.cpp
+++ b/src/core/bluetooth_task/bluetooth_dispatcher.cpp
@@ -1,21 +1,75 @@
-#include "bluetooth_task/bluetooth_handler.hpp"
-#include "infra/process_operation/process_message/process_message_type.hpp"
+#include "core/bluetooth_task/bluetooth_dispatcher.hpp"
+#include "core/bluetooth_task/bluetooth_handler.hpp"
+
+#include <stdexcept>
+#include <string>
 
 namespace device_reminder {
 
-BluetoothHandler::BluetoothHandler(std::shared_ptr<ILogger> logger,
-                                   std::shared_ptr<IBluetoothTask> task)
-    : logger_(std::move(logger)), task_(std::move(task)) {
-    if (logger_) logger_->info("BluetoothHandler created");
+IBluetoothDispatcher::IBluetoothDispatcher(std::shared_ptr<ILogger> logger,
+                                           std::shared_ptr<IBluetoothHandler> handler,
+                                           MessageType message_type)
+    : logger_(std::move(logger)),
+      handler_(std::move(handler)),
+      message_type_(message_type) {}
+
+BluetoothDispatcher::BluetoothDispatcher(std::shared_ptr<ILogger> logger,
+                                         std::shared_ptr<IBluetoothHandler> handler,
+                                         MessageType message_type)
+    : IBluetoothDispatcher(std::move(logger), std::move(handler), message_type) {}
+
+const char* BluetoothDispatcher::state_to_string(State state) const {
+    switch (state) {
+    case State::Ready:
+        return "スキャン待機";
+    case State::Cooldown:
+        return "クールダウン中";
+    }
+    return "";
 }
 
-void BluetoothHandler::handle(std::shared_ptr<IProcessMessage> msg) {
-    if (!msg || !task_) return;
+void BluetoothDispatcher::dispatch(std::shared_ptr<IMessage> msg) {
+    try {
+        if (!msg) {
+            if (logger_) logger_->error("dispatch start: msg is null");
+            throw std::invalid_argument("msg is null");
+        }
 
-    if (msg->type() == ProcessMessageType::RequestBluetoothScan) {
-        if (logger_) logger_->info("RequestBluetoothScan");
-        task_->on_waiting(msg->payload());
+        MessageType type = msg->type();
+        if (logger_) {
+            logger_->info(std::string("dispatch start: state=") +
+                          state_to_string(state_) +
+                          ", msg.type=" +
+                          std::to_string(static_cast<int>(type)));
+        }
+
+        if (type != message_type_) {
+            if (logger_) logger_->info("dispatch ignore: not scan request");
+            return;
+        }
+
+        if (state_ != State::Ready) {
+            if (logger_)
+                logger_->info(std::string("dispatch ignore: state=") +
+                               state_to_string(state_));
+            return;
+        }
+
+        if (logger_) {
+            logger_->info(std::string("dispatch processing: ") +
+                          msg->to_string());
+        }
+
+        if (handler_) handler_->scan();
+
+        state_ = State::Cooldown;
+
+        if (logger_) logger_->info("dispatch success: scan executed");
+    } catch (...) {
+        if (logger_) logger_->error("dispatch failed");
+        throw;
     }
 }
 
 } // namespace device_reminder
+


### PR DESCRIPTION
## Summary
- implement BluetoothDispatcher with state management and logging
- use external BluetoothHandler instead of defining interface in dispatcher

## Testing
- `cmake -S . -B build`
- `cmake --build build` (fails: main_task/i_main_process.hpp missing)
- `ctest --test-dir build` (fails: executables not found)


------
https://chatgpt.com/codex/tasks/task_e_689c342475d8832896311f39e2cd44b0