### PR TITLE
Add logger dependency to Message

### DIFF
--- a/include/infra/message/message.hpp
+++ b/include/infra/message/message.hpp
@@ -18,7 +18,9 @@ public:
 
 class Message : public IMessage {
 public:
-    Message(MessageType type, std::vector<std::string> payload);
+    Message(MessageType type,
+            std::vector<std::string> payload,
+            std::shared_ptr<ILogger> logger);
 
     MessageType type() const override;
     std::vector<std::string> payload() const override;

--- a/src/infra/message/message.cpp
+++ b/src/infra/message/message.cpp
@@ -5,8 +5,12 @@
 
 namespace device_reminder {
 
-Message::Message(MessageType type, std::vector<std::string> payload)
-    : type_{type}, payload_{std::move(payload)} {}
+Message::Message(MessageType type,
+                 std::vector<std::string> payload,
+                 std::shared_ptr<ILogger> logger)
+    : type_{type},
+      payload_{std::move(payload)},
+      logger_{std::move(logger)} {}
 
 MessageType Message::type() const {
     if (logger_) logger_->info("type start");

--- a/tests/integration/core/bluetooth_task/test_bluetooth_dispatcher.cpp
+++ b/tests/integration/core/bluetooth_task/test_bluetooth_dispatcher.cpp
@@ -35,7 +35,9 @@ TEST(BluetoothHandlerTest, RequestScanCallsTask) {
   EXPECT_CALL(*task, on_waiting(testing::_)).Times(1);
 
   auto msg = std::make_shared<ProcessMessage>(
-      ProcessMessageType::RequestBluetoothScan, std::vector<std::string>{});
+      ProcessMessageType::RequestBluetoothScan,
+      std::vector<std::string>{},
+      nullptr);
   handler.handle(msg);
 }
 
@@ -47,7 +49,9 @@ TEST(BluetoothHandlerTest, OtherMessageIgnored) {
   EXPECT_CALL(*task, on_waiting(testing::_)).Times(0);
 
   auto msg = std::make_shared<ProcessMessage>(
-      ProcessMessageType::StartHumanDetection, std::vector<std::string>{});
+      ProcessMessageType::StartHumanDetection,
+      std::vector<std::string>{},
+      nullptr);
   handler.handle(msg);
 }
 
@@ -76,7 +80,9 @@ TEST(BluetoothHandlerTest, HandleWithoutTaskDoesNothingAndNoLog) {
   EXPECT_CALL(*logger, info(testing::_)).Times(0);
   BluetoothHandler handler(logger, nullptr);
   auto msg = std::make_shared<ProcessMessage>(
-      ProcessMessageType::RequestBluetoothScan, std::vector<std::string>{});
+      ProcessMessageType::RequestBluetoothScan,
+      std::vector<std::string>{},
+      nullptr);
   handler.handle(msg);
 }
 
@@ -90,7 +96,9 @@ TEST(BluetoothHandlerTest, HandleLogsAndCallsTask) {
   EXPECT_CALL(*task, on_waiting(testing::_)).Times(1);
 
   auto msg = std::make_shared<ProcessMessage>(
-      ProcessMessageType::RequestBluetoothScan, std::vector<std::string>{});
+      ProcessMessageType::RequestBluetoothScan,
+      std::vector<std::string>{},
+      nullptr);
   handler.handle(msg);
 }
 

--- a/tests/integration/core/buzzer_task/test_buzzer_dispatcher.cpp
+++ b/tests/integration/core/buzzer_task/test_buzzer_dispatcher.cpp
@@ -46,7 +46,10 @@ TEST(BuzzerHandlerTest, StartBuzzingStartsTimerAndCallsTask) {
     EXPECT_CALL(*task, on_buzzing(testing::_)).Times(1);
     EXPECT_CALL(*timer, start()).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -59,7 +62,10 @@ TEST(BuzzerHandlerTest, StopBuzzingStopsTimerAndCallsTask) {
     EXPECT_CALL(*task, on_waiting(testing::_)).Times(1);
     EXPECT_CALL(*timer, stop()).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StopBuzzing, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StopBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -72,7 +78,10 @@ TEST(BuzzerHandlerTest, TimeoutStopsTimerAndCallsTask) {
     EXPECT_CALL(*task, on_waiting(testing::_)).Times(1);
     EXPECT_CALL(*timer, stop()).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::BuzzTimeout, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::BuzzTimeout,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -115,7 +124,10 @@ TEST(BuzzerHandlerTest, StartBuzzingWithoutTimer) {
         EXPECT_CALL(logger, info("StartBuzzing")).Times(1);
     }
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -135,7 +147,10 @@ TEST(BuzzerHandlerTest, StartBuzzingLogsMessage) {
                           std::shared_ptr<IBuzzerTask>(&task, [](IBuzzerTask*){}),
                           std::shared_ptr<ITimerService>(&timer, [](ITimerService*){}));
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 

--- a/tests/integration/core/buzzer_task/test_buzzer_handler.cpp
+++ b/tests/integration/core/buzzer_task/test_buzzer_handler.cpp
@@ -44,11 +44,11 @@ TEST(BuzzerTaskTest, StartAndTimeoutStopsBuzzer) {
     BuzzerTask task(logger, sender, loader, driver);
 
     EXPECT_CALL(*driver, on());
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}, nullptr});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 
     EXPECT_CALL(*driver, off());
-    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzing, {}, nullptr});
     EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
 }
 
@@ -61,10 +61,10 @@ TEST(BuzzerTaskTest, ManualStopCancelsTimer) {
     BuzzerTask task(logger, sender, loader, driver);
 
     EXPECT_CALL(*driver, on());
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}, nullptr});
 
     EXPECT_CALL(*driver, off());
-    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzing, {}, nullptr});
     EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
 }
 
@@ -77,10 +77,10 @@ TEST(BuzzerTaskTest, IgnoreDuplicateStart) {
     BuzzerTask task(logger, sender, loader, driver);
 
     EXPECT_CALL(*driver, on());
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}, nullptr});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}, nullptr});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 }
 
@@ -113,7 +113,7 @@ TEST(BuzzerTaskTest, StartMessageTurnsOnDriver) {
     BuzzerTask task(logger, sender, loader, driver);
 
     EXPECT_CALL(*driver, on()).Times(1);
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}, nullptr});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 }
 
@@ -126,7 +126,7 @@ TEST(BuzzerTaskTest, StopMessageIgnoredWhenWaiting) {
     BuzzerTask task(logger, sender, loader, driver);
 
     EXPECT_CALL(*driver, off()).Times(0);
-    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzing, {}, nullptr});
     EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
 }
 
@@ -137,7 +137,7 @@ TEST(BuzzerTaskTest, StartMessageWorksWithoutDriver) {
 
     BuzzerTask task(logger, sender, loader, nullptr);
 
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}, nullptr});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 }
 

