### PR TITLE
fix: adjust include paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/include/core
     ${CMAKE_SOURCE_DIR}/include/infra
     ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/tests
     ${CMAKE_SOURCE_DIR}/tests/stubs
     ${SPDLOG_INCLUDE_DIR}

--- a/di/app_injector.hpp
+++ b/di/app_injector.hpp
@@ -11,10 +11,10 @@
 #include "infra/gpio_operation/gpio_reader/gpio_reader.hpp"
 #include "infra/buzzer_driver/buzzer_driver.hpp"
 #include "infra/bluetooth_driver/bluetooth_driver.hpp"
-#include "infra/process_operation/process_sender/i_process_sender.hpp"
-#include "infra/process_operation/process_sender/process_sender.hpp"
-#include "infra/thread_operation/thread_queue/thread_queue.hpp"
-#include "infra/thread_operation/thread_queue/i_thread_queue.hpp"
+#include "infra/message/process_sender.hpp"
+#include "infra/message/process_sender.hpp"
+#include "infra/message/message_queue.hpp"
+#include "infra/message/message_queue.hpp"
 
 #include <tuple>
 #include <memory>

--- a/di/logger_injector.hpp
+++ b/di/logger_injector.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include "infra/logger/logger.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 
 #include <boost/di.hpp>
 #include <memory>

