### PR TITLE
refactor: update process sender interface usage

### DIFF
--- a/include/core/bluetooth_task/bluetooth_handler.hpp
+++ b/include/core/bluetooth_task/bluetooth_handler.hpp
@@ -4,7 +4,6 @@
 #include "infra/file_loader.hpp"
 #include "infra/message/process_sender.hpp"
 #include "infra/bluetooth_driver/bluetooth_driver.hpp"
-#include "infra/message/message_queue.hpp"
 #include "infra/message/message.hpp"
 
 #include <memory>
@@ -25,7 +24,7 @@ public:
                      std::shared_ptr<IFileLoader> loader,
                      std::shared_ptr<IProcessSender> sender,
                      std::shared_ptr<IBluetoothDriver> driver,
-                     std::shared_ptr<IMessageQueue> main_queue,
+                     std::string main_endpoint,
                      std::shared_ptr<IMessage> success_msg,
                      std::shared_ptr<IMessage> failure_msg);
 
@@ -36,7 +35,7 @@ private:
     std::shared_ptr<IFileLoader> loader_{};
     std::shared_ptr<IProcessSender> sender_{};
     std::shared_ptr<IBluetoothDriver> driver_{};
-    std::shared_ptr<IMessageQueue> main_queue_{};
+    std::string main_endpoint_{};
     std::shared_ptr<IMessage> success_msg_{};
     std::shared_ptr<IMessage> failure_msg_{};
 };

--- a/include/core/human_task/human_handler.hpp
+++ b/include/core/human_task/human_handler.hpp
@@ -27,6 +27,7 @@ public:
                  std::shared_ptr<IProcessSender> sender,
                  std::shared_ptr<IFileLoader> loader,
                  std::shared_ptr<IMessage> cooldown_msg,
+                 std::string main_endpoint,
                  std::shared_ptr<IMessageQueue> main_queue,
                  std::shared_ptr<IMessage> success_msg);
 
@@ -40,6 +41,7 @@ private:
     std::shared_ptr<IProcessSender> sender_;
     std::shared_ptr<IFileLoader> loader_;
     std::shared_ptr<IMessage> cooldown_msg_;
+    std::string main_endpoint_;
     std::shared_ptr<IMessageQueue> main_queue_;
     std::shared_ptr<IMessage> success_msg_;
 };

--- a/include/core/main_task/main_handler.hpp
+++ b/include/core/main_task/main_handler.hpp
@@ -27,12 +27,12 @@ public:
                 std::shared_ptr<IProcessSender> sender,
                 std::shared_ptr<IFileLoader> file_loader,
                 std::shared_ptr<ITimerService> timer_service,
-                std::shared_ptr<IMessageQueue> human_queue,
+                std::string human_endpoint,
                 std::shared_ptr<IMessage> human_start_msg,
                 std::shared_ptr<IMessage> human_stop_msg,
-                std::shared_ptr<IMessageQueue> bt_queue,
+                std::string bt_endpoint,
                 std::shared_ptr<IMessage> device_scan_msg,
-                std::shared_ptr<IMessageQueue> buzzer_queue,
+                std::string buzzer_endpoint,
                 std::shared_ptr<IMessage> buzzer_start_msg,
                 std::shared_ptr<IMessage> buzzer_stop_msg,
                 std::shared_ptr<IMessageQueue> main_queue,
@@ -50,12 +50,12 @@ private:
     std::shared_ptr<IProcessSender> sender_;
     std::shared_ptr<IFileLoader> file_loader_;
     std::shared_ptr<ITimerService> timer_service_;
-    std::shared_ptr<IMessageQueue> human_queue_;
+    std::string human_endpoint_;
     std::shared_ptr<IMessage> human_start_msg_;
     std::shared_ptr<IMessage> human_stop_msg_;
-    std::shared_ptr<IMessageQueue> bt_queue_;
+    std::string bt_endpoint_;
     std::shared_ptr<IMessage> device_scan_msg_;
-    std::shared_ptr<IMessageQueue> buzzer_queue_;
+    std::string buzzer_endpoint_;
     std::shared_ptr<IMessage> buzzer_start_msg_;
     std::shared_ptr<IMessage> buzzer_stop_msg_;
     std::shared_ptr<IMessageQueue> main_queue_;