--- a/tests/integration/core/human_task/test_human_dispatcher.cpp
+++ b/tests/integration/core/human_task/test_human_dispatcher.cpp
@@ -45,7 +45,10 @@ TEST(HumanHandlerTest, StopDetectionStartsTimer) {
     EXPECT_CALL(*task, on_stopping(testing::_)).Times(1);
     EXPECT_CALL(*timer, start()).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StopHumanDetection, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StopHumanDetection,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -58,7 +61,10 @@ TEST(HumanHandlerTest, StartDetectionStopsTimer) {
     EXPECT_CALL(*task, on_detecting(testing::_)).Times(1);
     EXPECT_CALL(*timer, stop()).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartHumanDetection, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartHumanDetection,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -70,7 +76,10 @@ TEST(HumanHandlerTest, CooldownCallsTask) {
 
     EXPECT_CALL(*task, on_cooldown(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::CooldownTimeout, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::CooldownTimeout,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -111,7 +120,10 @@ TEST(HumanHandlerTest, HandleWithNullTaskDoesNothing) {
     EXPECT_CALL(*timer, start()).Times(0);
     EXPECT_CALL(*timer, stop()).Times(0);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartHumanDetection, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartHumanDetection,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -122,7 +134,10 @@ TEST(HumanHandlerTest, StartDetectionWithNullTimerOnlyCallsTask) {
 
     EXPECT_CALL(*task, on_detecting(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartHumanDetection, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartHumanDetection,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -134,7 +149,10 @@ TEST(HumanHandlerTest, StopDetectionWithNullLoggerWorks) {
     EXPECT_CALL(*timer, start()).Times(1);
     EXPECT_CALL(*task, on_stopping(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StopHumanDetection, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StopHumanDetection,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -148,7 +166,10 @@ TEST(HumanHandlerTest, UnknownMessageKeepsDetectingState) {
     EXPECT_CALL(*timer, stop()).Times(0);
     EXPECT_CALL(*task, on_detecting(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 

--- a/tests/integration/core/main_task/test_main_dispatcher.cpp
+++ b/tests/integration/core/main_task/test_main_dispatcher.cpp
@@ -32,7 +32,10 @@ TEST(MainHandlerTest, HumanDetectedCallsTask) {
 
     EXPECT_CALL(*task, on_waiting_for_human(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::HumanDetected, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::HumanDetected,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -43,7 +46,10 @@ TEST(MainHandlerTest, DeviceFoundCallsHumanControl) {
 
     EXPECT_CALL(*task, on_response_to_human_task(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::ResponseDevicePresence, std::vector<std::string>{"found"});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::ResponseDevicePresence,
+        std::vector<std::string>{"found"},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -54,7 +60,10 @@ TEST(MainHandlerTest, DeviceNotFoundCallsBuzzerControl) {
 
     EXPECT_CALL(*task, on_response_to_buzzer_task(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::ResponseDevicePresence, std::vector<std::string>{"none"});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::ResponseDevicePresence,
+        std::vector<std::string>{"none"},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -65,7 +74,10 @@ TEST(MainHandlerTest, CooldownCallsTask) {
 
     EXPECT_CALL(*task, on_cooldown(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::CooldownTimeout, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::CooldownTimeout,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -103,8 +115,10 @@ TEST(MainHandlerExtendedTest, ScanTimeoutCallsWaitingSecondResponse) {
 
     EXPECT_CALL(*task, on_waiting_for_second_response(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::ScanTimeout,
-                                                std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::ScanTimeout,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -117,7 +131,8 @@ TEST(MainHandlerExtendedTest, InvalidPayloadCallsBuzzerTask) {
 
     auto msg = std::make_shared<ProcessMessage>(
         ProcessMessageType::ResponseDevicePresence,
-        std::vector<std::string>{"invalid"});
+        std::vector<std::string>{"invalid"},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -133,7 +148,9 @@ TEST(MainHandlerExtendedTest, UnknownMessageTypeDoesNothing) {
     EXPECT_CALL(*task, on_waiting_for_second_response(testing::_)).Times(0);
 
     auto msg = std::make_shared<ProcessMessage>(
-        static_cast<ProcessMessageType>(999), std::vector<std::string>{});
+        static_cast<ProcessMessageType>(999),
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -163,7 +180,9 @@ TEST(MainHandlerExtendedTest, NullTaskCausesNoCall) {
     EXPECT_CALL(*dummy_task, on_waiting_for_second_response(testing::_)).Times(0);
 
     auto msg = std::make_shared<ProcessMessage>(
-        ProcessMessageType::HumanDetected, std::vector<std::string>{});
+        ProcessMessageType::HumanDetected,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 

--- a/tests/integration/core/main_task/test_main_handler.cpp
+++ b/tests/integration/core/main_task/test_main_handler.cpp
@@ -53,7 +53,7 @@ TEST(MainTaskTest, HumanDetectedStartsScanAndTimer) {
     EXPECT_CALL(*det_timer, start());
     EXPECT_CALL(*bt_sender, send());
 
-    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}, nullptr});
     EXPECT_EQ(task.state(), MainTask::State::WaitDeviceResponse);
 }
 
@@ -72,13 +72,13 @@ TEST(MainTaskTest, DeviceDetectedStopsTimerAndNotifies) {
 
     MainTask task(logger, file_loader, human_start, human_stop, bt_sender, buz_start, buz_stop, det_timer, cd_timer);
 
-    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}, nullptr});
 
     EXPECT_CALL(*human_start, send());
     EXPECT_CALL(*buz_stop, send());
     EXPECT_CALL(*det_timer, stop());
 
-    task.run(ThreadMessage{ThreadMessageType::RespondDeviceFound, {"phone"}});
+    task.run(ThreadMessage{ThreadMessageType::RespondDeviceFound, {"phone"}, nullptr});
     EXPECT_EQ(task.state(), MainTask::State::WaitHumanDetect);
 }
 
@@ -96,11 +96,11 @@ TEST(MainTaskTest, DeviceNotDetectedStartsCooldown) {
     EXPECT_CALL(*file_loader, load_string_list("device_list")).WillOnce(testing::Return(std::vector<std::string>{"phone"}));
 
     MainTask task(logger, file_loader, human_start, human_stop, bt_sender, buz_start, buz_stop, det_timer, cd_timer);
-    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}, nullptr});
 
     EXPECT_CALL(*buz_start, send());
     EXPECT_CALL(*cd_timer, start());
-    task.run(ThreadMessage{ThreadMessageType::RespondDeviceNotFound, {"other"}});
+    task.run(ThreadMessage{ThreadMessageType::RespondDeviceNotFound, {"other"}, nullptr});
     EXPECT_EQ(task.state(), MainTask::State::ScanCooldown);
 }
 
@@ -118,11 +118,11 @@ TEST(MainTaskTest, CooldownTimeoutProcessesSecondScan) {
     EXPECT_CALL(*file_loader, load_string_list("device_list")).WillRepeatedly(testing::Return(std::vector<std::string>{"phone"}));
 
     MainTask task(logger, file_loader, human_start, human_stop, bt_sender, buz_start, buz_stop, det_timer, cd_timer);
-    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}});
-    task.run(ThreadMessage{ThreadMessageType::RespondDeviceNotFound, {"other"}});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}, nullptr});
+    task.run(ThreadMessage{ThreadMessageType::RespondDeviceNotFound, {"other"}, nullptr});
 
     EXPECT_CALL(*buz_start, send());
-    task.run(ThreadMessage{ThreadMessageType::ProcessingTimeout, {std::to_string(static_cast<int>(MainTask::TimerId::T_COOLDOWN))}});
+    task.run(ThreadMessage{ThreadMessageType::ProcessingTimeout, {std::to_string(static_cast<int>(MainTask::TimerId::T_COOLDOWN))}, nullptr});
     EXPECT_EQ(task.state(), MainTask::State::ScanCooldown);
 }
 
@@ -138,9 +138,9 @@ TEST(MainTaskTest, DetectionTimeoutReturnsToWaitHuman) {
     auto logger = std::make_shared<NiceMock<MockLogger>>();
 
     MainTask task(logger, file_loader, human_start, human_stop, bt_sender, buz_start, buz_stop, det_timer, cd_timer);
-    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}, nullptr});
 
-    task.run(ThreadMessage{ThreadMessageType::ProcessingTimeout, {std::to_string(static_cast<int>(MainTask::TimerId::T_DET_TIMEOUT))}});
+    task.run(ThreadMessage{ThreadMessageType::ProcessingTimeout, {std::to_string(static_cast<int>(MainTask::TimerId::T_DET_TIMEOUT))}, nullptr});
     EXPECT_EQ(task.state(), MainTask::State::WaitHumanDetect);
 }
 

--- a/tests/integration/infra/message/test_message.cpp
+++ b/tests/integration/infra/message/test_message.cpp
@@ -4,20 +4,20 @@
 using namespace device_reminder;
 
 TEST(ThreadMessageTest, ConstructorStoresValues) {
-    ThreadMessage msg(ThreadMessageType::StartBuzzing, {"1"});
+    ThreadMessage msg(ThreadMessageType::StartBuzzing, {"1"}, nullptr);
     EXPECT_EQ(msg.type(), ThreadMessageType::StartBuzzing);
     std::vector<std::string> expected{"1"};
     EXPECT_EQ(msg.payload(), expected);
 }
 
 TEST(ThreadMessageTest, HandlesUnknownType) {
-    ThreadMessage msg(ThreadMessageType::Unknown, {});
+    ThreadMessage msg(ThreadMessageType::Unknown, {}, nullptr);
     EXPECT_EQ(msg.type(), ThreadMessageType::Unknown);
     EXPECT_TRUE(msg.payload().empty());
 }
 
 TEST(ThreadMessageTest, HandlesInvalidEnum) {
-    ThreadMessage msg(static_cast<ThreadMessageType>(999), {"x"});
+    ThreadMessage msg(static_cast<ThreadMessageType>(999), {"x"}, nullptr);
     EXPECT_EQ(static_cast<int>(msg.type()), 999);
     std::vector<std::string> expected{"x"};
     EXPECT_EQ(msg.payload(), expected);
@@ -25,7 +25,7 @@ TEST(ThreadMessageTest, HandlesInvalidEnum) {
 }
 
 TEST(ThreadMessageTest, CloneCreatesEqualCopy) {
-    ThreadMessage original(ThreadMessageType::RespondDeviceFound, {"phone", "watch"});
+    ThreadMessage original(ThreadMessageType::RespondDeviceFound, {"phone", "watch"}, nullptr);
     auto copy = original.clone();
     ASSERT_NE(copy, nullptr);
     EXPECT_EQ(copy->type(), original.type());
@@ -33,7 +33,7 @@ TEST(ThreadMessageTest, CloneCreatesEqualCopy) {
 }
 
 TEST(ThreadMessageTest, ToStringFormatsCorrectly) {
-    ThreadMessage msg(ThreadMessageType::StartBuzzing, {"1"});
+    ThreadMessage msg(ThreadMessageType::StartBuzzing, {"1"}, nullptr);
     EXPECT_EQ(msg.to_string(), std::string("ThreadMessage{7,[1]}"));
 }
 

--- a/tests/integration/infra/message/test_message_codec.cpp
+++ b/tests/integration/infra/message/test_message_codec.cpp
@@ -39,8 +39,10 @@ TEST(MessageCodecTest, EncodeNullReturnsEmpty) {
 
 TEST(MessageCodecTest, EncodeSimpleMessage) {
     MessageCodec codec(nullptr);
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing,
-                                                std::vector<std::string>{"1"});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{"1"},
+        nullptr);
     auto out = codec.encode(msg);
     std::vector<uint8_t> expected = make_bytes({
         static_cast<uint8_t>(ProcessMessageType::StartBuzzing),

--- a/tests/integration/infra/message/test_message_dispatcher.cpp
+++ b/tests/integration/infra/message/test_message_dispatcher.cpp
@@ -25,8 +25,10 @@ TEST(ThreadDispatcherTest, CallsRegisteredHandler) {
          [&](std::shared_ptr<IThreadMessage>) { called = true; }}
     };
     ThreadDispatcher disp(nullptr, map);
-    auto msg = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing,
-                                               std::vector<std::string>{});
+    auto msg = std::make_shared<ThreadMessage>(
+        ThreadMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     disp.dispatch(msg);
     EXPECT_TRUE(called);
 }
@@ -38,8 +40,10 @@ TEST(ThreadDispatcherTest, IgnoresUnknownMessage) {
          [&](std::shared_ptr<IThreadMessage>) { called = true; }}
     };
     ThreadDispatcher disp(nullptr, map);
-    auto msg = std::make_shared<ThreadMessage>(ThreadMessageType::StopBuzzing,
-                                               std::vector<std::string>{});
+    auto msg = std::make_shared<ThreadMessage>(
+        ThreadMessageType::StopBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     disp.dispatch(msg);
     EXPECT_FALSE(called);
 }
@@ -67,7 +71,9 @@ TEST(ThreadDispatcherTest, DispatchLogsInfoOnUnhandledMessage) {
 
     ThreadDispatcher::HandlerMap map{};
     ThreadDispatcher disp(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), map);
-    auto msg = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing,
-                                               std::vector<std::string>{});
+    auto msg = std::make_shared<ThreadMessage>(
+        ThreadMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     disp.dispatch(msg);
 }

--- a/tests/integration/infra/message/test_message_queue.cpp
+++ b/tests/integration/infra/message/test_message_queue.cpp
@@ -20,8 +20,10 @@ public:
 TEST(ThreadQueueTest, PushPopWorks) {
   auto logger = std::make_shared<NiceMock<MockLogger>>();
   ThreadQueue q(logger);
-  auto msg = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing,
-                                             std::vector<std::string>{"1"});
+  auto msg = std::make_shared<ThreadMessage>(
+      ThreadMessageType::StartBuzzing,
+      std::vector<std::string>{"1"},
+      nullptr);
   q.push(msg);
   auto res = q.pop();
   ASSERT_NE(res, nullptr);
@@ -38,8 +40,10 @@ TEST(ThreadQueueTest, PopOnEmptyReturnsNullptr) {
 TEST(ThreadQueueTest, SizeReflectsQueueState) {
   ThreadQueue q(nullptr);
   EXPECT_EQ(q.size(), 0u);
-  q.push(std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing,
-                                         std::vector<std::string>{}));
+  q.push(std::make_shared<ThreadMessage>(
+      ThreadMessageType::StartBuzzing,
+      std::vector<std::string>{},
+      nullptr));
   EXPECT_EQ(q.size(), 1u);
 }
 
@@ -53,8 +57,10 @@ TEST(ThreadQueueTest, PushLogsWhenLoggerProvided) {
   auto logger = std::make_shared<NiceMock<MockLogger>>();
   EXPECT_CALL(*logger, info("ThreadQueue push"));
   ThreadQueue q(logger);
-  auto msg = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing,
-                                             std::vector<std::string>{"2"});
+  auto msg = std::make_shared<ThreadMessage>(
+      ThreadMessageType::StartBuzzing,
+      std::vector<std::string>{"2"},
+      nullptr);
   q.push(msg);
   auto res = q.pop();
   ASSERT_NE(res, nullptr);
@@ -64,10 +70,14 @@ TEST(ThreadQueueTest, PushLogsWhenLoggerProvided) {
 
 TEST(ThreadQueueTest, PushMultipleMaintainsFIFO) {
   ThreadQueue q(nullptr);
-  auto msg1 = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing,
-                                              std::vector<std::string>{"a"});
-  auto msg2 = std::make_shared<ThreadMessage>(ThreadMessageType::StopBuzzing,
-                                              std::vector<std::string>{"b"});
+  auto msg1 = std::make_shared<ThreadMessage>(
+      ThreadMessageType::StartBuzzing,
+      std::vector<std::string>{"a"},
+      nullptr);
+  auto msg2 = std::make_shared<ThreadMessage>(
+      ThreadMessageType::StopBuzzing,
+      std::vector<std::string>{"b"},
+      nullptr);
   q.push(msg1);
   q.push(msg2);
   auto first = q.pop();

--- a/tests/integration/infra/message/test_message_receiver.cpp
+++ b/tests/integration/infra/message/test_message_receiver.cpp
@@ -32,7 +32,10 @@ TEST(ThreadReceiverTest, DispatchesMessages) {
 
     std::thread th{[&]{ receiver.run(); }};
 
-    auto msg = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing, std::vector<std::string>{"1"});
+    auto msg = std::make_shared<ThreadMessage>(
+        ThreadMessageType::StartBuzzing,
+        std::vector<std::string>{"1"},
+        nullptr);
     queue->push(msg);
 
     {

--- a/tests/integration/infra/message/test_process_sender.cpp
+++ b/tests/integration/infra/message/test_process_sender.cpp
@@ -41,7 +41,10 @@ TEST(ProcessSenderTest, ValueNormal_EnqueuesMessage) {
     std::shared_ptr<ILogger> logger{};
     auto codec = std::make_shared<MessageCodec>(nullptr);
     auto queue = std::make_shared<ProcessQueue>(logger, codec, unique_name("sender1_"));
-    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{"1"});
+    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{"1"},
+        nullptr);
     ProcessSender sender(queue, msg);
 
     sender.send();
@@ -58,13 +61,19 @@ TEST(ProcessSenderTest, ValueAbnormal_LongPayload) {
     auto codec = std::make_shared<MessageCodec>(nullptr);
     auto queue = std::make_shared<ProcessQueue>(logger, codec, unique_name("sender2_"));
     std::string long_str(1024, 'x');
-    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{long_str});
+    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{long_str},
+        nullptr);
     ProcessSender sender(queue, msg);
     EXPECT_NO_THROW(sender.send());
 }
 
 TEST(ProcessSenderTest, PointerNormal_NullQueue) {
-    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     ProcessSender sender(nullptr, msg);
     EXPECT_NO_THROW(sender.send());
 }
@@ -83,7 +92,10 @@ TEST(ProcessSenderTest, PointerAbnormal_BothNull) {
 
 TEST(ProcessSenderTest, MockNormal_PushCalledOnce) {
     StrictMock<MockQueue> queue;
-    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     EXPECT_CALL(queue, push(msg)).Times(1);
     ProcessSender sender(std::shared_ptr<IProcessQueue>(&queue, [](IProcessQueue*){}), msg);
     sender.send();
@@ -91,7 +103,10 @@ TEST(ProcessSenderTest, MockNormal_PushCalledOnce) {
 
 TEST(ProcessSenderTest, MockAbnormal_ThrowsFromQueue) {
     StrictMock<MockQueue> queue;
-    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     EXPECT_CALL(queue, push(msg)).WillOnce(Throw(std::runtime_error("fail")));
     ProcessSender sender(std::shared_ptr<IProcessQueue>(&queue, [](IProcessQueue*){}), msg);
     EXPECT_THROW(sender.send(), std::runtime_error);

--- a/tests/integration/infra/message/test_thread_sender.cpp
+++ b/tests/integration/infra/message/test_thread_sender.cpp
@@ -22,7 +22,10 @@ public:
 TEST(ThreadSenderTest, SendPushesMessageToQueue) {
     NiceMock<MockLogger> logger;
     auto queue = std::make_shared<MessageQueue>(std::shared_ptr<ILogger>(&logger, [](ILogger*){}));
-    auto message = std::make_shared<Message>(MessageType::StartBuzzing, std::vector<std::string>{"1"});
+    auto message = std::make_shared<Message>(
+        MessageType::StartBuzzing,
+        std::vector<std::string>{"1"},
+        std::shared_ptr<ILogger>(&logger, [](ILogger*){}));
 
     ThreadSender sender(std::shared_ptr<ILogger>(&logger, [](ILogger*){}));
 

--- a/tests/unit/core/bluetooth_task/test_bluetooth_dispatcher.cpp
+++ b/tests/unit/core/bluetooth_task/test_bluetooth_dispatcher.cpp
@@ -35,7 +35,9 @@ TEST(BluetoothHandlerTest, RequestScanCallsTask) {
   EXPECT_CALL(*task, on_waiting(testing::_)).Times(1);
 
   auto msg = std::make_shared<ProcessMessage>(
-      ProcessMessageType::RequestBluetoothScan, std::vector<std::string>{});
+      ProcessMessageType::RequestBluetoothScan,
+      std::vector<std::string>{},
+      nullptr);
   handler.handle(msg);
 }
 
@@ -47,7 +49,9 @@ TEST(BluetoothHandlerTest, OtherMessageIgnored) {
   EXPECT_CALL(*task, on_waiting(testing::_)).Times(0);
 
   auto msg = std::make_shared<ProcessMessage>(
-      ProcessMessageType::StartHumanDetection, std::vector<std::string>{});
+      ProcessMessageType::StartHumanDetection,
+      std::vector<std::string>{},
+      nullptr);
   handler.handle(msg);
 }
 
@@ -76,7 +80,9 @@ TEST(BluetoothHandlerTest, HandleWithoutTaskDoesNothingAndNoLog) {
   EXPECT_CALL(*logger, info(testing::_)).Times(0);
   BluetoothHandler handler(logger, nullptr);
   auto msg = std::make_shared<ProcessMessage>(
-      ProcessMessageType::RequestBluetoothScan, std::vector<std::string>{});
+      ProcessMessageType::RequestBluetoothScan,
+      std::vector<std::string>{},
+      nullptr);
   handler.handle(msg);
 }
 
@@ -90,7 +96,9 @@ TEST(BluetoothHandlerTest, HandleLogsAndCallsTask) {
   EXPECT_CALL(*task, on_waiting(testing::_)).Times(1);
 
   auto msg = std::make_shared<ProcessMessage>(
-      ProcessMessageType::RequestBluetoothScan, std::vector<std::string>{});
+      ProcessMessageType::RequestBluetoothScan,
+      std::vector<std::string>{},
+      nullptr);
   handler.handle(msg);
 }
 

--- a/tests/unit/core/buzzer_task/test_buzzer_dispatcher.cpp
+++ b/tests/unit/core/buzzer_task/test_buzzer_dispatcher.cpp
@@ -46,7 +46,10 @@ TEST(BuzzerHandlerTest, StartBuzzingStartsTimerAndCallsTask) {
     EXPECT_CALL(*task, on_buzzing(testing::_)).Times(1);
     EXPECT_CALL(*timer, start()).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -59,7 +62,10 @@ TEST(BuzzerHandlerTest, StopBuzzingStopsTimerAndCallsTask) {
     EXPECT_CALL(*task, on_waiting(testing::_)).Times(1);
     EXPECT_CALL(*timer, stop()).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StopBuzzing, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StopBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -72,7 +78,10 @@ TEST(BuzzerHandlerTest, TimeoutStopsTimerAndCallsTask) {
     EXPECT_CALL(*task, on_waiting(testing::_)).Times(1);
     EXPECT_CALL(*timer, stop()).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::BuzzTimeout, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::BuzzTimeout,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -115,7 +124,10 @@ TEST(BuzzerHandlerTest, StartBuzzingWithoutTimer) {
         EXPECT_CALL(logger, info("StartBuzzing")).Times(1);
     }
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -135,7 +147,10 @@ TEST(BuzzerHandlerTest, StartBuzzingLogsMessage) {
                           std::shared_ptr<IBuzzerTask>(&task, [](IBuzzerTask*){}),
                           std::shared_ptr<ITimerService>(&timer, [](ITimerService*){}));
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 

--- a/tests/unit/core/buzzer_task/test_buzzer_handler.cpp
+++ b/tests/unit/core/buzzer_task/test_buzzer_handler.cpp
@@ -44,11 +44,11 @@ TEST(BuzzerTaskTest, StartAndTimeoutStopsBuzzer) {
     BuzzerTask task(logger, sender, loader, driver);
 
     EXPECT_CALL(*driver, on());
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}, nullptr});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 
     EXPECT_CALL(*driver, off());
-    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzing, {}, nullptr});
     EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
 }
 
@@ -61,10 +61,10 @@ TEST(BuzzerTaskTest, ManualStopCancelsTimer) {
     BuzzerTask task(logger, sender, loader, driver);
 
     EXPECT_CALL(*driver, on());
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}, nullptr});
 
     EXPECT_CALL(*driver, off());
-    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzing, {}, nullptr});
     EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
 }
 
@@ -77,10 +77,10 @@ TEST(BuzzerTaskTest, IgnoreDuplicateStart) {
     BuzzerTask task(logger, sender, loader, driver);
 
     EXPECT_CALL(*driver, on());
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}, nullptr});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}, nullptr});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 }
 