--- a/include/core/app/app.hpp
+++ b/include/core/app/app.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "infra/process/process.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 
 namespace device_reminder {
 

--- a/include/core/bluetooth_task/bluetooth_dispatcher.hpp
+++ b/include/core/bluetooth_task/bluetooth_dispatcher.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "infra/message/message.hpp"
 
 #include <memory>

--- a/include/core/bluetooth_task/bluetooth_handler.hpp
+++ b/include/core/bluetooth_task/bluetooth_handler.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "infra/logger/i_logger.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
-#include "infra/process_operation/process_sender/i_process_sender.hpp"
-#include "infra/bluetooth_driver/i_bluetooth_driver.hpp"
+#include "infra/logger.hpp"
+#include "infra/file_loader.hpp"
+#include "infra/message/process_sender.hpp"
+#include "infra/bluetooth_driver/bluetooth_driver.hpp"
 #include "infra/message/message_queue.hpp"
 #include "infra/message/message.hpp"
 

--- a/include/core/buzzer_task/buzzer_dispatcher.hpp
+++ b/include/core/buzzer_task/buzzer_dispatcher.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "buzzer_task/buzzer_handler.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "infra/message/message.hpp"
 
 #include <memory>

--- a/include/core/buzzer_task/buzzer_handler.hpp
+++ b/include/core/buzzer_task/buzzer_handler.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "infra/logger/i_logger.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
+#include "infra/logger.hpp"
+#include "infra/file_loader.hpp"
 #include "infra/buzzer_driver/buzzer_driver.hpp"
 #include "infra/timer_service/timer_service.hpp"
 #include "infra/message/message_queue.hpp"

--- a/include/core/human_task/human_dispatcher.hpp
+++ b/include/core/human_task/human_dispatcher.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "human_task/human_handler.hpp"
 #include "infra/message/message.hpp"
 

--- a/include/core/human_task/human_handler.hpp
+++ b/include/core/human_task/human_handler.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "infra/pir_driver/pir_driver.hpp"
 #include "infra/timer_service/timer_service.hpp"
 #include "infra/file_loader.hpp"

--- a/include/core/main_task/main_dispatcher.hpp
+++ b/include/core/main_task/main_dispatcher.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "core/main_task/main_handler.hpp"
 #include "infra/message/message.hpp"
 

--- a/include/core/main_task/main_handler.hpp
+++ b/include/core/main_task/main_handler.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "infra/message/message.hpp"
 #include "infra/message/message_queue.hpp"
 #include "infra/message/process_sender.hpp"

--- a/include/infra/buzzer_driver/buzzer_driver.hpp
+++ b/include/infra/buzzer_driver/buzzer_driver.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "infra/file_loader/i_file_loader.hpp"
-#include "infra/gpio_operation/gpio_setter/i_gpio_setter.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/file_loader.hpp"
+#include "infra/gpio_operation/gpio_setter.hpp"
+#include "infra/logger.hpp"
 
 #include <memory>
 #include <string>

--- a/include/infra/file_loader.hpp
+++ b/include/infra/file_loader.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 
 #include <memory>
 #include <string>

--- a/include/infra/gpio_operation/gpio_reader.hpp
+++ b/include/infra/gpio_operation/gpio_reader.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "infra/logger/i_logger.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
+#include "infra/logger.hpp"
+#include "infra/file_loader.hpp"
 
 #include <memory>
 

--- a/include/infra/gpio_operation/gpio_setter.hpp
+++ b/include/infra/gpio_operation/gpio_setter.hpp
@@ -2,8 +2,8 @@
 
 // GPIOSetter インターフェースおよび実装
 
-#include "infra/logger/i_logger.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
+#include "infra/logger.hpp"
+#include "infra/file_loader.hpp"
 
 #include <memory>
 

--- a/include/infra/logger.hpp
+++ b/include/infra/logger.hpp
@@ -1,10 +1,18 @@
 #pragma once
 
-#include "infra/logger/i_logger.hpp"
 #include <spdlog/logger.h>
 #include <memory>
+#include <string>
 
 namespace device_reminder {
+
+class ILogger {
+public:
+    virtual ~ILogger() = default;
+    virtual void info(const std::string& msg) = 0;
+    virtual void error(const std::string& msg) = 0;
+    virtual void warn(const std::string& msg) = 0;
+};
 
 class Logger : public ILogger {
 public:

--- a/include/infra/message/message.hpp
+++ b/include/infra/message/message.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "infra/message/message_type.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include <memory>
 #include <string>
 #include <vector>

--- a/include/infra/message/message_codec.hpp
+++ b/include/infra/message/message_codec.hpp
@@ -5,7 +5,7 @@
 #include <memory>
 #include <vector>
 
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "infra/message/message.hpp"
 
 namespace device_reminder {

--- a/include/infra/message/message_dispatcher.hpp
+++ b/include/infra/message/message_dispatcher.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "infra/message/message.hpp"
 
 #include <memory>

--- a/include/infra/message/message_queue.hpp
+++ b/include/infra/message/message_queue.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "infra/message/message.hpp"
 
 #include <condition_variable>

--- a/include/infra/message/message_receiver.hpp
+++ b/include/infra/message/message_receiver.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "infra/message/message_dispatcher.hpp"
 #include "infra/message/message_queue.hpp"
 

--- a/include/infra/message/process_sender.hpp
+++ b/include/infra/message/process_sender.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "infra/message/message.hpp"
 #include "infra/message/message_codec.hpp"
 #include "infra/message/message_queue.hpp"

--- a/include/infra/message/thread_sender.hpp
+++ b/include/infra/message/thread_sender.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "infra/message/message_queue.hpp"
 #include "infra/message/message.hpp"
 

--- a/include/infra/pir_driver/pir_driver.hpp
+++ b/include/infra/pir_driver/pir_driver.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "infra/file_loader/i_file_loader.hpp"
+#include "infra/file_loader.hpp"
 #include "infra/gpio_operation/gpio_reader.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 
 #include <atomic>
 #include <memory>

--- a/include/infra/process/process.hpp
+++ b/include/infra/process/process.hpp
@@ -2,7 +2,7 @@
 
 #include "infra/message/message_receiver.hpp"
 #include "infra/file_loader.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 
 #include <atomic>
 #include <memory>

--- a/include/infra/timer_service/timer_service.hpp
+++ b/include/infra/timer_service/timer_service.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "infra/logger/i_logger.hpp"
-#include "infra/thread_operation/thread_sender/i_thread_sender.hpp"
+#include "infra/logger.hpp"
+#include "infra/message/thread_sender.hpp"
 
 #include <atomic>
 #include <exception>

--- a/src/infra/bluetooth_driver/bluetooth_driver.cpp
+++ b/src/infra/bluetooth_driver/bluetooth_driver.cpp
@@ -1,7 +1,7 @@
 #include "bluetooth_driver/bluetooth_driver.hpp"
 
 #include "bluetooth_driver/bluetooth_scanner.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 
 #include <string>
 #include <utility>

--- a/src/infra/logger.cpp
+++ b/src/infra/logger.cpp
@@ -1,4 +1,4 @@
-#include "infra/logger/logger.hpp"
+#include "infra/logger.hpp"
 
 namespace device_reminder {
 

--- a/src/infra/message/process_sender.cpp
+++ b/src/infra/message/process_sender.cpp
@@ -1,6 +1,6 @@
 #include "infra/message/process_sender.hpp"
 
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "infra/message/message_codec.hpp"
 #include "infra/message/message_queue.hpp"
 

--- a/tests/integration/core/bluetooth_task/test_bluetooth_dispatcher.cpp
+++ b/tests/integration/core/bluetooth_task/test_bluetooth_dispatcher.cpp
@@ -2,7 +2,7 @@
 #include <gtest/gtest.h>
 
 #include "core/bluetooth_task/bluetooth_handler.hpp"
-#include "infra/process_operation/process_message/process_message.hpp"
+#include "infra/message/message.hpp"
 
 using ::testing::StrictMock;
 

--- a/tests/integration/core/bluetooth_task/test_bluetooth_handler.cpp
+++ b/tests/integration/core/bluetooth_task/test_bluetooth_handler.cpp
@@ -3,9 +3,9 @@
 #include <vector>
 
 #include "bluetooth_task/bluetooth_task.hpp"
-#include "infra/bluetooth_driver/i_bluetooth_driver.hpp"
-#include "infra/process_operation/process_sender/i_process_sender.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
+#include "infra/bluetooth_driver/bluetooth_driver.hpp"
+#include "infra/message/process_sender.hpp"
+#include "infra/file_loader.hpp"
 
 using namespace std;
 

--- a/tests/integration/core/buzzer_task/test_buzzer_dispatcher.cpp
+++ b/tests/integration/core/buzzer_task/test_buzzer_dispatcher.cpp
@@ -2,7 +2,7 @@
 #include <gmock/gmock.h>
 
 #include "buzzer_task/buzzer_handler.hpp"
-#include "infra/process_operation/process_message/process_message.hpp"
+#include "infra/message/message.hpp"
 
 using ::testing::StrictMock;
 using ::testing::NiceMock;

--- a/tests/integration/core/buzzer_task/test_buzzer_handler.cpp
+++ b/tests/integration/core/buzzer_task/test_buzzer_handler.cpp
@@ -2,7 +2,7 @@
 #include <gmock/gmock.h>
 
 #include "buzzer_task/buzzer_task.hpp"
-#include "infra/thread_operation/thread_message/thread_message.hpp"
+#include "infra/message/message.hpp"
 
 using ::testing::StrictMock;
 using ::testing::NiceMock;

--- a/tests/integration/core/human_task/test_human_dispatcher.cpp
+++ b/tests/integration/core/human_task/test_human_dispatcher.cpp
@@ -2,7 +2,7 @@
 #include <gmock/gmock.h>
 
 #include "human_task/human_handler.hpp"
-#include "infra/process_operation/process_message/process_message.hpp"
+#include "infra/message/message.hpp"
 
 using ::testing::StrictMock;
 using ::testing::NiceMock;

--- a/tests/integration/core/main_task/test_main_dispatcher.cpp
+++ b/tests/integration/core/main_task/test_main_dispatcher.cpp
@@ -2,7 +2,7 @@
 #include <gmock/gmock.h>
 
 #include "main_task/main_handler.hpp"
-#include "infra/process_operation/process_message/process_message.hpp"
+#include "infra/message/message.hpp"
 
 using ::testing::StrictMock;
 

--- a/tests/integration/core/main_task/test_main_handler.cpp
+++ b/tests/integration/core/main_task/test_main_handler.cpp
@@ -2,9 +2,9 @@
 #include <gmock/gmock.h>
 
 #include "main_task/main_task.hpp"
-#include "infra/thread_operation/thread_message/thread_message.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
-#include "infra/process_operation/process_sender/i_process_sender.hpp"
+#include "infra/message/message.hpp"
+#include "infra/file_loader.hpp"
+#include "infra/message/process_sender.hpp"
 
 using ::testing::StrictMock;
 using ::testing::NiceMock;

--- a/tests/integration/infra/bluetooth_driver/test_bluetooth_driver.cpp
+++ b/tests/integration/infra/bluetooth_driver/test_bluetooth_driver.cpp
@@ -2,11 +2,11 @@
 #include <gmock/gmock.h>
 
 #include "infra/bluetooth_driver/bluetooth_driver.hpp"
-#include "infra/bluetooth_driver/i_bluetooth_scanner.hpp"
-#include "infra/bluetooth_driver/i_bluetooth_pairer.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
-#include "infra/thread_operation/thread_sender/i_thread_sender.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/bluetooth_driver/bluetooth_scanner.hpp"
+#include "infra/bluetooth_driver/bluetooth_pairer.hpp"
+#include "infra/file_loader.hpp"
+#include "infra/message/thread_sender.hpp"
+#include "infra/logger.hpp"
 
 using ::testing::Return;
 using ::testing::StrictMock;

--- a/tests/integration/infra/buzzer_driver/test_buzzer_driver.cpp
+++ b/tests/integration/infra/buzzer_driver/test_buzzer_driver.cpp
@@ -2,8 +2,8 @@
 #include <gmock/gmock.h>
 
 #include "infra/buzzer_driver/buzzer_driver.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
-#include "infra/gpio_operation/gpio_setter/i_gpio_setter.hpp"
+#include "infra/file_loader.hpp"
+#include "infra/gpio_operation/gpio_setter.hpp"
 
 using namespace device_reminder;
 using ::testing::NiceMock;

--- a/tests/integration/infra/gpio_operation/test_gpio_reader.cpp
+++ b/tests/integration/infra/gpio_operation/test_gpio_reader.cpp
@@ -3,7 +3,7 @@
 
 #include "infra/gpio_operation/gpio_reader/gpio_reader.hpp"
 
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "stubs/gpiod_stub.h"
 
 using namespace device_reminder;

--- a/tests/integration/infra/gpio_operation/test_gpio_setter.cpp
+++ b/tests/integration/infra/gpio_operation/test_gpio_setter.cpp
@@ -3,7 +3,7 @@
 #include <gmock/gmock.h>
 
 #include "infra/gpio_operation/gpio_setter/gpio_setter.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "stubs/gpiod_stub.h"
 #include <memory>
 

--- a/tests/integration/infra/message/test_message.cpp
+++ b/tests/integration/infra/message/test_message.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include "infra/thread_operation/thread_message/thread_message.hpp"
+#include "infra/message/message.hpp"
 
 using namespace device_reminder;
 

--- a/tests/integration/infra/message/test_message_codec.cpp
+++ b/tests/integration/infra/message/test_message_codec.cpp
@@ -1,9 +1,9 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "infra/process_operation/message_codec/message_codec.hpp"
-#include "infra/process_operation/process_message/process_message.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/message/message_codec.hpp"
+#include "infra/message/message.hpp"
+#include "infra/logger.hpp"
 
 using ::testing::StrictMock;
 using ::testing::NiceMock;

--- a/tests/integration/infra/message/test_message_dispatcher.cpp
+++ b/tests/integration/infra/message/test_message_dispatcher.cpp
@@ -1,9 +1,9 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "infra/thread_operation/thread_dispatcher/thread_dispatcher.hpp"
-#include "infra/thread_operation/thread_message/thread_message.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/message/message_dispatcher.hpp"
+#include "infra/message/message.hpp"
+#include "infra/logger.hpp"
 
 using ::testing::NiceMock;
 

--- a/tests/integration/infra/message/test_message_queue.cpp
+++ b/tests/integration/infra/message/test_message_queue.cpp
@@ -1,9 +1,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "infra/logger/i_logger.hpp"
-#include "infra/thread_operation/thread_message/thread_message.hpp"
-#include "infra/thread_operation/thread_queue/thread_queue.hpp"
+#include "infra/logger.hpp"
+#include "infra/message/message.hpp"
+#include "infra/message/message_queue.hpp"
 
 using namespace device_reminder;
 using ::testing::NiceMock;

--- a/tests/integration/infra/message/test_message_receiver.cpp
+++ b/tests/integration/infra/message/test_message_receiver.cpp
@@ -2,10 +2,10 @@
 #include <thread>
 #include <mutex>
 #include <condition_variable>
-#include "infra/thread_operation/thread_receiver/thread_receiver.hpp"
-#include "infra/thread_operation/thread_queue/thread_queue.hpp"
-#include "infra/thread_operation/thread_dispatcher/i_thread_dispatcher.hpp"
-#include "infra/thread_operation/thread_message/thread_message.hpp"
+#include "infra/message/message_receiver.hpp"
+#include "infra/message/message_queue.hpp"
+#include "infra/message/message_dispatcher.hpp"
+#include "infra/message/message.hpp"
 
 using namespace device_reminder;
 

--- a/tests/integration/infra/message/test_process_sender.cpp
+++ b/tests/integration/infra/message/test_process_sender.cpp
@@ -1,12 +1,12 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "infra/process_operation/process_sender/process_sender.hpp"
-#include "infra/process_operation/process_queue/i_process_queue.hpp"
-#include "infra/process_operation/process_queue/process_queue.hpp"
-#include "infra/process_operation/process_message/process_message.hpp"
-#include "infra/process_operation/message_codec/message_codec.hpp"
-#include "infra/logger/logger.hpp"
+#include "infra/message/process_sender.hpp"
+#include "infra/message/message_queue.hpp"
+#include "infra/message/message_queue.hpp"
+#include "infra/message/message.hpp"
+#include "infra/message/message_codec.hpp"
+#include "infra/logger.hpp"
 #include "posix_mq_stub.h"
 
 using namespace device_reminder;

--- a/tests/integration/infra/message/test_thread_sender.cpp
+++ b/tests/integration/infra/message/test_thread_sender.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "infra/message/message.hpp"
 #include "infra/message/message_queue.hpp"
 #include "infra/message/message_type.hpp"

--- a/tests/integration/infra/pir_driver/test_pir_driver.cpp
+++ b/tests/integration/infra/pir_driver/test_pir_driver.cpp
@@ -3,10 +3,10 @@
 #include <thread>
 
 #include "infra/pir_driver/pir_driver.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
-#include "infra/gpio_operation/gpio_reader/i_gpio_reader.hpp"
-#include "infra/thread_operation/thread_sender/i_thread_sender.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/file_loader.hpp"
+#include "infra/gpio_operation/gpio_reader.hpp"
+#include "infra/message/thread_sender.hpp"
+#include "infra/logger.hpp"
 
 using namespace device_reminder;
 using ::testing::StrictMock;

--- a/tests/integration/infra/process/test_process.cpp
+++ b/tests/integration/infra/process/test_process.cpp
@@ -1,13 +1,13 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "infra/process_operation/process_base/process_base.hpp"
-#include "infra/process_operation/process_queue/i_process_queue.hpp"
-#include "infra/process_operation/process_receiver/i_process_receiver.hpp"
-#include "infra/process_operation/process_dispatcher/i_process_dispatcher.hpp"
-#include "infra/process_operation/process_sender/i_process_sender.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/process/process.hpp"
+#include "infra/message/message_queue.hpp"
+#include "infra/message/message_receiver.hpp"
+#include "infra/message/message_dispatcher.hpp"
+#include "infra/message/process_sender.hpp"
+#include "infra/file_loader.hpp"
+#include "infra/logger.hpp"
 
 #include <thread>
 #include <memory>

--- a/tests/integration/infra/test_file_loader.cpp
+++ b/tests/integration/infra/test_file_loader.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "infra/file_loader/file_loader.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/file_loader.hpp"
+#include "infra/logger.hpp"
 
 #include <fstream>
 

--- a/tests/integration/infra/test_logger.cpp
+++ b/tests/integration/infra/test_logger.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "infra/logger/logger.hpp"
+#include "infra/logger.hpp"
 
 #include <spdlog/logger.h>
 #include <spdlog/sinks/sink.h>

--- a/tests/integration/infra/timer_service/test_timer_service.cpp
+++ b/tests/integration/infra/timer_service/test_timer_service.cpp
@@ -2,8 +2,8 @@
 #include <gmock/gmock.h>
 
 #include "infra/timer_service/timer_service.hpp"
-#include "infra/thread_operation/thread_sender/i_thread_sender.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/message/thread_sender.hpp"
+#include "infra/logger.hpp"
 
 #include <chrono>
 #include <thread>

--- a/tests/unit/core/bluetooth_task/test_bluetooth_dispatcher.cpp
+++ b/tests/unit/core/bluetooth_task/test_bluetooth_dispatcher.cpp
@@ -2,7 +2,7 @@
 #include <gtest/gtest.h>
 
 #include "core/bluetooth_task/bluetooth_handler.hpp"
-#include "infra/process_operation/process_message/process_message.hpp"
+#include "infra/message/message.hpp"
 
 using ::testing::StrictMock;
 

--- a/tests/unit/core/bluetooth_task/test_bluetooth_handler.cpp
+++ b/tests/unit/core/bluetooth_task/test_bluetooth_handler.cpp
@@ -3,9 +3,9 @@
 #include <vector>
 
 #include "bluetooth_task/bluetooth_task.hpp"
-#include "infra/bluetooth_driver/i_bluetooth_driver.hpp"
-#include "infra/process_operation/process_sender/i_process_sender.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
+#include "infra/bluetooth_driver/bluetooth_driver.hpp"
+#include "infra/message/process_sender.hpp"
+#include "infra/file_loader.hpp"
 
 using namespace std;
 

--- a/tests/unit/core/buzzer_task/test_buzzer_dispatcher.cpp
+++ b/tests/unit/core/buzzer_task/test_buzzer_dispatcher.cpp
@@ -2,7 +2,7 @@
 #include <gmock/gmock.h>
 
 #include "buzzer_task/buzzer_handler.hpp"
-#include "infra/process_operation/process_message/process_message.hpp"
+#include "infra/message/message.hpp"
 
 using ::testing::StrictMock;
 using ::testing::NiceMock;

--- a/tests/unit/core/buzzer_task/test_buzzer_handler.cpp
+++ b/tests/unit/core/buzzer_task/test_buzzer_handler.cpp
@@ -2,7 +2,7 @@
 #include <gmock/gmock.h>
 
 #include "buzzer_task/buzzer_task.hpp"
-#include "infra/thread_operation/thread_message/thread_message.hpp"
+#include "infra/message/message.hpp"
 
 using ::testing::StrictMock;
 using ::testing::NiceMock;

--- a/tests/unit/core/human_task/test_human_dispatcher.cpp
+++ b/tests/unit/core/human_task/test_human_dispatcher.cpp
@@ -2,7 +2,7 @@
 #include <gmock/gmock.h>
 
 #include "human_task/human_handler.hpp"
-#include "infra/process_operation/process_message/process_message.hpp"
+#include "infra/message/message.hpp"
 
 using ::testing::StrictMock;
 using ::testing::NiceMock;

--- a/tests/unit/core/main_task/test_main_dispatcher.cpp
+++ b/tests/unit/core/main_task/test_main_dispatcher.cpp
@@ -2,7 +2,7 @@
 #include <gmock/gmock.h>
 
 #include "main_task/main_handler.hpp"
-#include "infra/process_operation/process_message/process_message.hpp"
+#include "infra/message/message.hpp"
 
 using ::testing::StrictMock;
 

--- a/tests/unit/core/main_task/test_main_handler.cpp
+++ b/tests/unit/core/main_task/test_main_handler.cpp
@@ -2,9 +2,9 @@
 #include <gmock/gmock.h>
 
 #include "main_task/main_task.hpp"
-#include "infra/thread_operation/thread_message/thread_message.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
-#include "infra/process_operation/process_sender/i_process_sender.hpp"
+#include "infra/message/message.hpp"
+#include "infra/file_loader.hpp"
+#include "infra/message/process_sender.hpp"
 
 using ::testing::StrictMock;
 using ::testing::NiceMock;

--- a/tests/unit/infra/bluetooth_driver/test_bluetooth_driver.cpp
+++ b/tests/unit/infra/bluetooth_driver/test_bluetooth_driver.cpp
@@ -2,11 +2,11 @@
 #include <gmock/gmock.h>
 
 #include "infra/bluetooth_driver/bluetooth_driver.hpp"
-#include "infra/bluetooth_driver/i_bluetooth_scanner.hpp"
-#include "infra/bluetooth_driver/i_bluetooth_pairer.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
-#include "infra/thread_operation/thread_sender/i_thread_sender.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/bluetooth_driver/bluetooth_scanner.hpp"
+#include "infra/bluetooth_driver/bluetooth_pairer.hpp"
+#include "infra/file_loader.hpp"
+#include "infra/message/thread_sender.hpp"
+#include "infra/logger.hpp"
 
 using ::testing::Return;
 using ::testing::StrictMock;

--- a/tests/unit/infra/buzzer_driver/test_buzzer_driver.cpp
+++ b/tests/unit/infra/buzzer_driver/test_buzzer_driver.cpp
@@ -2,8 +2,8 @@
 #include <gmock/gmock.h>
 
 #include "infra/buzzer_driver/buzzer_driver.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
-#include "infra/gpio_operation/gpio_setter/i_gpio_setter.hpp"
+#include "infra/file_loader.hpp"
+#include "infra/gpio_operation/gpio_setter.hpp"
 
 using namespace device_reminder;
 using ::testing::NiceMock;

--- a/tests/unit/infra/gpio_operation/test_gpio_reader.cpp
+++ b/tests/unit/infra/gpio_operation/test_gpio_reader.cpp
@@ -3,7 +3,7 @@
 
 #include "infra/gpio_operation/gpio_reader/gpio_reader.hpp"
 
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "stubs/gpiod_stub.h"
 
 using namespace device_reminder;

--- a/tests/unit/infra/gpio_operation/test_gpio_setter.cpp
+++ b/tests/unit/infra/gpio_operation/test_gpio_setter.cpp
@@ -3,7 +3,7 @@
 #include <gmock/gmock.h>
 
 #include "infra/gpio_operation/gpio_setter/gpio_setter.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "stubs/gpiod_stub.h"
 #include <memory>
 

--- a/tests/unit/infra/message/test_message.cpp
+++ b/tests/unit/infra/message/test_message.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include "infra/thread_operation/thread_message/thread_message.hpp"
+#include "infra/message/message.hpp"
 
 using namespace device_reminder;
 

--- a/tests/unit/infra/message/test_message_codec.cpp
+++ b/tests/unit/infra/message/test_message_codec.cpp
@@ -1,9 +1,9 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "infra/process_operation/message_codec/message_codec.hpp"
-#include "infra/process_operation/process_message/process_message.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/message/message_codec.hpp"
+#include "infra/message/message.hpp"
+#include "infra/logger.hpp"
 
 using ::testing::StrictMock;
 using ::testing::NiceMock;

--- a/tests/unit/infra/message/test_message_dispatcher.cpp
+++ b/tests/unit/infra/message/test_message_dispatcher.cpp
@@ -1,9 +1,9 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "infra/thread_operation/thread_dispatcher/thread_dispatcher.hpp"
-#include "infra/thread_operation/thread_message/thread_message.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/message/message_dispatcher.hpp"
+#include "infra/message/message.hpp"
+#include "infra/logger.hpp"
 
 using ::testing::NiceMock;
 

--- a/tests/unit/infra/message/test_message_queue.cpp
+++ b/tests/unit/infra/message/test_message_queue.cpp
@@ -1,9 +1,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "infra/logger/i_logger.hpp"
-#include "infra/thread_operation/thread_message/thread_message.hpp"
-#include "infra/thread_operation/thread_queue/thread_queue.hpp"
+#include "infra/logger.hpp"
+#include "infra/message/message.hpp"
+#include "infra/message/message_queue.hpp"
 
 using namespace device_reminder;
 using ::testing::NiceMock;

--- a/tests/unit/infra/message/test_message_receiver.cpp
+++ b/tests/unit/infra/message/test_message_receiver.cpp
@@ -2,10 +2,10 @@
 #include <thread>
 #include <mutex>
 #include <condition_variable>
-#include "infra/thread_operation/thread_receiver/thread_receiver.hpp"
-#include "infra/thread_operation/thread_queue/thread_queue.hpp"
-#include "infra/thread_operation/thread_dispatcher/i_thread_dispatcher.hpp"
-#include "infra/thread_operation/thread_message/thread_message.hpp"
+#include "infra/message/message_receiver.hpp"
+#include "infra/message/message_queue.hpp"
+#include "infra/message/message_dispatcher.hpp"
+#include "infra/message/message.hpp"
 
 using namespace device_reminder;
 

--- a/tests/unit/infra/message/test_process_sender.cpp
+++ b/tests/unit/infra/message/test_process_sender.cpp
@@ -1,12 +1,12 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "infra/process_operation/process_sender/process_sender.hpp"
-#include "infra/process_operation/process_queue/i_process_queue.hpp"
-#include "infra/process_operation/process_queue/process_queue.hpp"
-#include "infra/process_operation/process_message/process_message.hpp"
-#include "infra/process_operation/message_codec/message_codec.hpp"
-#include "infra/logger/logger.hpp"
+#include "infra/message/process_sender.hpp"
+#include "infra/message/message_queue.hpp"
+#include "infra/message/message_queue.hpp"
+#include "infra/message/message.hpp"
+#include "infra/message/message_codec.hpp"
+#include "infra/logger.hpp"
 #include "posix_mq_stub.h"
 
 using namespace device_reminder;

--- a/tests/unit/infra/message/test_thread_sender.cpp
+++ b/tests/unit/infra/message/test_thread_sender.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "infra/logger/i_logger.hpp"
+#include "infra/logger.hpp"
 #include "infra/message/message.hpp"
 #include "infra/message/message_queue.hpp"
 #include "infra/message/message_type.hpp"

--- a/tests/unit/infra/pir_driver/test_pir_driver.cpp
+++ b/tests/unit/infra/pir_driver/test_pir_driver.cpp
@@ -3,10 +3,10 @@
 #include <thread>
 
 #include "infra/pir_driver/pir_driver.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
-#include "infra/gpio_operation/gpio_reader/i_gpio_reader.hpp"
-#include "infra/thread_operation/thread_sender/i_thread_sender.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/file_loader.hpp"
+#include "infra/gpio_operation/gpio_reader.hpp"
+#include "infra/message/thread_sender.hpp"
+#include "infra/logger.hpp"
 
 using namespace device_reminder;
 using ::testing::StrictMock;

--- a/tests/unit/infra/process/test_process.cpp
+++ b/tests/unit/infra/process/test_process.cpp
@@ -1,13 +1,13 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "infra/process_operation/process_base/process_base.hpp"
-#include "infra/process_operation/process_queue/i_process_queue.hpp"
-#include "infra/process_operation/process_receiver/i_process_receiver.hpp"
-#include "infra/process_operation/process_dispatcher/i_process_dispatcher.hpp"
-#include "infra/process_operation/process_sender/i_process_sender.hpp"
-#include "infra/file_loader/i_file_loader.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/process/process.hpp"
+#include "infra/message/message_queue.hpp"
+#include "infra/message/message_receiver.hpp"
+#include "infra/message/message_dispatcher.hpp"
+#include "infra/message/process_sender.hpp"
+#include "infra/file_loader.hpp"
+#include "infra/logger.hpp"
 
 #include <thread>
 #include <memory>

--- a/tests/unit/infra/test_file_loader.cpp
+++ b/tests/unit/infra/test_file_loader.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "infra/file_loader/file_loader.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/file_loader.hpp"
+#include "infra/logger.hpp"
 
 #include <fstream>
 

--- a/tests/unit/infra/test_logger.cpp
+++ b/tests/unit/infra/test_logger.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "infra/logger/logger.hpp"
+#include "infra/logger.hpp"
 
 #include <spdlog/logger.h>
 #include <spdlog/sinks/sink.h>

--- a/tests/unit/infra/timer_service/test_timer_service.cpp
+++ b/tests/unit/infra/timer_service/test_timer_service.cpp
@@ -2,8 +2,8 @@
 #include <gmock/gmock.h>
 
 #include "infra/timer_service/timer_service.hpp"
-#include "infra/thread_operation/thread_sender/i_thread_sender.hpp"
-#include "infra/logger/i_logger.hpp"
+#include "infra/message/thread_sender.hpp"
+#include "infra/logger.hpp"
 
 #include <chrono>
 #include <thread>


### PR DESCRIPTION
## Summary
- refactor logger header and update include paths across project
- add project root to include directories for dependency headers

## Testing
- `cmake -S . -B build` *(pass)*
- `cmake --build build --target device_reminder` *(fail: missing core/main_task/main_task.hpp)*


------
https://chatgpt.com/codex/tasks/task_e_689c3cafdb748328aa67fb119104b9e6