### PR TITLE
Refactor ProcessSender to use endpoint-based sending

### DIFF
--- a/include/infra/message/process_sender.hpp
+++ b/include/infra/message/process_sender.hpp
@@ -3,17 +3,23 @@
 #include "infra/logger.hpp"
 #include "infra/message/message.hpp"
 #include "infra/message/message_codec.hpp"
-#include "infra/message/message_queue.hpp"
 
 #include <memory>
+#include <string>
 
 namespace device_reminder {
 
 class IProcessSender {
 public:
+    IProcessSender(std::shared_ptr<ILogger> logger,
+                   std::shared_ptr<IMessageCodec> codec);
     virtual ~IProcessSender() = default;
-    virtual void send(std::shared_ptr<IMessageQueue> queue,
-                      std::shared_ptr<IMessage> msg) = 0;
+    virtual void send(const std::string& endpoint,
+                      std::shared_ptr<IMessage> message) = 0;
+
+protected:
+    std::shared_ptr<ILogger> logger_{};
+    std::shared_ptr<IMessageCodec> codec_{};
 };
 
 class ProcessSender : public IProcessSender {
@@ -21,12 +27,8 @@ public:
     ProcessSender(std::shared_ptr<ILogger> logger,
                   std::shared_ptr<IMessageCodec> codec);
 
-    void send(std::shared_ptr<IMessageQueue> queue,
-              std::shared_ptr<IMessage> msg) override;
-
-private:
-    std::shared_ptr<ILogger> logger_{};
-    std::shared_ptr<IMessageCodec> codec_{};
+    void send(const std::string& endpoint,
+              std::shared_ptr<IMessage> message) override;
 };
 
 } // namespace device_reminder


### PR DESCRIPTION
## Summary
- refactor ProcessSender interface to send messages by endpoint string
- add validation and logging for endpoint and message

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)` (fails: no known conversion for argument 1 from `unique_ptr<testing::StrictMock<device_reminder::MockMainProcess>>` to `unique_ptr<device_reminder::IProcess>`)


------
https://chatgpt.com/codex/tasks/task_e_689f0e373794832886df889dcafef3b6