### PR TITLE
Add Bluetooth scanner stop handling

### DIFF
--- a/include/infra/bluetooth_driver/bluetooth_driver.hpp
+++ b/include/infra/bluetooth_driver/bluetooth_driver.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <atomic>
 
 namespace device_reminder {
 
@@ -28,7 +29,7 @@ private:
     std::shared_ptr<IBluetoothScanner> scanner_{};
     std::shared_ptr<IBluetoothPairer> pairer_{};
     std::shared_ptr<ILogger> logger_{};
-    bool running_{false};
+    std::atomic<bool> running_{false};
 };
 
 } // namespace device_reminder

--- a/include/infra/bluetooth_driver/bluetooth_scanner.hpp
+++ b/include/infra/bluetooth_driver/bluetooth_scanner.hpp
@@ -14,6 +14,8 @@ class IBluetoothScanner {
 public:
     virtual ~IBluetoothScanner() = default;
     virtual std::vector<BluetoothDevice> scan() = 0;
+    virtual void stop() = 0;
+    virtual void wait_for_stop() = 0;
 };
 
 } // namespace device_reminder

--- a/src/infra/bluetooth_driver/bluetooth_driver.cpp
+++ b/src/infra/bluetooth_driver/bluetooth_driver.cpp
@@ -63,6 +63,12 @@ void BluetoothDriver::stop() {
     }
     try {
         running_ = false;
+        if (scanner_) {
+            scanner_->stop();
+            scanner_->wait_for_stop();
+            scanner_.reset();
+        }
+        pairer_.reset();
         if (logger_) {
             logger_->info("BluetoothDriver stop succeeded");
         }

--- a/tests/integration/infra/bluetooth_driver/test_bluetooth_driver.cpp
+++ b/tests/integration/infra/bluetooth_driver/test_bluetooth_driver.cpp
@@ -14,6 +14,8 @@ namespace device_reminder {
 class MockScanner : public IBluetoothScanner {
 public:
     MOCK_METHOD(std::vector<BluetoothDevice>, scan, (), (override));
+    MOCK_METHOD(void, stop, (), (override));
+    MOCK_METHOD(void, wait_for_stop, (), (override));
 };
 
 class MockPairer : public IBluetoothPairer {

--- a/tests/unit/infra/bluetooth_driver/test_bluetooth_driver.cpp
+++ b/tests/unit/infra/bluetooth_driver/test_bluetooth_driver.cpp
@@ -14,6 +14,8 @@ namespace device_reminder {
 class MockScanner : public IBluetoothScanner {
 public:
     MOCK_METHOD(std::vector<BluetoothDevice>, scan, (), (override));
+    MOCK_METHOD(void, stop, (), (override));
+    MOCK_METHOD(void, wait_for_stop, (), (override));
 };
 
 class MockPairer : public IBluetoothPairer {


### PR DESCRIPTION
## Summary
- Bluetoothスキャナ停止APIを追加
- BluetoothDriverのstopでスキャナ停止・待機・リソース解放を実装
- スレッド安全性のためrunning_をstd::atomicに変更

## Testing
- `cmake --build build` (fails: undefined reference to `main`)
- `cmake --build build --target test_unit`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a022f171e08328a171b049e3434d15