@@ -113,7 +113,7 @@ TEST(BuzzerTaskTest, StartMessageTurnsOnDriver) {
     BuzzerTask task(logger, sender, loader, driver);
 
     EXPECT_CALL(*driver, on()).Times(1);
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}, nullptr});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 }
 
@@ -126,7 +126,7 @@ TEST(BuzzerTaskTest, StopMessageIgnoredWhenWaiting) {
     BuzzerTask task(logger, sender, loader, driver);
 
     EXPECT_CALL(*driver, off()).Times(0);
-    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StopBuzzing, {}, nullptr});
     EXPECT_EQ(task.state(), BuzzerTask::State::WaitStart);
 }
 
@@ -137,7 +137,7 @@ TEST(BuzzerTaskTest, StartMessageWorksWithoutDriver) {
 
     BuzzerTask task(logger, sender, loader, nullptr);
 
-    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}});
+    task.send_message(ThreadMessage{ThreadMessageType::StartBuzzing, {}, nullptr});
     EXPECT_EQ(task.state(), BuzzerTask::State::Buzzing);
 }
 

--- a/tests/unit/core/human_task/test_human_dispatcher.cpp
+++ b/tests/unit/core/human_task/test_human_dispatcher.cpp
@@ -45,7 +45,10 @@ TEST(HumanHandlerTest, StopDetectionStartsTimer) {
     EXPECT_CALL(*task, on_stopping(testing::_)).Times(1);
     EXPECT_CALL(*timer, start()).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StopHumanDetection, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StopHumanDetection,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -58,7 +61,10 @@ TEST(HumanHandlerTest, StartDetectionStopsTimer) {
     EXPECT_CALL(*task, on_detecting(testing::_)).Times(1);
     EXPECT_CALL(*timer, stop()).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartHumanDetection, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartHumanDetection,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -70,7 +76,10 @@ TEST(HumanHandlerTest, CooldownCallsTask) {
 
     EXPECT_CALL(*task, on_cooldown(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::CooldownTimeout, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::CooldownTimeout,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -111,7 +120,10 @@ TEST(HumanHandlerTest, HandleWithNullTaskDoesNothing) {
     EXPECT_CALL(*timer, start()).Times(0);
     EXPECT_CALL(*timer, stop()).Times(0);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartHumanDetection, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartHumanDetection,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -122,7 +134,10 @@ TEST(HumanHandlerTest, StartDetectionWithNullTimerOnlyCallsTask) {
 
     EXPECT_CALL(*task, on_detecting(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartHumanDetection, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartHumanDetection,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -134,7 +149,10 @@ TEST(HumanHandlerTest, StopDetectionWithNullLoggerWorks) {
     EXPECT_CALL(*timer, start()).Times(1);
     EXPECT_CALL(*task, on_stopping(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StopHumanDetection, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StopHumanDetection,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -148,7 +166,10 @@ TEST(HumanHandlerTest, UnknownMessageKeepsDetectingState) {
     EXPECT_CALL(*timer, stop()).Times(0);
     EXPECT_CALL(*task, on_detecting(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 

--- a/tests/unit/core/main_task/test_main_dispatcher.cpp
+++ b/tests/unit/core/main_task/test_main_dispatcher.cpp
@@ -32,7 +32,10 @@ TEST(MainHandlerTest, HumanDetectedCallsTask) {
 
     EXPECT_CALL(*task, on_waiting_for_human(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::HumanDetected, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::HumanDetected,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -43,7 +46,10 @@ TEST(MainHandlerTest, DeviceFoundCallsHumanControl) {
 
     EXPECT_CALL(*task, on_response_to_human_task(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::ResponseDevicePresence, std::vector<std::string>{"found"});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::ResponseDevicePresence,
+        std::vector<std::string>{"found"},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -54,7 +60,10 @@ TEST(MainHandlerTest, DeviceNotFoundCallsBuzzerControl) {
 
     EXPECT_CALL(*task, on_response_to_buzzer_task(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::ResponseDevicePresence, std::vector<std::string>{"none"});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::ResponseDevicePresence,
+        std::vector<std::string>{"none"},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -65,7 +74,10 @@ TEST(MainHandlerTest, CooldownCallsTask) {
 
     EXPECT_CALL(*task, on_cooldown(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::CooldownTimeout, std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::CooldownTimeout,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -103,8 +115,10 @@ TEST(MainHandlerExtendedTest, ScanTimeoutCallsWaitingSecondResponse) {
 
     EXPECT_CALL(*task, on_waiting_for_second_response(testing::_)).Times(1);
 
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::ScanTimeout,
-                                                std::vector<std::string>{});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::ScanTimeout,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -117,7 +131,8 @@ TEST(MainHandlerExtendedTest, InvalidPayloadCallsBuzzerTask) {
 
     auto msg = std::make_shared<ProcessMessage>(
         ProcessMessageType::ResponseDevicePresence,
-        std::vector<std::string>{"invalid"});
+        std::vector<std::string>{"invalid"},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -133,7 +148,9 @@ TEST(MainHandlerExtendedTest, UnknownMessageTypeDoesNothing) {
     EXPECT_CALL(*task, on_waiting_for_second_response(testing::_)).Times(0);
 
     auto msg = std::make_shared<ProcessMessage>(
-        static_cast<ProcessMessageType>(999), std::vector<std::string>{});
+        static_cast<ProcessMessageType>(999),
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 
@@ -163,7 +180,9 @@ TEST(MainHandlerExtendedTest, NullTaskCausesNoCall) {
     EXPECT_CALL(*dummy_task, on_waiting_for_second_response(testing::_)).Times(0);
 
     auto msg = std::make_shared<ProcessMessage>(
-        ProcessMessageType::HumanDetected, std::vector<std::string>{});
+        ProcessMessageType::HumanDetected,
+        std::vector<std::string>{},
+        nullptr);
     handler.handle(msg);
 }
 

--- a/tests/unit/core/main_task/test_main_handler.cpp
+++ b/tests/unit/core/main_task/test_main_handler.cpp
@@ -53,7 +53,7 @@ TEST(MainTaskTest, HumanDetectedStartsScanAndTimer) {
     EXPECT_CALL(*det_timer, start());
     EXPECT_CALL(*bt_sender, send());
 
-    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}, nullptr});
     EXPECT_EQ(task.state(), MainTask::State::WaitDeviceResponse);
 }
 
@@ -72,13 +72,13 @@ TEST(MainTaskTest, DeviceDetectedStopsTimerAndNotifies) {
 
     MainTask task(logger, file_loader, human_start, human_stop, bt_sender, buz_start, buz_stop, det_timer, cd_timer);
 
-    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}, nullptr});
 
     EXPECT_CALL(*human_start, send());
     EXPECT_CALL(*buz_stop, send());
     EXPECT_CALL(*det_timer, stop());
 
-    task.run(ThreadMessage{ThreadMessageType::RespondDeviceFound, {"phone"}});
+    task.run(ThreadMessage{ThreadMessageType::RespondDeviceFound, {"phone"}, nullptr});
     EXPECT_EQ(task.state(), MainTask::State::WaitHumanDetect);
 }
 
@@ -96,11 +96,11 @@ TEST(MainTaskTest, DeviceNotDetectedStartsCooldown) {
     EXPECT_CALL(*file_loader, load_string_list("device_list")).WillOnce(testing::Return(std::vector<std::string>{"phone"}));
 
     MainTask task(logger, file_loader, human_start, human_stop, bt_sender, buz_start, buz_stop, det_timer, cd_timer);
-    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}, nullptr});
 
     EXPECT_CALL(*buz_start, send());
     EXPECT_CALL(*cd_timer, start());
-    task.run(ThreadMessage{ThreadMessageType::RespondDeviceNotFound, {"other"}});
+    task.run(ThreadMessage{ThreadMessageType::RespondDeviceNotFound, {"other"}, nullptr});
     EXPECT_EQ(task.state(), MainTask::State::ScanCooldown);
 }
 
@@ -118,11 +118,11 @@ TEST(MainTaskTest, CooldownTimeoutProcessesSecondScan) {
     EXPECT_CALL(*file_loader, load_string_list("device_list")).WillRepeatedly(testing::Return(std::vector<std::string>{"phone"}));
 
     MainTask task(logger, file_loader, human_start, human_stop, bt_sender, buz_start, buz_stop, det_timer, cd_timer);
-    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}});
-    task.run(ThreadMessage{ThreadMessageType::RespondDeviceNotFound, {"other"}});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}, nullptr});
+    task.run(ThreadMessage{ThreadMessageType::RespondDeviceNotFound, {"other"}, nullptr});
 
     EXPECT_CALL(*buz_start, send());
-    task.run(ThreadMessage{ThreadMessageType::ProcessingTimeout, {std::to_string(static_cast<int>(MainTask::TimerId::T_COOLDOWN))}});
+    task.run(ThreadMessage{ThreadMessageType::ProcessingTimeout, {std::to_string(static_cast<int>(MainTask::TimerId::T_COOLDOWN))}, nullptr});
     EXPECT_EQ(task.state(), MainTask::State::ScanCooldown);
 }
 
@@ -138,9 +138,9 @@ TEST(MainTaskTest, DetectionTimeoutReturnsToWaitHuman) {
     auto logger = std::make_shared<NiceMock<MockLogger>>();
 
     MainTask task(logger, file_loader, human_start, human_stop, bt_sender, buz_start, buz_stop, det_timer, cd_timer);
-    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}});
+    task.run(ThreadMessage{ThreadMessageType::HumanDetected, {}, nullptr});
 
-    task.run(ThreadMessage{ThreadMessageType::ProcessingTimeout, {std::to_string(static_cast<int>(MainTask::TimerId::T_DET_TIMEOUT))}});
+    task.run(ThreadMessage{ThreadMessageType::ProcessingTimeout, {std::to_string(static_cast<int>(MainTask::TimerId::T_DET_TIMEOUT))}, nullptr});
     EXPECT_EQ(task.state(), MainTask::State::WaitHumanDetect);
 }
 

--- a/tests/unit/infra/message/test_message.cpp
+++ b/tests/unit/infra/message/test_message.cpp
@@ -4,20 +4,20 @@
 using namespace device_reminder;
 
 TEST(ThreadMessageTest, ConstructorStoresValues) {
-    ThreadMessage msg(ThreadMessageType::StartBuzzing, {"1"});
+    ThreadMessage msg(ThreadMessageType::StartBuzzing, {"1"}, nullptr);
     EXPECT_EQ(msg.type(), ThreadMessageType::StartBuzzing);
     std::vector<std::string> expected{"1"};
     EXPECT_EQ(msg.payload(), expected);
 }
 
 TEST(ThreadMessageTest, HandlesUnknownType) {
-    ThreadMessage msg(ThreadMessageType::Unknown, {});
+    ThreadMessage msg(ThreadMessageType::Unknown, {}, nullptr);
     EXPECT_EQ(msg.type(), ThreadMessageType::Unknown);
     EXPECT_TRUE(msg.payload().empty());
 }
 
 TEST(ThreadMessageTest, HandlesInvalidEnum) {
-    ThreadMessage msg(static_cast<ThreadMessageType>(999), {"x"});
+    ThreadMessage msg(static_cast<ThreadMessageType>(999), {"x"}, nullptr);
     EXPECT_EQ(static_cast<int>(msg.type()), 999);
     std::vector<std::string> expected{"x"};
     EXPECT_EQ(msg.payload(), expected);
@@ -25,7 +25,7 @@ TEST(ThreadMessageTest, HandlesInvalidEnum) {
 }
 
 TEST(ThreadMessageTest, CloneCreatesEqualCopy) {
-    ThreadMessage original(ThreadMessageType::RespondDeviceFound, {"phone", "watch"});
+    ThreadMessage original(ThreadMessageType::RespondDeviceFound, {"phone", "watch"}, nullptr);
     auto copy = original.clone();
     ASSERT_NE(copy, nullptr);
     EXPECT_EQ(copy->type(), original.type());
@@ -33,7 +33,7 @@ TEST(ThreadMessageTest, CloneCreatesEqualCopy) {
 }
 
 TEST(ThreadMessageTest, ToStringFormatsCorrectly) {
-    ThreadMessage msg(ThreadMessageType::StartBuzzing, {"1"});
+    ThreadMessage msg(ThreadMessageType::StartBuzzing, {"1"}, nullptr);
     EXPECT_EQ(msg.to_string(), std::string("ThreadMessage{7,[1]}"));
 }
 

--- a/tests/unit/infra/message/test_message_codec.cpp
+++ b/tests/unit/infra/message/test_message_codec.cpp
@@ -39,8 +39,10 @@ TEST(MessageCodecTest, EncodeNullReturnsEmpty) {
 
 TEST(MessageCodecTest, EncodeSimpleMessage) {
     MessageCodec codec(nullptr);
-    auto msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing,
-                                                std::vector<std::string>{"1"});
+    auto msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{"1"},
+        nullptr);
     auto out = codec.encode(msg);
     std::vector<uint8_t> expected = make_bytes({
         static_cast<uint8_t>(ProcessMessageType::StartBuzzing),

--- a/tests/unit/infra/message/test_message_dispatcher.cpp
+++ b/tests/unit/infra/message/test_message_dispatcher.cpp
@@ -25,8 +25,10 @@ TEST(ThreadDispatcherTest, CallsRegisteredHandler) {
          [&](std::shared_ptr<IThreadMessage>) { called = true; }}
     };
     ThreadDispatcher disp(nullptr, map);
-    auto msg = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing,
-                                               std::vector<std::string>{});
+    auto msg = std::make_shared<ThreadMessage>(
+        ThreadMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     disp.dispatch(msg);
     EXPECT_TRUE(called);
 }
@@ -38,8 +40,10 @@ TEST(ThreadDispatcherTest, IgnoresUnknownMessage) {
          [&](std::shared_ptr<IThreadMessage>) { called = true; }}
     };
     ThreadDispatcher disp(nullptr, map);
-    auto msg = std::make_shared<ThreadMessage>(ThreadMessageType::StopBuzzing,
-                                               std::vector<std::string>{});
+    auto msg = std::make_shared<ThreadMessage>(
+        ThreadMessageType::StopBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     disp.dispatch(msg);
     EXPECT_FALSE(called);
 }
@@ -67,7 +71,9 @@ TEST(ThreadDispatcherTest, DispatchLogsInfoOnUnhandledMessage) {
 
     ThreadDispatcher::HandlerMap map{};
     ThreadDispatcher disp(std::shared_ptr<ILogger>(&logger, [](ILogger*){}), map);
-    auto msg = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing,
-                                               std::vector<std::string>{});
+    auto msg = std::make_shared<ThreadMessage>(
+        ThreadMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     disp.dispatch(msg);
 }

--- a/tests/unit/infra/message/test_message_queue.cpp
+++ b/tests/unit/infra/message/test_message_queue.cpp
@@ -20,8 +20,10 @@ public:
 TEST(ThreadQueueTest, PushPopWorks) {
   auto logger = std::make_shared<NiceMock<MockLogger>>();
   ThreadQueue q(logger);
-  auto msg = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing,
-                                             std::vector<std::string>{"1"});
+  auto msg = std::make_shared<ThreadMessage>(
+      ThreadMessageType::StartBuzzing,
+      std::vector<std::string>{"1"},
+      nullptr);
   q.push(msg);
   auto res = q.pop();
   ASSERT_NE(res, nullptr);
@@ -38,8 +40,10 @@ TEST(ThreadQueueTest, PopOnEmptyReturnsNullptr) {
 TEST(ThreadQueueTest, SizeReflectsQueueState) {
   ThreadQueue q(nullptr);
   EXPECT_EQ(q.size(), 0u);
-  q.push(std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing,
-                                         std::vector<std::string>{}));
+  q.push(std::make_shared<ThreadMessage>(
+      ThreadMessageType::StartBuzzing,
+      std::vector<std::string>{},
+      nullptr));
   EXPECT_EQ(q.size(), 1u);
 }
 
@@ -53,8 +57,10 @@ TEST(ThreadQueueTest, PushLogsWhenLoggerProvided) {
   auto logger = std::make_shared<NiceMock<MockLogger>>();
   EXPECT_CALL(*logger, info("ThreadQueue push"));
   ThreadQueue q(logger);
-  auto msg = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing,
-                                             std::vector<std::string>{"2"});
+  auto msg = std::make_shared<ThreadMessage>(
+      ThreadMessageType::StartBuzzing,
+      std::vector<std::string>{"2"},
+      nullptr);
   q.push(msg);
   auto res = q.pop();
   ASSERT_NE(res, nullptr);
@@ -64,10 +70,14 @@ TEST(ThreadQueueTest, PushLogsWhenLoggerProvided) {
 
 TEST(ThreadQueueTest, PushMultipleMaintainsFIFO) {
   ThreadQueue q(nullptr);
-  auto msg1 = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing,
-                                              std::vector<std::string>{"a"});
-  auto msg2 = std::make_shared<ThreadMessage>(ThreadMessageType::StopBuzzing,
-                                              std::vector<std::string>{"b"});
+  auto msg1 = std::make_shared<ThreadMessage>(
+      ThreadMessageType::StartBuzzing,
+      std::vector<std::string>{"a"},
+      nullptr);
+  auto msg2 = std::make_shared<ThreadMessage>(
+      ThreadMessageType::StopBuzzing,
+      std::vector<std::string>{"b"},
+      nullptr);
   q.push(msg1);
   q.push(msg2);
   auto first = q.pop();

--- a/tests/unit/infra/message/test_message_receiver.cpp
+++ b/tests/unit/infra/message/test_message_receiver.cpp
@@ -32,7 +32,10 @@ TEST(ThreadReceiverTest, DispatchesMessages) {
 
     std::thread th{[&]{ receiver.run(); }};
 
-    auto msg = std::make_shared<ThreadMessage>(ThreadMessageType::StartBuzzing, std::vector<std::string>{"1"});
+    auto msg = std::make_shared<ThreadMessage>(
+        ThreadMessageType::StartBuzzing,
+        std::vector<std::string>{"1"},
+        nullptr);
     queue->push(msg);
 
     {

--- a/tests/unit/infra/message/test_process_sender.cpp
+++ b/tests/unit/infra/message/test_process_sender.cpp
@@ -41,7 +41,10 @@ TEST(ProcessSenderTest, ValueNormal_EnqueuesMessage) {
     std::shared_ptr<ILogger> logger{};
     auto codec = std::make_shared<MessageCodec>(nullptr);
     auto queue = std::make_shared<ProcessQueue>(logger, codec, unique_name("sender1_"));
-    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{"1"});
+    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{"1"},
+        nullptr);
     ProcessSender sender(queue, msg);
 
     sender.send();
@@ -58,13 +61,19 @@ TEST(ProcessSenderTest, ValueAbnormal_LongPayload) {
     auto codec = std::make_shared<MessageCodec>(nullptr);
     auto queue = std::make_shared<ProcessQueue>(logger, codec, unique_name("sender2_"));
     std::string long_str(1024, 'x');
-    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{long_str});
+    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{long_str},
+        nullptr);
     ProcessSender sender(queue, msg);
     EXPECT_NO_THROW(sender.send());
 }
 
 TEST(ProcessSenderTest, PointerNormal_NullQueue) {
-    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     ProcessSender sender(nullptr, msg);
     EXPECT_NO_THROW(sender.send());
 }
@@ -83,7 +92,10 @@ TEST(ProcessSenderTest, PointerAbnormal_BothNull) {
 
 TEST(ProcessSenderTest, MockNormal_PushCalledOnce) {
     StrictMock<MockQueue> queue;
-    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     EXPECT_CALL(queue, push(msg)).Times(1);
     ProcessSender sender(std::shared_ptr<IProcessQueue>(&queue, [](IProcessQueue*){}), msg);
     sender.send();
@@ -91,7 +103,10 @@ TEST(ProcessSenderTest, MockNormal_PushCalledOnce) {
 
 TEST(ProcessSenderTest, MockAbnormal_ThrowsFromQueue) {
     StrictMock<MockQueue> queue;
-    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(ProcessMessageType::StartBuzzing, std::vector<std::string>{});
+    std::shared_ptr<IProcessMessage> msg = std::make_shared<ProcessMessage>(
+        ProcessMessageType::StartBuzzing,
+        std::vector<std::string>{},
+        nullptr);
     EXPECT_CALL(queue, push(msg)).WillOnce(Throw(std::runtime_error("fail")));
     ProcessSender sender(std::shared_ptr<IProcessQueue>(&queue, [](IProcessQueue*){}), msg);
     EXPECT_THROW(sender.send(), std::runtime_error);

--- a/tests/unit/infra/message/test_thread_sender.cpp
+++ b/tests/unit/infra/message/test_thread_sender.cpp
@@ -22,7 +22,10 @@ public:
 TEST(ThreadSenderTest, SendPushesMessageToQueue) {
     NiceMock<MockLogger> logger;
     auto queue = std::make_shared<MessageQueue>(std::shared_ptr<ILogger>(&logger, [](ILogger*){}));
-    auto message = std::make_shared<Message>(MessageType::StartBuzzing, std::vector<std::string>{"1"});
+    auto message = std::make_shared<Message>(
+        MessageType::StartBuzzing,
+        std::vector<std::string>{"1"},
+        std::shared_ptr<ILogger>(&logger, [](ILogger*){}));
 
     ThreadSender sender(std::shared_ptr<ILogger>(&logger, [](ILogger*){}));
 


### PR DESCRIPTION
## Summary
- inject ILogger into Message for logging
- store logger in Message implementation
- update message creation sites to pass logger

## Testing
- `cmake -S . -B build` *(pass)*
- `cmake --build build` *(fail: core/main_task/main_task.hpp missing)*

------
https://chatgpt.com/codex/tasks/task_e_689d245cf6ac832898573eae2635f286