### PR TITLE
WatchDogで注入されたIThreadSenderを利用するよう修正

### DIFF
--- a/include/infra/watch_dog/watch_dog.hpp
+++ b/include/infra/watch_dog/watch_dog.hpp
@@ -11,6 +11,7 @@ class ITimerService;
 class IMessageQueue;
 class IMessage;
 class ILogger;
+class IThreadSender;
 
 class IWatchDog {
 public:
@@ -25,7 +26,9 @@ public:
     WatchDog(std::shared_ptr<ITimerService> timer_service,
              std::shared_ptr<IMessageQueue> message_queue,
              std::shared_ptr<IMessage> message,
-             std::shared_ptr<ILogger> logger);
+             std::shared_ptr<IThreadSender> thread_sender,
+             std::shared_ptr<ILogger> logger,
+             int duration_ms = 0);
 
     void start() override;
     void stop() override;
@@ -35,7 +38,9 @@ private:
     std::shared_ptr<ITimerService> timer_service_{};
     std::shared_ptr<IMessageQueue> message_queue_{};
     std::shared_ptr<IMessage> message_{};
+    std::shared_ptr<IThreadSender> thread_sender_{};
     std::shared_ptr<ILogger> logger_{};
+    int duration_ms_{};
 };
 
 } // namespace device_reminder


### PR DESCRIPTION
## 概要
- WatchDogのstart/kickでThreadSenderを生成せず、コンストラクタで受け取ったIThreadSenderを利用
- timer_service_->start呼び出しにduration_msを使用できるようWatchDogのIFを拡張
- タイマー再始動と通知を確認するテストを追加

## テスト
- `g++ ... -o test_watch_dog_bin && ./test_watch_dog_bin`


------
https://chatgpt.com/codex/tasks/task_e_68a00b15b96c83288b9146afcb2ed7af