### PR TITLE
buzz_stopで停止確認を追加し失敗時に例外送出

### DIFF
--- a/src/infra/gpio_operation/gpio_setter.cpp
+++ b/src/infra/gpio_operation/gpio_setter.cpp
@@ -104,7 +104,18 @@ void GPIOSetter::buzz_stop() {
         if (gpiod_line_set_value(line_, 0) < 0) {
             throw std::runtime_error("Failed to stop buzzer");
         }
-        if (logger_) logger_->info("GPIOSetter::buzz_stop success");
+
+        int value = gpiod_line_get_value(line_);
+        if (value < 0) {
+            throw std::runtime_error("Failed to read buzzer state");
+        }
+        if (value != 0) {
+            throw std::runtime_error("Buzzer did not stop");
+        }
+
+        if (logger_)
+            logger_->info(std::string("GPIOSetter::buzz_stop success: value=") +
+                           (value ? "1" : "0"));
     } catch (const std::exception& e) {
         if (logger_) logger_->error(std::string("GPIOSetter::buzz_stop failed: ") + e.what());
         throw;

--- a/tests/unit/infra/gpio_operation/test_gpio_setter.cpp
+++ b/tests/unit/infra/gpio_operation/test_gpio_setter.cpp
@@ -126,6 +126,29 @@ TEST_F(GPIOSetterTest, WriteFailureLogsError) {
     }
 }
 
+// ---- Buzz Stop Tests ----
+
+TEST_F(GPIOSetterTest, BuzzStopSuccess) {
+    GPIOSetter setter(nullptr, 1);
+    gpiod_stub_set_set_value_result(0);
+    gpiod_stub_set_get_value_result(0);
+    EXPECT_NO_THROW(setter.buzz_stop());
+}
+
+TEST_F(GPIOSetterTest, BuzzStopThrowsWhenStateHigh) {
+    GPIOSetter setter(nullptr, 1);
+    gpiod_stub_set_set_value_result(0);
+    gpiod_stub_set_get_value_result(1);
+    EXPECT_THROW(setter.buzz_stop(), std::runtime_error);
+}
+
+TEST_F(GPIOSetterTest, BuzzStopThrowsWhenGetValueFails) {
+    GPIOSetter setter(nullptr, 1);
+    gpiod_stub_set_set_value_result(0);
+    gpiod_stub_set_get_value_result(-1);
+    EXPECT_THROW(setter.buzz_stop(), std::runtime_error);
+}
+
 // ---- Destructor Tests ----
 
 TEST_F(GPIOSetterTest, DestructorLogsInfo) {


### PR DESCRIPTION
## 概要
- GPIOSetter::buzz_stopで停止後のGPIO状態を取得し、停止していない場合は例外を送出するように変更
- buzz_stopに対するユニットテストを追加

## テスト
- `cmake --build build` (core/main_task/main_task.hpp が見つからず失敗)
- `cmake --build build --target test_unit` (tests/unit/core/app/test_app.cpp のコンパイルエラーで失敗)
- `ctest --test-dir build` (テスト実行ファイルが生成されず失敗)


------
https://chatgpt.com/codex/tasks/task_e_68a0185b32788328a34cbfcbdc8fb233