### PR TITLE
feat: add MessageInbox module

### DIFF
--- a/include/infra/message/message_inbox.hpp
+++ b/include/infra/message/message_inbox.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "infra/logger.hpp"
+#include "infra/message/message_codec.hpp"
+#include "infra/message/thread_sender.hpp"
+#include "infra/message/message_queue.hpp"
+#include "infra/message/message.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace device_reminder {
+
+class IMessageInbox {
+public:
+    virtual ~IMessageInbox() = default;
+    virtual void on_recv(const std::vector<uint8_t>& bytes) = 0;
+
+protected:
+    IMessageInbox(std::shared_ptr<ILogger> logger,
+                  std::shared_ptr<IMessageCodec> codec,
+                  std::shared_ptr<IThreadSender> sender,
+                  std::shared_ptr<IMessageQueue> queue);
+
+    std::shared_ptr<ILogger> logger_{};
+    std::shared_ptr<IMessageCodec> codec_{};
+    std::shared_ptr<IThreadSender> sender_{};
+    std::shared_ptr<IMessageQueue> queue_{};
+};
+
+class MessageInbox : public IMessageInbox {
+public:
+    MessageInbox(std::shared_ptr<ILogger> logger,
+                 std::shared_ptr<IMessageCodec> codec,
+                 std::shared_ptr<IThreadSender> sender,
+                 std::shared_ptr<IMessageQueue> queue);
+
+    void on_recv(const std::vector<uint8_t>& bytes) override;
+};
+
+} // namespace device_reminder
+

--- a/src/infra/message/message_inbox.cpp
+++ b/src/infra/message/message_inbox.cpp
@@ -1,0 +1,65 @@
+#include "infra/message/message_inbox.hpp"
+
+#include <stdexcept>
+#include <utility>
+
+namespace device_reminder {
+
+IMessageInbox::IMessageInbox(std::shared_ptr<ILogger> logger,
+                             std::shared_ptr<IMessageCodec> codec,
+                             std::shared_ptr<IThreadSender> sender,
+                             std::shared_ptr<IMessageQueue> queue)
+    : logger_(std::move(logger)),
+      codec_(std::move(codec)),
+      sender_(std::move(sender)),
+      queue_(std::move(queue)) {}
+
+MessageInbox::MessageInbox(std::shared_ptr<ILogger> logger,
+                           std::shared_ptr<IMessageCodec> codec,
+                           std::shared_ptr<IThreadSender> sender,
+                           std::shared_ptr<IMessageQueue> queue)
+    : IMessageInbox(std::move(logger), std::move(codec), std::move(sender), std::move(queue)) {}
+
+void MessageInbox::on_recv(const std::vector<uint8_t>& bytes) {
+    if (logger_) {
+        logger_->info("MessageInbox on_recv start: size=" + std::to_string(bytes.size()));
+    }
+    try {
+        if (!codec_) {
+            if (logger_) logger_->error("MessageInbox on_recv failed: codec is null");
+            throw std::runtime_error("codec is null");
+        }
+        if (!sender_) {
+            if (logger_) logger_->error("MessageInbox on_recv failed: sender is null");
+            throw std::runtime_error("sender is null");
+        }
+        if (!queue_) {
+            if (logger_) logger_->error("MessageInbox on_recv failed: queue is null");
+            throw std::runtime_error("queue is null");
+        }
+
+        auto msg = codec_->decode(bytes);
+        if (logger_ && msg) {
+            logger_->info("MessageInbox decode success: " + msg->to_string());
+        }
+
+        sender_->send(queue_, msg);
+
+        if (logger_) {
+            logger_->info("MessageInbox on_recv success");
+        }
+    } catch (const std::exception& e) {
+        if (logger_) {
+            logger_->error(std::string("MessageInbox on_recv exception: ") + e.what());
+        }
+        throw;
+    } catch (...) {
+        if (logger_) {
+            logger_->error("MessageInbox on_recv unknown exception");
+        }
+        throw;
+    }
+}
+
+} // namespace device_reminder
+


### PR DESCRIPTION
## Summary
- add MessageInbox interface and implementation for decoding bytes and sending messages via thread sender

## Testing
- `cmake -S . -B build`
- `cmake --build build --target test_unit` (fails: expected class-name before '{' token in test_app.cpp)
- `cmake --build build --target test_integration` (fails: expected class-name before '{' token in test_app.cpp)


------
https://chatgpt.com/codex/tasks/task_e_689f0a1bcabc83289e34ffca8bf33469