### PR TITLE
AppがIProcessを所有するようunique_ptrに変更

### DIFF
--- a/include/core/app/app.hpp
+++ b/include/core/app/app.hpp
@@ -1,26 +1,27 @@
 #pragma once
 #include "infra/process/process.hpp"
 #include "infra/logger.hpp"
+#include <memory>
 
 namespace device_reminder {
 
 
 class App {
 public:
-    App(IProcess& main_process,
-        IProcess& human_process,
-        IProcess& bluetooth_process,
-        IProcess& buzzer_process,
-        ILogger& logger);
+    App(std::unique_ptr<IProcess> main_process,
+        std::unique_ptr<IProcess> human_process,
+        std::unique_ptr<IProcess> bluetooth_process,
+        std::unique_ptr<IProcess> buzzer_process,
+        std::unique_ptr<ILogger> logger);
 
     void run();
 
 private:
-    IProcess& main_process_;
-    IProcess& human_process_;
-    IProcess& bluetooth_process_;
-    IProcess& buzzer_process_;
-    ILogger& logger_;
+    std::unique_ptr<IProcess> main_process_;
+    std::unique_ptr<IProcess> human_process_;
+    std::unique_ptr<IProcess> bluetooth_process_;
+    std::unique_ptr<IProcess> buzzer_process_;
+    std::unique_ptr<ILogger> logger_;
 };
 
 } // namespace device_reminder

--- a/src/core/app/app.cpp
+++ b/src/core/app/app.cpp
@@ -2,46 +2,47 @@
 
 #include <array>
 #include <string>
+#include <utility>
 
 namespace device_reminder {
 
-App::App(IProcess& main_process,
-         IProcess& human_process,
-         IProcess& bluetooth_process,
-         IProcess& buzzer_process,
-         ILogger& logger)
-    : main_process_(main_process)
-    , human_process_(human_process)
-    , bluetooth_process_(bluetooth_process)
-    , buzzer_process_(buzzer_process)
-    , logger_(logger) {}
+App::App(std::unique_ptr<IProcess> main_process,
+         std::unique_ptr<IProcess> human_process,
+         std::unique_ptr<IProcess> bluetooth_process,
+         std::unique_ptr<IProcess> buzzer_process,
+         std::unique_ptr<ILogger> logger)
+    : main_process_(std::move(main_process))
+    , human_process_(std::move(human_process))
+    , bluetooth_process_(std::move(bluetooth_process))
+    , buzzer_process_(std::move(buzzer_process))
+    , logger_(std::move(logger)) {}
 
 void App::run() {
-    logger_.info("App.run 開始");
+    logger_->info("App.run 開始");
     try {
         struct ProcessInfo {
             const char* name;
-            IProcess& process;
+            IProcess* process;
         };
         std::array<ProcessInfo, 4> processes = {{
-            {"main_process", main_process_},
-            {"human_process", human_process_},
-            {"bluetooth_process", bluetooth_process_},
-            {"buzzer_process", buzzer_process_},
+            {"main_process", main_process_.get()},
+            {"human_process", human_process_.get()},
+            {"bluetooth_process", bluetooth_process_.get()},
+            {"buzzer_process", buzzer_process_.get()},
         }};
 
         for (auto& info : processes) {
-            logger_.info(std::string(info.name) + " 起動開始");
-            info.process.run();
-            logger_.info(std::string(info.name) + " 起動完了");
+            logger_->info(std::string(info.name) + " 起動開始");
+            info.process->run();
+            logger_->info(std::string(info.name) + " 起動完了");
         }
 
-        logger_.info("App.run 成功（全タスク起動）");
+        logger_->info("App.run 成功（全タスク起動）");
     } catch (const std::exception& e) {
-        logger_.error(std::string("App.run 失敗: ") + e.what());
+        logger_->error(std::string("App.run 失敗: ") + e.what());
         throw;
     } catch (...) {
-        logger_.error("App.run 失敗: 不明な例外");
+        logger_->error("App.run 失敗: 不明な例外");
         throw;
     }
 }


### PR DESCRIPTION
## Summary
- Appのコンストラクタを`std::unique_ptr<IProcess>`および`std::unique_ptr<ILogger>`で受け取り、メンバとして所有するように変更
- 各プロセスとロガー呼び出しをポインタ経由に修正

## Testing
- `cmake -S . -B build` (成功)
- `cmake --build build` (core/main_task/main_task.hppが存在せずビルド失敗)


------
https://chatgpt.com/codex/tasks/task_e_689c6246321083289398265853e14701