### PR TITLE
timer serviceでの例外伝播と停止処理の整理

### DIFF
--- a/include/infra/timer_service/timer_service.hpp
+++ b/include/infra/timer_service/timer_service.hpp
@@ -6,9 +6,8 @@
 #include "infra/message/message.hpp"
 
 #include <atomic>
-#include <exception>
+#include <future>
 #include <memory>
-#include <thread>
 
 namespace device_reminder {
 
@@ -40,10 +39,9 @@ private:
     std::shared_ptr<IThreadSender> sender_{};
     std::shared_ptr<IMessageQueue> queue_{};
     std::shared_ptr<IMessage> message_{};
-    std::thread thread_{};
+    std::future<void> worker_future_{};
     std::atomic<bool> cancel_{false};
     std::atomic<bool> running_{false};
-    std::exception_ptr worker_exception_{};
 };
 
 } // namespace device_reminder


### PR DESCRIPTION
## 概要
- TimerServiceのワーカー例外をstd::asyncで上位に伝播
- worker_exception_を削除しstop処理を簡素化

## テスト
- `cmake -S . -B build` : 成功
- `cmake --build build --target test_unit` : 依存テストのコンパイルエラーにより失敗


------
https://chatgpt.com/codex/tasks/task_e_68a00781dce08328a68eff5fb1376309