--- a/src/core/bluetooth_task/bluetooth_handler.cpp
+++ b/src/core/bluetooth_task/bluetooth_handler.cpp
@@ -6,14 +6,14 @@ BluetoothHandler::BluetoothHandler(std::shared_ptr<ILogger> logger,
                                    std::shared_ptr<IFileLoader> loader,
                                    std::shared_ptr<IProcessSender> sender,
                                    std::shared_ptr<IBluetoothDriver> driver,
-                                   std::shared_ptr<IMessageQueue> main_queue,
+                                   std::string main_endpoint,
                                    std::shared_ptr<IMessage> success_msg,
                                    std::shared_ptr<IMessage> failure_msg)
     : logger_(std::move(logger))
     , loader_(std::move(loader))
     , sender_(std::move(sender))
     , driver_(std::move(driver))
-    , main_queue_(std::move(main_queue))
+    , main_endpoint_(std::move(main_endpoint))
     , success_msg_(std::move(success_msg))
     , failure_msg_(std::move(failure_msg)) {}
 
@@ -29,11 +29,11 @@ std::vector<std::string> BluetoothHandler::scan() {
             devices = driver_->scan();
         }
 
-        if (sender_ && main_queue_) {
+        if (sender_ && !main_endpoint_.empty()) {
             if (!devices.empty() && success_msg_) {
-                sender_->send(main_queue_, success_msg_);
+                sender_->send(main_endpoint_, success_msg_);
             } else if (devices.empty() && failure_msg_) {
-                sender_->send(main_queue_, failure_msg_);
+                sender_->send(main_endpoint_, failure_msg_);
             }
         }
 

--- a/src/core/human_task/human_handler.cpp
+++ b/src/core/human_task/human_handler.cpp
@@ -9,6 +9,7 @@ HumanHandler::HumanHandler(std::shared_ptr<ILogger> logger,
                            std::shared_ptr<IProcessSender> sender,
                            std::shared_ptr<IFileLoader> loader,
                            std::shared_ptr<IMessage> cooldown_msg,
+                           std::string main_endpoint,
                            std::shared_ptr<IMessageQueue> main_queue,
                            std::shared_ptr<IMessage> success_msg)
     : logger_(std::move(logger))
@@ -17,14 +18,15 @@ HumanHandler::HumanHandler(std::shared_ptr<ILogger> logger,
     , sender_(std::move(sender))
     , loader_(std::move(loader))
     , cooldown_msg_(std::move(cooldown_msg))
+    , main_endpoint_(std::move(main_endpoint))
     , main_queue_(std::move(main_queue))
     , success_msg_(std::move(success_msg)) {}
 
 void HumanHandler::get_detect() {
     if (logger_) logger_->info("[HumanHandler::get_detect] start");
     try {
-        if (sender_ && main_queue_ && success_msg_) {
-            sender_->send(main_queue_, success_msg_);
+        if (sender_ && !main_endpoint_.empty() && success_msg_) {
+            sender_->send(main_endpoint_, success_msg_);
         }
 
         if (timer_ && main_queue_ && cooldown_msg_) {

--- a/src/core/main_task/main_handler.cpp
+++ b/src/core/main_task/main_handler.cpp
@@ -7,12 +7,12 @@ MainHandler::MainHandler(std::shared_ptr<ILogger> logger,
                          std::shared_ptr<IProcessSender> sender,
                          std::shared_ptr<IFileLoader> file_loader,
                          std::shared_ptr<ITimerService> timer_service,
-                         std::shared_ptr<IMessageQueue> human_queue,
+                         std::string human_endpoint,
                          std::shared_ptr<IMessage> human_start_msg,
                          std::shared_ptr<IMessage> human_stop_msg,
-                         std::shared_ptr<IMessageQueue> bt_queue,
+                         std::string bt_endpoint,
                          std::shared_ptr<IMessage> device_scan_msg,
-                         std::shared_ptr<IMessageQueue> buzzer_queue,
+                         std::string buzzer_endpoint,
                          std::shared_ptr<IMessage> buzzer_start_msg,
                          std::shared_ptr<IMessage> buzzer_stop_msg,
                          std::shared_ptr<IMessageQueue> main_queue,
@@ -22,12 +22,12 @@ MainHandler::MainHandler(std::shared_ptr<ILogger> logger,
     , sender_(std::move(sender))
     , file_loader_(std::move(file_loader))
     , timer_service_(std::move(timer_service))
-    , human_queue_(std::move(human_queue))
+    , human_endpoint_(std::move(human_endpoint))
     , human_start_msg_(std::move(human_start_msg))
     , human_stop_msg_(std::move(human_stop_msg))
-    , bt_queue_(std::move(bt_queue))
+    , bt_endpoint_(std::move(bt_endpoint))
     , device_scan_msg_(std::move(device_scan_msg))
-    , buzzer_queue_(std::move(buzzer_queue))
+    , buzzer_endpoint_(std::move(buzzer_endpoint))
     , buzzer_start_msg_(std::move(buzzer_start_msg))
     , buzzer_stop_msg_(std::move(buzzer_stop_msg))
     , main_queue_(std::move(main_queue))
@@ -37,11 +37,11 @@ MainHandler::MainHandler(std::shared_ptr<ILogger> logger,
 void MainHandler::start_device_detect() {
     if (logger_) logger_->info("[MainHandler::start_device_detect] start");
     try {
-        if (sender_ && bt_queue_ && device_scan_msg_) {
-            sender_->send(bt_queue_, device_scan_msg_);
+        if (sender_ && !bt_endpoint_.empty() && device_scan_msg_) {
+            sender_->send(bt_endpoint_, device_scan_msg_);
         }
-        if (sender_ && human_queue_ && human_stop_msg_) {
-            sender_->send(human_queue_, human_stop_msg_);
+        if (sender_ && !human_endpoint_.empty() && human_stop_msg_) {
+            sender_->send(human_endpoint_, human_stop_msg_);
         }
         if (timer_service_ && main_queue_ && device_detect_timeout_msg_) {
             auto thread_sender = std::make_shared<ThreadSender>(logger_);
@@ -57,8 +57,8 @@ void MainHandler::start_device_detect() {
 void MainHandler::end_device_first_detect() {
     if (logger_) logger_->info("[MainHandler::end_device_first_detect] start");
     try {
-        if (sender_ && human_queue_ && human_start_msg_) {
-            sender_->send(human_queue_, human_start_msg_);
+        if (sender_ && !human_endpoint_.empty() && human_start_msg_) {
+            sender_->send(human_endpoint_, human_start_msg_);
         }
         if (logger_) logger_->info("[MainHandler::end_device_first_detect] success");
     } catch (const std::exception& e) {
@@ -70,11 +70,11 @@ void MainHandler::end_device_first_detect() {
 void MainHandler::end_device_retry_detect() {
     if (logger_) logger_->info("[MainHandler::end_device_retry_detect] start");
     try {
-        if (sender_ && human_queue_ && human_start_msg_) {
-            sender_->send(human_queue_, human_start_msg_);
+        if (sender_ && !human_endpoint_.empty() && human_start_msg_) {
+            sender_->send(human_endpoint_, human_start_msg_);
         }
-        if (sender_ && buzzer_queue_ && buzzer_stop_msg_) {
-            sender_->send(buzzer_queue_, buzzer_stop_msg_);
+        if (sender_ && !buzzer_endpoint_.empty() && buzzer_stop_msg_) {
+            sender_->send(buzzer_endpoint_, buzzer_stop_msg_);
         }
         if (logger_) logger_->info("[MainHandler::end_device_retry_detect] success");
     } catch (const std::exception& e) {
@@ -86,8 +86,8 @@ void MainHandler::end_device_retry_detect() {
 void MainHandler::retry_device_detect() {
     if (logger_) logger_->info("[MainHandler::retry_device_detect] start");
     try {
-        if (sender_ && buzzer_queue_ && buzzer_start_msg_) {
-            sender_->send(buzzer_queue_, buzzer_start_msg_);
+        if (sender_ && !buzzer_endpoint_.empty() && buzzer_start_msg_) {
+            sender_->send(buzzer_endpoint_, buzzer_start_msg_);
         }
         if (timer_service_ && main_queue_ && bt_cooldown_end_msg_) {
             auto thread_sender = std::make_shared<ThreadSender>(logger_);
@@ -103,8 +103,8 @@ void MainHandler::retry_device_detect() {
 void MainHandler::send_bt_request() {
     if (logger_) logger_->info("[MainHandler::send_bt_request] start");
     try {
-        if (sender_ && bt_queue_ && device_scan_msg_) {
-            sender_->send(bt_queue_, device_scan_msg_);
+        if (sender_ && !bt_endpoint_.empty() && device_scan_msg_) {
+            sender_->send(bt_endpoint_, device_scan_msg_);
         }
         if (logger_) logger_->info("[MainHandler::send_bt_request] success");
     } catch (const std::exception& e) {


### PR DESCRIPTION
## Summary
- adjust BluetoothHandler to send via endpoint string instead of message queue
- update MainHandler and HumanHandler to use endpoint names when invoking ProcessSender

## Testing
- `cmake .. && cmake --build . --target test_unit` *(failed: core/main_task/main_task.hpp not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f12eaf6d48328a662c75f75b0966f