### PR TITLE
load buzzer duration from config

### DIFF
--- a/src/core/buzzer_task/buzzer_handler.cpp
+++ b/src/core/buzzer_task/buzzer_handler.cpp
@@ -26,8 +26,14 @@ void BuzzerHandler::start_buzzing_and_start_timer() {
         }
 
         if (timer_service_ && buzzer_queue_ && buzzing_end_msg_) {
+            constexpr char kConfigFile[] = "/etc/device_reminder/buzzer.conf";
+            constexpr char kDurationKey[] = "buzz_duration_ms";
+            int duration_ms = 0;
+            if (file_loader_) {
+                duration_ms = file_loader_->load_int(kConfigFile, kDurationKey);
+            }
             auto thread_sender = std::make_shared<ThreadSender>(logger_);
-            timer_service_->start(0, thread_sender, buzzer_queue_, buzzing_end_msg_);
+            timer_service_->start(duration_ms, thread_sender, buzzer_queue_, buzzing_end_msg_);
         }
 
         if (logger_) logger_->info("[BuzzerHandler::start_buzzing_and_start_timer] success");


### PR DESCRIPTION
## Summary
- buzzerの鳴動開始時に設定ファイルから鳴動時間を読み込み、タイマーに反映

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68a027c218b88328b7013656088be9ee